### PR TITLE
feat: start and listen monitoring

### DIFF
--- a/__mocks__/@podman-desktop/api.js
+++ b/__mocks__/@podman-desktop/api.js
@@ -17,7 +17,6 @@
  ***********************************************************************/
 import { vi } from 'vitest';
 import { EventEmitter } from 'node:events';
-import { parse } from 'node:path';
 
 /**
  * Mock the extension API for vitest.
@@ -75,6 +74,10 @@ const plugin = {
   process: {
     exec: vi.fn(),
   },
+  kubernetes: {
+    onDidUpdateKubeconfig: vi.fn(),
+    getKubeconfig: vi.fn(),
+  }
 };
 
 module.exports = plugin;

--- a/packages/extension/__mocks__/fs.cjs
+++ b/packages/extension/__mocks__/fs.cjs
@@ -1,0 +1,2 @@
+const { fs } = require('memfs')
+module.exports = fs

--- a/packages/extension/__mocks__/fs/promises.cjs
+++ b/packages/extension/__mocks__/fs/promises.cjs
@@ -1,0 +1,2 @@
+const { fs } = require('memfs')
+module.exports = fs.promises

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-redundant-undefined": "^1.0.0",
     "eslint-plugin-sonarjs": "^3.0.2",
+    "memfs": "^4.17.2",
     "prettier": "^3.6.1",
     "typescript": "5.8.3",
     "vite": "^7.0",

--- a/packages/extension/src/main.ts
+++ b/packages/extension/src/main.ts
@@ -19,12 +19,21 @@
 import type { ExtensionContext } from '@podman-desktop/api';
 
 import { DashboardExtension } from './dashboard-extension';
+import { ContextsManager } from './manager/contexts-manager';
+import { ContextsStatesDispatcher } from './manager/contexts-states-dispatcher';
 
 let dashboardExtension: DashboardExtension | undefined;
 
 // Initialize the activation of the extension.
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
-  dashboardExtension ??= new DashboardExtension(extensionContext);
+  const contextsManager = new ContextsManager();
+  const apiSender = {
+    send: (channel: string, data?: unknown): void => {
+      console.log(`==> recv data "${data}" on channel ${channel}`);
+    },
+  };
+  const contextsStatesDispatcher = new ContextsStatesDispatcher(contextsManager, apiSender);
+  dashboardExtension ??= new DashboardExtension(extensionContext, contextsManager, contextsStatesDispatcher);
 
   await dashboardExtension.activate();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       eslint-plugin-sonarjs:
         specifier: ^3.0.2
         version: 3.0.4(eslint@9.29.0(jiti@2.4.2))
+      memfs:
+        specifier: ^4.17.2
+        version: 4.17.2
       prettier:
         specifier: ^3.6.1
         version: 3.6.2
@@ -656,6 +659,24 @@ packages:
     engines: {node: '>= 10.16.0'}
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
+
+  '@jsonjoy.com/base64@1.1.2':
+    resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pack@1.2.0':
+    resolution: {integrity: sha512-io1zEbbYcElht3tdlqEOFxZ0dMTYrHz9iMf0gqn1pPjZFTCgM5R4R5IMA20Chb2UPYYsxjzs8CgZ7Nb5n2K2rA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@1.6.0':
+    resolution: {integrity: sha512-sw/RMbehRhN68WRtcKCpQOPfnH6lLP4GJfqzi3iYej8tnzpZUDr6UkZYJjcjjC0FWEJOJbyM3PTIwxucUmDG2A==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
 
   '@kubernetes/client-node@1.3.0':
     resolution: {integrity: sha512-IE0yrIpOT97YS5fg2QpzmPzm8Wmcdf4ueWMn+FiJSI3jgTTQT1u+LUhoYpdfhdHAVxdrNsaBg2C0UXSnOgMoCQ==}
@@ -2157,6 +2178,10 @@ packages:
   humanize-duration@3.33.0:
     resolution: {integrity: sha512-vYJX7BSzn7EQ4SaP2lPYVy+icHDppB6k7myNeI3wrSRfwMS5+BHyGgzpHR0ptqJ2AQ6UuIKrclSg5ve6Ci4IAQ==}
 
+  hyperdyperid@1.2.0:
+    resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
+    engines: {node: '>=10.18'}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -2554,6 +2579,10 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  memfs@4.17.2:
+    resolution: {integrity: sha512-NgYhCOWgovOXSzvYgUW0LQ7Qy72rWQMGGFJDoWg4G30RHd3z77VbYdtJ4fembJXBy8pMIUA31XNAupobOQlwdg==}
+    engines: {node: '>= 4.0.0'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -3290,6 +3319,12 @@ packages:
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
+  thingies@1.21.0:
+    resolution: {integrity: sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==}
+    engines: {node: '>=10.18'}
+    peerDependencies:
+      tslib: ^2
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3337,6 +3372,12 @@ packages:
   tr46@5.0.0:
     resolution: {integrity: sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==}
     engines: {node: '>=18'}
+
+  tree-dump@1.0.3:
+    resolution: {integrity: sha512-il+Cv80yVHFBwokQSfd4bldvr1Md951DpgAGfmhydt04L+YzHgubm2tQ7zueWDcGENKHq0ZvGFR/hjvNXilHEg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -3968,6 +4009,22 @@ snapshots:
   '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
     dependencies:
       jsep: 1.4.0
+
+  '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pack@1.2.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/base64': 1.1.2(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.6.0(tslib@2.8.1)
+      hyperdyperid: 1.2.0
+      thingies: 1.21.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/util@1.6.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
 
   '@kubernetes/client-node@1.3.0(encoding@0.1.13)':
     dependencies:
@@ -5729,6 +5786,8 @@ snapshots:
 
   humanize-duration@3.33.0: {}
 
+  hyperdyperid@1.2.0: {}
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -6114,6 +6173,13 @@ snapshots:
   marked@5.1.2: {}
 
   math-intrinsics@1.1.0: {}
+
+  memfs@4.17.2:
+    dependencies:
+      '@jsonjoy.com/json-pack': 1.2.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.6.0(tslib@2.8.1)
+      tree-dump: 1.0.3(tslib@2.8.1)
+      tslib: 2.8.1
 
   merge2@1.4.1: {}
 
@@ -6855,6 +6921,10 @@ snapshots:
     dependencies:
       b4a: 1.6.7
 
+  thingies@1.21.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -6894,6 +6964,10 @@ snapshots:
   tr46@5.0.0:
     dependencies:
       punycode: 2.3.1
+
+  tree-dump@1.0.3(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
 
   tree-kill@1.2.2: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
       excludeAfterRemap: true,
       provider: 'v8',
       exclude: ['**/coverage/**'],
-      reporter: [process.env.GITHUB_ACTIONS?'html':'text'],
+      reporter: process.env.GITHUB_ACTIONS ? ['html'] : ['text','lcov'],
     },
   },
 });


### PR DESCRIPTION
Starts the monitoring and the states dispatcher.

The API sender passed to the dispatcher is only logging info in the console. It will be replaced by RPC channels in upcoming PR
