### PR TITLE
feat: dispatch event at subscription time

### DIFF
--- a/packages/extension/src/manager/contexts-states-dispatcher.spec.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.spec.ts
@@ -158,3 +158,11 @@ test('ContextsStatesDispatcher should call updateResource and updateActiveResour
   expect(dispatcherSpy).toHaveBeenCalledWith(UPDATE_RESOURCE, { contextName: 'context1', resourceName: 'res1' });
   expect(dispatcherSpy).toHaveBeenCalledWith(ACTIVE_RESOURCES_COUNT);
 });
+
+test('dispatchByChannelName is called when onSubscribe emits an event', async () => {
+  const dispatchByChannelNameSpy = vi.spyOn(dispatcher, 'dispatchByChannelName').mockResolvedValue();
+
+  vi.spyOn(dispatcher, 'onSubscribe').mockImplementation(f => f('channel1') as IDisposable);
+  dispatcher.init();
+  expect(dispatchByChannelNameSpy).toHaveBeenCalledWith('channel1');
+});

--- a/packages/extension/src/manager/contexts-states-dispatcher.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.ts
@@ -72,6 +72,8 @@ export class ContextsStatesDispatcher extends ChannelSubscriber implements Subsc
       await this.dispatch(UPDATE_RESOURCE, { contextName: event.contextName, resourceName: event.resourceName });
       await this.dispatch(ACTIVE_RESOURCES_COUNT);
     });
+
+    this.onSubscribe(channelName => this.dispatchByChannelName(channelName));
   }
 
   // TODO replace this with an event
@@ -80,13 +82,17 @@ export class ContextsStatesDispatcher extends ChannelSubscriber implements Subsc
   }
 
   async dispatch(channel: RpcChannel<unknown>, options?: unknown): Promise<void> {
-    if (!this.hasSubscribers(channel.name)) {
+    return this.dispatchByChannelName(channel.name, options);
+  }
+
+  async dispatchByChannelName(channelName: string, options?: unknown): Promise<void> {
+    if (!this.hasSubscribers(channelName)) {
       return;
     }
-    console.debug('dispatch data for', channel.name);
-    const dispatcher = this.#dispatchers.get(channel.name);
+    console.debug('dispatch data for', channelName);
+    const dispatcher = this.#dispatchers.get(channelName);
     if (!dispatcher) {
-      console.error(`dispatcher not found for channel ${channel.name}`);
+      console.error(`dispatcher not found for channel ${channelName}`);
       return;
     }
     await dispatcher.dispatch(options);

--- a/packages/extension/src/types/channel-subscriber.spec.ts
+++ b/packages/extension/src/types/channel-subscriber.spec.ts
@@ -43,6 +43,17 @@ test('happy path', async () => {
   expect(console.warn).not.toHaveBeenCalled();
 });
 
+test('subscribe makes onSubscribe emit an event', async () => {
+  const channel = 'channel1';
+  const uid = 1;
+  const subscriber = new ChannelSubscriber();
+  const listener = vi.fn();
+  subscriber.onSubscribe(listener);
+  await subscriber.resetChannelSubscribers(channel);
+  await subscriber.subscribeToChannel(channel, uid);
+  expect(listener).toHaveBeenCalledWith(channel);
+});
+
 describe('unexpected paths are safe', () => {
   test('reset is not called', async () => {
     const channel = 'channel1';

--- a/packages/extension/src/types/channel-subscriber.ts
+++ b/packages/extension/src/types/channel-subscriber.ts
@@ -16,12 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { Event } from './emitter';
+import { Emitter } from './emitter';
+
 interface ChannelSubscriberInfo {
   uid: number;
 }
 
 export class ChannelSubscriber {
   #subscribers: { [channelName: string]: ChannelSubscriberInfo[] } = {};
+
+  #onSubscribe = new Emitter<string>();
+
+  onSubscribe: Event<string> = this.#onSubscribe.event;
 
   async resetChannelSubscribers(channelName: string): Promise<void> {
     this.#subscribers[channelName] = [];
@@ -33,6 +40,7 @@ export class ChannelSubscriber {
       console.warn('subscription already in use for channel', channelName, subscription);
     }
     this.#subscribers[channelName] = [...(this.#subscribers[channelName] ?? []), { uid: subscription }];
+    this.#onSubscribe.fire(channelName);
   }
 
   async unsubscribeFromChannel(channelName: string, subscription: number): Promise<void> {


### PR DESCRIPTION
Dispatch a broadcast event when a subscription happens for the channel

(does not support channel with parameters like `UPDATE_RESOURCE`, see #32 )