### PR TITLE
feat: subscribe to broadcast events

### DIFF
--- a/packages/common/src/channels.ts
+++ b/packages/common/src/channels.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { SubscribeApi } from './interface/subscribe-api';
 import type { ActiveResourcesCountInfo } from './model/active-resources-count-info';
 import type { ContextsHealthsInfo } from './model/contexts-healths-info';
 import type { ContextsPermissionsInfo } from './model/contexts-permissions-info';
@@ -23,6 +24,9 @@ import type { ResourcesCountInfo } from './model/resources-count-info';
 import type { UpdateResourceInfo } from './model/update-resource-info';
 
 import { createRpcChannel } from './rpc';
+
+// RPC channels (used by the webview to send requests to the extension)
+export const API_SUBSCRIBE = createRpcChannel<SubscribeApi>('SubscribeApi');
 
 // Broadcast events (sent by extension and received by the webview)
 export const RESOURCES_COUNT = createRpcChannel<ResourcesCountInfo>('ResourcesCount');

--- a/packages/common/src/interface/subscribe-api.ts
+++ b/packages/common/src/interface/subscribe-api.ts
@@ -1,0 +1,31 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export const SubscribeApi = Symbol.for('SubscribeApi');
+
+/**
+ * Interface for webview to subscribe to broadcast events
+ *
+ * It is the responsabiility of the caller to manage unique subscription ids
+ * to remove the necessity to get the unique ID from the API in an asynchronous way
+ */
+export interface SubscribeApi {
+  resetChannelSubscribers(channelName: string): Promise<void>;
+  subscribeToChannel(channelName: string, subscription: number): Promise<void>;
+  unsubscribeFromChannel(channelName: string, subscription: number): Promise<void>;
+}

--- a/packages/extension/src/dashboard-extension.ts
+++ b/packages/extension/src/dashboard-extension.ts
@@ -28,6 +28,7 @@ import { KubeConfig } from '@kubernetes/client-node';
 import { ContextsStatesDispatcher } from './manager/contexts-states-dispatcher';
 import { InversifyBinding } from './inject/inversify-binding';
 import type { Container } from 'inversify';
+import { API_SUBSCRIBE } from '/@common/channels';
 
 export class DashboardExtension {
   #container: Container | undefined;
@@ -62,6 +63,8 @@ export class DashboardExtension {
     const afterFirst = performance.now();
 
     console.log('activation time:', afterFirst - now);
+
+    rpcExtension.registerInstance(API_SUBSCRIBE, this.#contextsStatesDispatcher);
 
     await this.listenMonitoring();
     await this.startMonitoring();

--- a/packages/extension/src/types/channel-subscriber.spec.ts
+++ b/packages/extension/src/types/channel-subscriber.spec.ts
@@ -1,0 +1,96 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { ChannelSubscriber } from './channel-subscriber';
+
+const originalConsoleDebug = console.debug;
+
+beforeEach(() => {
+  console.warn = vi.fn();
+  vi.resetAllMocks();
+});
+
+afterEach(() => {
+  console.warn = originalConsoleDebug;
+});
+
+test('happy path', async () => {
+  const channel = 'channel1';
+  const uid = 1;
+  const subscriber = new ChannelSubscriber();
+  await subscriber.resetChannelSubscribers(channel);
+  expect(subscriber.hasSubscribers(channel)).toBeFalsy();
+  await subscriber.subscribeToChannel(channel, uid);
+  expect(subscriber.hasSubscribers(channel)).toBeTruthy();
+  await subscriber.unsubscribeFromChannel(channel, uid);
+  expect(subscriber.hasSubscribers(channel)).toBeFalsy();
+  expect(console.warn).not.toHaveBeenCalled();
+});
+
+describe('unexpected paths are safe', () => {
+  test('reset is not called', async () => {
+    const channel = 'channel1';
+    const uid = 1;
+    const subscriber = new ChannelSubscriber();
+    expect(subscriber.hasSubscribers(channel)).toBeFalsy();
+    await subscriber.subscribeToChannel(channel, uid);
+    expect(subscriber.hasSubscribers(channel)).toBeTruthy();
+    await subscriber.unsubscribeFromChannel(channel, uid);
+    expect(subscriber.hasSubscribers(channel)).toBeFalsy();
+  });
+
+  test('reset and subscribe are not called', async () => {
+    const channel = 'channel1';
+    const uid = 1;
+    const subscriber = new ChannelSubscriber();
+    await subscriber.unsubscribeFromChannel(channel, uid);
+    expect(subscriber.hasSubscribers(channel)).toBeFalsy();
+  });
+});
+
+describe('assertions', () => {
+  test('subscribing to the same channel with the same UID', async () => {
+    const channel = 'channel1';
+    const uid = 1;
+    const subscriber = new ChannelSubscriber();
+    await subscriber.subscribeToChannel(channel, uid);
+    await subscriber.subscribeToChannel(channel, uid);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  test('subscribing to different channels with the same UID', async () => {
+    const channel1 = 'channel1';
+    const channel2 = 'channel2';
+    const uid = 1;
+    const subscriber = new ChannelSubscriber();
+    await subscriber.subscribeToChannel(channel1, uid);
+    await subscriber.subscribeToChannel(channel2, uid);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  test('unsubscribing from a non-subscribed subscription', async () => {
+    const channel = 'channel1';
+    const uid1 = 1;
+    const uid2 = 2;
+    const subscriber = new ChannelSubscriber();
+    await subscriber.subscribeToChannel(channel, uid1);
+    await subscriber.unsubscribeFromChannel(channel, uid2);
+    expect(console.warn).toHaveBeenCalled();
+  });
+});

--- a/packages/extension/src/types/channel-subscriber.ts
+++ b/packages/extension/src/types/channel-subscriber.ts
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+interface ChannelSubscriberInfo {
+  uid: number;
+}
+
+export class ChannelSubscriber {
+  #subscribers: { [channelName: string]: ChannelSubscriberInfo[] } = {};
+
+  async resetChannelSubscribers(channelName: string): Promise<void> {
+    this.#subscribers[channelName] = [];
+  }
+
+  async subscribeToChannel(channelName: string, subscription: number): Promise<void> {
+    // assert that subscriptions are not done with the same UID
+    if ((this.#subscribers[channelName] ?? []).filter(subscriber => subscriber.uid === subscription).length > 0) {
+      console.warn('subscription already in use for channel', channelName, subscription);
+    }
+    this.#subscribers[channelName] = [...(this.#subscribers[channelName] ?? []), { uid: subscription }];
+  }
+
+  async unsubscribeFromChannel(channelName: string, subscription: number): Promise<void> {
+    // assert that a subscription exists with the UID
+    if ((this.#subscribers[channelName] ?? []).filter(subscriber => subscriber.uid === subscription).length === 0) {
+      console.warn('subscription does not exist for channel', channelName, subscription);
+    }
+    this.#subscribers[channelName] = (this.#subscribers[channelName] ?? []).filter(
+      subscriber => subscriber.uid !== subscription,
+    );
+  }
+
+  hasSubscribers(channelName: string): boolean {
+    return channelName in this.#subscribers && this.#subscribers[channelName].length > 0;
+  }
+}

--- a/packages/webview/src/MainContextAware.svelte
+++ b/packages/webview/src/MainContextAware.svelte
@@ -4,6 +4,7 @@ import { setContext } from 'svelte';
 import type { MainContext } from './main';
 import { States } from './state/states';
 import App from './App.svelte';
+import { Remote } from './remote/remote';
 
 interface Props {
   context: MainContext;
@@ -15,6 +16,7 @@ let initialized = $state(false);
 
 // Sets the value in the global svelte context
 setContext(States, context.states);
+setContext(Remote, context.remote);
 
 initialized = true;
 </script>

--- a/packages/webview/src/component/ResourcesCount.svelte
+++ b/packages/webview/src/component/ResourcesCount.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
-import { getContext } from 'svelte';
+import { getContext, onMount } from 'svelte';
 import { States } from '/@/state/states';
 import { NavPage } from '@podman-desktop/ui-svelte';
 
 const resourcesCount = getContext<States>(States).stateResourcesCountInfoUI;
+
+onMount(() => {
+  return resourcesCount.subscribe();
+});
 </script>
 
 <NavPage title="Resources count" searchEnabled={false}>

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -24,6 +24,7 @@ import { Container } from 'inversify';
 import { RpcBrowser } from '/@common/rpc/rpc';
 
 import { statesModule } from '/@/state/state-module';
+import { Remote } from '../remote/remote';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -39,6 +40,7 @@ export class InversifyBinding {
   public async initBindings(): Promise<Container> {
     this.#container = new Container();
     this.#container.bind(RpcBrowser).toConstantValue(this.#rpcBrowser);
+    this.#container.bind(Remote).toConstantValue(this.#rpcBrowser);
     this.#container.bind('WebviewApi').toConstantValue(this.#webviewApi);
 
     await this.#container.load(statesModule);

--- a/packages/webview/src/main.ts
+++ b/packages/webview/src/main.ts
@@ -23,10 +23,12 @@ import { IDisposable } from '/@common/types/disposable';
 import { States } from './state/states';
 import { StateObject } from './state/util/state-object.svelte';
 import type { WebviewApi } from '@podman-desktop/webview-api';
+import { Remote } from './remote/remote';
 
 export interface MainContext {
   states: States;
   webviewApi: WebviewApi;
+  remote: Remote;
 }
 
 export class Main implements IDisposable {
@@ -55,6 +57,7 @@ export class Main implements IDisposable {
     const mainContext: MainContext = {
       states: await container.getAsync<States>(States),
       webviewApi,
+      remote: container.get<Remote>(Remote),
     };
 
     return mainContext;

--- a/packages/webview/src/remote/remote.ts
+++ b/packages/webview/src/remote/remote.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { RpcChannel } from '/@common/rpc';
+
+export const Remote = Symbol.for('Remote');
+export interface Remote {
+  getProxy<T>(channel: RpcChannel<T>, options?: { noTimeoutMethods: string[] }): T;
+}


### PR DESCRIPTION
Adds an API for the webview to subscribe to broadcast events. Events are broacasted only when there is at least one subscriber.

