### PR TITLE
refactor: UPDATE_RESOURCE

### DIFF
--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -1,0 +1,30 @@
+```mermaid
+graph TD;
+  subgraph webview;
+    component[Svelte component]-- "subscribe" -->states[States]
+    states-- "reactive data" -->component
+  end;
+
+  states-- "subscribe" -->dispatcher
+  dispatcher-- "on new data" -->states
+
+  subgraph extension;
+    manager[Contexts Manager]-- "onEvent" -->dispatcher[Contexts States Dispatcher];
+    dispatcher-- "getData" -->manager
+  end;
+````
+
+The `Contexts Manager` fetches *basic information* (health, permissions, resources counts, active resources counts) for all contexts, and Kubernetes objects details for the current context (and other contexts on request).
+
+The `Contexts States Dispatcher` receives events from the Contexts manager for every change, and broadcast information to the webview through *RPC Channels*.
+
+RPC Channels are defined between the extension and the webview. They define the format of the data transiting from the extension to the webview. The data transiting into these channels is determined by the subscriptions on these channels.
+
+The `Svelte Components` subscribe to specific channels. Data begins transiting into a channel as soon as a component has subscribed to this channel. 
+
+Some channels accept parameters, for example the `UPDATE_RESOURCE` channel, which provides the list of resources for specific contexts and resource types. A component have to subscribe for a specific context and a specific resource type. A component can subscribe several times if interested by several contexts and/or several resources types, and several components can subscribe on such channel with different parameters. 
+
+As a result, the extension will broadcast through such a channel all the 
+data related to the ongoing subscriptions only.
+
+For channels without parameters (channels related to basic information for example), all the available data is sent.

--- a/packages/common/src/interface/subscribe-api.ts
+++ b/packages/common/src/interface/subscribe-api.ts
@@ -26,6 +26,6 @@ export const SubscribeApi = Symbol.for('SubscribeApi');
  */
 export interface SubscribeApi {
   resetChannelSubscribers(channelName: string): Promise<void>;
-  subscribeToChannel(channelName: string, subscription: number): Promise<void>;
+  subscribeToChannel(channelName: string, options: unknown, subscription: number): Promise<void>;
   unsubscribeFromChannel(channelName: string, subscription: number): Promise<void>;
 }

--- a/packages/common/src/interface/subscribe-api.ts
+++ b/packages/common/src/interface/subscribe-api.ts
@@ -26,6 +26,6 @@ export const SubscribeApi = Symbol.for('SubscribeApi');
  */
 export interface SubscribeApi {
   resetChannelSubscribers(channelName: string): Promise<void>;
-  subscribeToChannel(channelName: string, options: unknown, subscription: number): Promise<void>;
+  subscribeToChannel<T>(channelName: string, options: T, subscription: number): Promise<void>;
   unsubscribeFromChannel(channelName: string, subscription: number): Promise<void>;
 }

--- a/packages/common/src/model/context-resources-items.ts
+++ b/packages/common/src/model/context-resources-items.ts
@@ -18,7 +18,8 @@
 
 import type { KubernetesObject } from '@kubernetes/client-node';
 
-export interface KubernetesContextResources {
+export interface ContextResourceItems {
   contextName: string;
+  resourceName: string;
   items: readonly KubernetesObject[];
 }

--- a/packages/extension/src/dispatcher/_dispatcher-module.ts
+++ b/packages/extension/src/dispatcher/_dispatcher-module.ts
@@ -23,6 +23,7 @@ import { ContextsPermissionsDispatcher } from './contexts-permissions-dispatcher
 import { ResourcesCountDispatcher } from './resources-count-dispatcher';
 import { DispatcherObject } from './util/dispatcher-object';
 import { CurrentContextDispatcher } from './current-context-dispatcher';
+import { UpdateResourceDispatcher } from './update-resource-dispatcher';
 
 const dispatchersModule = new ContainerModule(options => {
   options.bind<ActiveResourcesCountDispatcher>(ActiveResourcesCountDispatcher).toSelf().inSingletonScope();
@@ -39,6 +40,9 @@ const dispatchersModule = new ContainerModule(options => {
 
   options.bind<CurrentContextDispatcher>(CurrentContextDispatcher).toSelf().inSingletonScope();
   options.bind(DispatcherObject).toService(CurrentContextDispatcher);
+
+  options.bind<UpdateResourceDispatcher>(UpdateResourceDispatcher).toSelf().inSingletonScope();
+  options.bind(DispatcherObject).toService(UpdateResourceDispatcher);
 });
 
 export { dispatchersModule };

--- a/packages/extension/src/dispatcher/update-resource-dispatcher.ts
+++ b/packages/extension/src/dispatcher/update-resource-dispatcher.ts
@@ -27,8 +27,8 @@ import { UpdateResourceOptions } from '/@common/model/update-resource-options';
 
 @injectable()
 export class UpdateResourceDispatcher
-  extends AbsDispatcherObjectImpl<UpdateResourceOptions, UpdateResourceInfo>
-  implements DispatcherObject<UpdateResourceOptions>
+  extends AbsDispatcherObjectImpl<UpdateResourceOptions[], UpdateResourceInfo>
+  implements DispatcherObject<UpdateResourceOptions[]>
 {
   @inject(ContextsManager)
   private manager: ContextsManager;
@@ -37,11 +37,9 @@ export class UpdateResourceDispatcher
     super(rpcExtension, UPDATE_RESOURCE);
   }
 
-  getData(options: UpdateResourceOptions): UpdateResourceInfo {
+  getData(options: UpdateResourceOptions[]): UpdateResourceInfo {
     return {
-      contextName: options.contextName,
-      resourceName: options.resourceName,
-      resources: this.manager.getResources([options.contextName], options.resourceName),
+      resources: options.flatMap(option => this.manager.getResources([option.contextName], option.resourceName)),
     };
   }
 }

--- a/packages/extension/src/manager/contexts-manager.spec.ts
+++ b/packages/extension/src/manager/contexts-manager.spec.ts
@@ -709,10 +709,12 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
       expect(resources).toEqual([
         {
           contextName: 'context1',
+          resourceName: 'resource1',
           items: [{ metadata: { name: 'obj1' } }],
         },
         {
           contextName: 'context2',
+          resourceName: 'resource1',
           items: [{ metadata: { name: 'obj2' } }, { metadata: { name: 'obj3' } }],
         },
       ]);
@@ -740,10 +742,12 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
       expect(resources).toEqual([
         {
           contextName: 'context1',
+          resourceName: 'resource1',
           items: [{ metadata: { name: 'obj1' } }],
         },
         {
           contextName: 'context2',
+          resourceName: 'resource1',
           items: [{ metadata: { name: 'obj2' } }, { metadata: { name: 'obj3' } }],
         },
       ]);
@@ -767,6 +771,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
       expect(resourcesAfter).toEqual([
         {
           contextName: 'context2',
+          resourceName: 'resource1',
           items: [{ metadata: { name: 'obj2' } }, { metadata: { name: 'obj3' } }],
         },
       ]);

--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -20,7 +20,6 @@ import type { KubeConfig, KubernetesObject, ObjectCache } from '@kubernetes/clie
 
 import type { ContextPermission } from '/@common/model/kubernetes-contexts-permissions.js';
 import type { ResourceCount } from '/@common/model/kubernetes-resource-count.js';
-import type { KubernetesContextResources } from '/@common/model/kubernetes-resources.js';
 import type { KubernetesTroubleshootingInformation } from '/@common/model/kubernetes-troubleshooting.js';
 
 import type { Event } from '/@/types/emitter.js';
@@ -49,6 +48,7 @@ import { RoutesResourceFactory } from '/@/resources/routes-resource-factory.js';
 import { SecretsResourceFactory } from '/@/resources/secrets-resource-factory.js';
 import { ServicesResourceFactory } from '/@/resources/services-resource-factory.js';
 import { injectable } from 'inversify';
+import { ContextResourceItems } from '/@common/model/context-resources-items.js';
 
 const HEALTH_CHECK_TIMEOUT_MS = 5_000;
 
@@ -205,9 +205,10 @@ export class ContextsManager {
       .filter(f => !!f);
   }
 
-  getResources(contextNames: string[], resourceName: string): KubernetesContextResources[] {
+  getResources(contextNames: string[], resourceName: string): ContextResourceItems[] {
     return this.#objectCaches.getForContextsAndResource(contextNames, resourceName).map(({ contextName, value }) => {
       return {
+        resourceName,
         contextName,
         items: value.list(),
       };

--- a/packages/extension/src/manager/contexts-states-dispatcher.spec.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.spec.ts
@@ -157,7 +157,7 @@ test('ContextsStatesDispatcher should call updateResource and updateActiveResour
   await vi.waitFor(() => {
     expect(dispatcherSpy).toHaveBeenCalledTimes(2);
   });
-  expect(dispatcherSpy).toHaveBeenCalledWith(UPDATE_RESOURCE, { contextName: 'context1', resourceName: 'res1' });
+  expect(dispatcherSpy).toHaveBeenCalledWith(UPDATE_RESOURCE);
   expect(dispatcherSpy).toHaveBeenCalledWith(ACTIVE_RESOURCES_COUNT);
 });
 

--- a/packages/extension/src/manager/contexts-states-dispatcher.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.ts
@@ -70,7 +70,6 @@ export class ContextsStatesDispatcher extends ChannelSubscriber implements Subsc
       await this.dispatch(RESOURCES_COUNT);
     });
     this.manager.onResourceUpdated(async event => {
-      console.log('==> resource update', event);
       await this.dispatch(UPDATE_RESOURCE);
       await this.dispatch(ACTIVE_RESOURCES_COUNT);
     });
@@ -95,7 +94,6 @@ export class ContextsStatesDispatcher extends ChannelSubscriber implements Subsc
       return;
     }
     const subscriptions = this.getSubscriptions(channelName);
-    console.log('==> subscriptions', subscriptions);
 
     console.debug('dispatch data for', channelName);
     const dispatcher = this.#dispatchers.get(channelName);

--- a/packages/extension/src/manager/contexts-states-dispatcher.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.ts
@@ -70,7 +70,8 @@ export class ContextsStatesDispatcher extends ChannelSubscriber implements Subsc
       await this.dispatch(RESOURCES_COUNT);
     });
     this.manager.onResourceUpdated(async event => {
-      await this.dispatch(UPDATE_RESOURCE, { contextName: event.contextName, resourceName: event.resourceName });
+      console.log('==> resource update', event);
+      await this.dispatch(UPDATE_RESOURCE);
       await this.dispatch(ACTIVE_RESOURCES_COUNT);
     });
     this.manager.onCurrentContextChange(async () => {
@@ -85,20 +86,23 @@ export class ContextsStatesDispatcher extends ChannelSubscriber implements Subsc
     return this.manager.getTroubleshootingInformation();
   }
 
-  async dispatch(channel: RpcChannel<unknown>, options?: unknown): Promise<void> {
-    return this.dispatchByChannelName(channel.name, options);
+  async dispatch(channel: RpcChannel<unknown>): Promise<void> {
+    return this.dispatchByChannelName(channel.name);
   }
 
-  async dispatchByChannelName(channelName: string, options?: unknown): Promise<void> {
+  async dispatchByChannelName(channelName: string): Promise<void> {
     if (!this.hasSubscribers(channelName)) {
       return;
     }
+    const subscriptions = this.getSubscriptions(channelName);
+    console.log('==> subscriptions', subscriptions);
+
     console.debug('dispatch data for', channelName);
     const dispatcher = this.#dispatchers.get(channelName);
     if (!dispatcher) {
       console.error(`dispatcher not found for channel ${channelName}`);
       return;
     }
-    await dispatcher.dispatch(options);
+    await dispatcher.dispatch(subscriptions);
   }
 }

--- a/packages/extension/src/manager/contexts-states-dispatcher.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.ts
@@ -69,7 +69,7 @@ export class ContextsStatesDispatcher extends ChannelSubscriber implements Subsc
     this.manager.onResourceCountUpdated(async () => {
       await this.dispatch(RESOURCES_COUNT);
     });
-    this.manager.onResourceUpdated(async event => {
+    this.manager.onResourceUpdated(async () => {
       await this.dispatch(UPDATE_RESOURCE);
       await this.dispatch(ACTIVE_RESOURCES_COUNT);
     });

--- a/packages/extension/src/types/channel-subscriber.spec.ts
+++ b/packages/extension/src/types/channel-subscriber.spec.ts
@@ -36,7 +36,7 @@ test('happy path', async () => {
   const subscriber = new ChannelSubscriber();
   await subscriber.resetChannelSubscribers(channel);
   expect(subscriber.hasSubscribers(channel)).toBeFalsy();
-  await subscriber.subscribeToChannel(channel, uid);
+  await subscriber.subscribeToChannel(channel, {}, uid);
   expect(subscriber.hasSubscribers(channel)).toBeTruthy();
   await subscriber.unsubscribeFromChannel(channel, uid);
   expect(subscriber.hasSubscribers(channel)).toBeFalsy();
@@ -50,7 +50,7 @@ test('subscribe makes onSubscribe emit an event', async () => {
   const listener = vi.fn();
   subscriber.onSubscribe(listener);
   await subscriber.resetChannelSubscribers(channel);
-  await subscriber.subscribeToChannel(channel, uid);
+  await subscriber.subscribeToChannel(channel, {}, uid);
   expect(listener).toHaveBeenCalledWith(channel);
 });
 
@@ -60,7 +60,7 @@ describe('unexpected paths are safe', () => {
     const uid = 1;
     const subscriber = new ChannelSubscriber();
     expect(subscriber.hasSubscribers(channel)).toBeFalsy();
-    await subscriber.subscribeToChannel(channel, uid);
+    await subscriber.subscribeToChannel(channel, {}, uid);
     expect(subscriber.hasSubscribers(channel)).toBeTruthy();
     await subscriber.unsubscribeFromChannel(channel, uid);
     expect(subscriber.hasSubscribers(channel)).toBeFalsy();
@@ -80,8 +80,8 @@ describe('assertions', () => {
     const channel = 'channel1';
     const uid = 1;
     const subscriber = new ChannelSubscriber();
-    await subscriber.subscribeToChannel(channel, uid);
-    await subscriber.subscribeToChannel(channel, uid);
+    await subscriber.subscribeToChannel(channel, {}, uid);
+    await subscriber.subscribeToChannel(channel, {}, uid);
     expect(console.warn).toHaveBeenCalled();
   });
 
@@ -90,8 +90,8 @@ describe('assertions', () => {
     const channel2 = 'channel2';
     const uid = 1;
     const subscriber = new ChannelSubscriber();
-    await subscriber.subscribeToChannel(channel1, uid);
-    await subscriber.subscribeToChannel(channel2, uid);
+    await subscriber.subscribeToChannel(channel1, {}, uid);
+    await subscriber.subscribeToChannel(channel2, {}, uid);
     expect(console.warn).not.toHaveBeenCalled();
   });
 
@@ -100,7 +100,7 @@ describe('assertions', () => {
     const uid1 = 1;
     const uid2 = 2;
     const subscriber = new ChannelSubscriber();
-    await subscriber.subscribeToChannel(channel, uid1);
+    await subscriber.subscribeToChannel(channel, {}, uid1);
     await subscriber.unsubscribeFromChannel(channel, uid2);
     expect(console.warn).toHaveBeenCalled();
   });

--- a/packages/extension/src/types/channel-subscriber.ts
+++ b/packages/extension/src/types/channel-subscriber.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import util from 'node:util';
+
 import type { Event } from './emitter';
 import { Emitter } from './emitter';
 
@@ -62,8 +64,12 @@ export class ChannelSubscriber {
     if (!(channelName in this.#subscribers)) {
       return [];
     }
-    return this.#subscribers[channelName]
-      .filter(subscriber => !!subscriber.options)
-      .map(subscriber => subscriber.options);
+    return (
+      this.#subscribers[channelName]
+        .map(subscriber => subscriber.options)
+        .filter(options => !!options)
+        // return unique values
+        .filter((value, index, self) => self.findIndex(elt => util.isDeepStrictEqual(value, elt)) === index)
+    );
   }
 }

--- a/packages/extension/src/types/channel-subscriber.ts
+++ b/packages/extension/src/types/channel-subscriber.ts
@@ -21,6 +21,7 @@ import { Emitter } from './emitter';
 
 interface ChannelSubscriberInfo {
   uid: number;
+  options: unknown;
 }
 
 export class ChannelSubscriber {
@@ -34,12 +35,12 @@ export class ChannelSubscriber {
     this.#subscribers[channelName] = [];
   }
 
-  async subscribeToChannel(channelName: string, subscription: number): Promise<void> {
+  async subscribeToChannel(channelName: string, options: unknown, subscription: number): Promise<void> {
     // assert that subscriptions are not done with the same UID
     if ((this.#subscribers[channelName] ?? []).filter(subscriber => subscriber.uid === subscription).length > 0) {
       console.warn('subscription already in use for channel', channelName, subscription);
     }
-    this.#subscribers[channelName] = [...(this.#subscribers[channelName] ?? []), { uid: subscription }];
+    this.#subscribers[channelName] = [...(this.#subscribers[channelName] ?? []), { uid: subscription, options }];
     this.#onSubscribe.fire(channelName);
   }
 
@@ -55,5 +56,14 @@ export class ChannelSubscriber {
 
   hasSubscribers(channelName: string): boolean {
     return channelName in this.#subscribers && this.#subscribers[channelName].length > 0;
+  }
+
+  getSubscriptions(channelName: string): unknown[] {
+    if (!(channelName in this.#subscribers)) {
+      return [];
+    }
+    return this.#subscribers[channelName]
+      .filter(subscriber => !!subscriber.options)
+      .map(subscriber => subscriber.options);
   }
 }

--- a/packages/extension/src/types/channel-subscriber.ts
+++ b/packages/extension/src/types/channel-subscriber.ts
@@ -35,7 +35,7 @@ export class ChannelSubscriber {
     this.#subscribers[channelName] = [];
   }
 
-  async subscribeToChannel(channelName: string, options: unknown, subscription: number): Promise<void> {
+  async subscribeToChannel<T>(channelName: string, options: T, subscription: number): Promise<void> {
     // assert that subscriptions are not done with the same UID
     if ((this.#subscribers[channelName] ?? []).filter(subscriber => subscriber.uid === subscription).length > 0) {
       console.warn('subscription already in use for channel', channelName, subscription);

--- a/packages/webview/src/App.svelte
+++ b/packages/webview/src/App.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 import ActiveResourcesCount from './component/ActiveResourcesCount.svelte';
+import ConfigsList from './component/ConfigsList.svelte';
 import CurrentContext from './component/CurrentContext.svelte';
 import Dashboard from './component/Dashboard.svelte';
+import PodsList from './component/PodsList.svelte';
 import ResourcesCount from './component/ResourcesCount.svelte';
 import Navigation from './Navigation.svelte';
 import Route from './Route.svelte';
@@ -29,6 +31,13 @@ let isMounted = false;
 
         <Route path="/active-resources-count">
           <ActiveResourcesCount />
+        </Route>
+
+        <Route path="/lists">
+          <div class="flex flex-row">
+            <PodsList />
+            <ConfigsList />
+          </div>
         </Route>
       </div>
     </div>

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -30,5 +30,6 @@ const { meta }: Props = $props();
       title="Active resources count"
       selected={meta.url === '/active-resources-count'}
       href="/active-resources-count" />
+    <SettingsNavItem title="Resources Lists" selected={meta.url === '/lists'} href="/lists" />
   </div>
 </nav>

--- a/packages/webview/src/component/ConfigsList.svelte
+++ b/packages/webview/src/component/ConfigsList.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+import { getContext, onDestroy, onMount } from 'svelte';
+import { States } from '/@/state/states';
+import { NavPage } from '@podman-desktop/ui-svelte';
+import type { Unsubscriber } from 'svelte/store';
+import type { ContextResourceItems } from '/@common/model/context-resources-items';
+
+const updateResource = getContext<States>(States).stateUpdateResourceInfoUI;
+const currentContext = getContext<States>(States).stateCurrentContextInfoUI;
+
+$effect(() => {
+  if (currentContext.data?.contextName) {
+    subscribeToContext(currentContext.data.contextName);
+  }
+});
+
+let unsubscriberConfigmaps: Unsubscriber | undefined;
+let unsubscriberSecrets: Unsubscriber | undefined;
+
+function subscribeToContext(contextName: string): void {
+  unsubscriberConfigmaps?.();
+  unsubscriberSecrets?.();
+  unsubscriberConfigmaps = updateResource.subscribe({
+    contextName: contextName,
+    resourceName: 'configmaps',
+  });
+  unsubscriberSecrets = updateResource.subscribe({
+    contextName: contextName,
+    resourceName: 'secrets',
+  });
+}
+
+onMount(() => {
+  return currentContext.subscribe();
+});
+
+onDestroy(() => {
+  unsubscriberConfigmaps?.();
+  unsubscriberSecrets?.();
+});
+
+function filterResources(allResources: ContextResourceItems[]): ContextResourceItems[] {
+  return allResources.filter(
+    resources =>
+      resources.contextName === currentContext.data?.contextName &&
+      ['configmaps', 'secrets'].includes(resources.resourceName),
+  );
+}
+</script>
+
+<NavPage title="Configmaps and Secrets List" searchEnabled={false}>
+  {#snippet content()}
+    <main class="flex flex-col h-screen overflow-auto bg-[var(--pd-content-bg)] text-base m-4">
+      context: {currentContext.data?.contextName}
+      {#if updateResource.data}
+        {#each filterResources(updateResource.data.resources) as resources, index (index)}
+          <h2>List of {resources.resourceName} in context {resources.contextName}</h2>
+          <ul class="list-disc list-inside">
+            {#each resources.items as item, index (index)}
+              <li>{item.metadata?.name}</li>
+            {/each}
+          </ul>
+        {/each}
+      {/if}
+    </main>
+  {/snippet}
+</NavPage>

--- a/packages/webview/src/component/PodsList.svelte
+++ b/packages/webview/src/component/PodsList.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+import { getContext, onDestroy, onMount } from 'svelte';
+import { States } from '/@/state/states';
+import { NavPage } from '@podman-desktop/ui-svelte';
+import type { Unsubscriber } from 'svelte/store';
+import type { ContextResourceItems } from '/@common/model/context-resources-items';
+
+const updateResource = getContext<States>(States).stateUpdateResourceInfoUI;
+const currentContext = getContext<States>(States).stateCurrentContextInfoUI;
+
+let unsubscriber: Unsubscriber | undefined;
+
+$effect(() => {
+  if (currentContext.data?.contextName) {
+    subscribeToContext(currentContext.data.contextName);
+  } else {
+    unsubscriber?.();
+  }
+});
+
+function subscribeToContext(contextName: string): void {
+  unsubscriber?.();
+  unsubscriber = updateResource.subscribe({
+    contextName: contextName,
+    resourceName: 'pods',
+  });
+}
+
+onMount(() => {
+  return currentContext.subscribe();
+});
+
+onDestroy(() => {
+  unsubscriber?.();
+});
+
+function filterResources(allResources: ContextResourceItems[]): ContextResourceItems[] {
+  return allResources.filter(
+    resources => resources.contextName === currentContext.data?.contextName && resources.resourceName === 'pods',
+  );
+}
+</script>
+
+<NavPage title="Pods List" searchEnabled={false}>
+  {#snippet content()}
+    <main class="flex flex-col h-screen overflow-auto bg-[var(--pd-content-bg)] text-base m-4">
+      context: {currentContext.data?.contextName}
+      {#if updateResource.data}
+        {#each filterResources(updateResource.data.resources) as resources, index (index)}
+          <h2>List of {resources.resourceName} in context {resources.contextName}</h2>
+          <ul class="list-disc list-inside">
+            {#each resources.items as item, index (index)}
+              <li>{item.metadata?.name}</li>
+            {/each}
+          </ul>
+        {/each}
+      {/if}
+    </main>
+  {/snippet}
+</NavPage>

--- a/packages/webview/src/component/PodsList.svelte
+++ b/packages/webview/src/component/PodsList.svelte
@@ -11,27 +11,31 @@ const currentContext = getContext<States>(States).stateCurrentContextInfoUI;
 let unsubscriber: Unsubscriber | undefined;
 
 $effect(() => {
+  // first unsubscribe from previous context
+  unsubscribeFromContext();
   if (currentContext.data?.contextName) {
     subscribeToContext(currentContext.data.contextName);
-  } else {
-    unsubscriber?.();
   }
 });
 
 function subscribeToContext(contextName: string): void {
-  unsubscriber?.();
   unsubscriber = updateResource.subscribe({
     contextName: contextName,
     resourceName: 'pods',
   });
 }
 
+function unsubscribeFromContext(): void {
+  unsubscriber?.();
+}
+
 onMount(() => {
+  // returns the unsubscriber, which will be called automatically at destroy time
   return currentContext.subscribe();
 });
 
 onDestroy(() => {
-  unsubscriber?.();
+  unsubscribeFromContext();
 });
 
 function filterResources(allResources: ContextResourceItems[]): ContextResourceItems[] {

--- a/packages/webview/src/main.ts
+++ b/packages/webview/src/main.ts
@@ -43,7 +43,7 @@ export class Main implements IDisposable {
     const container = await inversifyBinding.initBindings();
 
     // Grab all state object instances
-    const stateObjectInstances = container.getAll<StateObject<unknown>>(StateObject);
+    const stateObjectInstances = container.getAll<StateObject<unknown, unknown>>(StateObject);
 
     // Init all state object instances
     for (const stateObjectInstance of stateObjectInstances) {

--- a/packages/webview/src/state/active-resources-count.svelte.ts
+++ b/packages/webview/src/state/active-resources-count.svelte.ts
@@ -27,8 +27,8 @@ import type { ActiveResourcesCountInfo } from '/@common/model/active-resources-c
 // Define a state for the ActiveResourcesCountInfo
 @injectable()
 export class StateActiveResourcesCountInfo
-  extends AbsStateObjectImpl<ActiveResourcesCountInfo>
-  implements StateObject<ActiveResourcesCountInfo>
+  extends AbsStateObjectImpl<ActiveResourcesCountInfo, void>
+  implements StateObject<ActiveResourcesCountInfo, void>
 {
   constructor(@inject(RpcBrowser) rpcBrowser: RpcBrowser) {
     super(rpcBrowser);

--- a/packages/webview/src/state/current-context.svelte.ts
+++ b/packages/webview/src/state/current-context.svelte.ts
@@ -27,8 +27,8 @@ import type { CurrentContextInfo } from '/@common/model/current-context-info';
 // Define a state for the CurrentContextInfo
 @injectable()
 export class StateCurrentContextInfo
-  extends AbsStateObjectImpl<CurrentContextInfo>
-  implements StateObject<CurrentContextInfo>
+  extends AbsStateObjectImpl<CurrentContextInfo, void>
+  implements StateObject<CurrentContextInfo, void>
 {
   constructor(@inject(RpcBrowser) rpcBrowser: RpcBrowser) {
     super(rpcBrowser);

--- a/packages/webview/src/state/resources-count.svelte.ts
+++ b/packages/webview/src/state/resources-count.svelte.ts
@@ -27,8 +27,8 @@ import type { ResourcesCountInfo } from '/@common/model/resources-count-info';
 // Define a state for the ResourcesCountInfo
 @injectable()
 export class StateResourcesCountInfo
-  extends AbsStateObjectImpl<ResourcesCountInfo>
-  implements StateObject<ResourcesCountInfo>
+  extends AbsStateObjectImpl<ResourcesCountInfo, void>
+  implements StateObject<ResourcesCountInfo, void>
 {
   constructor(@inject(RpcBrowser) rpcBrowser: RpcBrowser) {
     super(rpcBrowser);

--- a/packages/webview/src/state/state-module.ts
+++ b/packages/webview/src/state/state-module.ts
@@ -24,6 +24,7 @@ import { IDisposable } from '/@common/types/disposable';
 import { StateResourcesCountInfo } from './resources-count.svelte';
 import { StateActiveResourcesCountInfo } from './active-resources-count.svelte';
 import { StateCurrentContextInfo } from './current-context.svelte';
+import { StateUpdateResourceInfo } from './update-resource.svelte';
 
 const statesModule = new ContainerModule(options => {
   options.bind(States).toSelf().inSingletonScope();
@@ -39,6 +40,10 @@ const statesModule = new ContainerModule(options => {
   options.bind(StateCurrentContextInfo).toSelf().inSingletonScope();
   options.bind(StateObject).toService(StateCurrentContextInfo);
   options.bind(IDisposable).toService(StateCurrentContextInfo);
+
+  options.bind(StateUpdateResourceInfo).toSelf().inSingletonScope();
+  options.bind(StateObject).toService(StateUpdateResourceInfo);
+  options.bind(IDisposable).toService(StateUpdateResourceInfo);
 });
 
 export { statesModule };

--- a/packages/webview/src/state/states.ts
+++ b/packages/webview/src/state/states.ts
@@ -20,6 +20,7 @@ import { inject, injectable } from 'inversify';
 import { StateResourcesCountInfo } from './resources-count.svelte';
 import { StateActiveResourcesCountInfo } from './active-resources-count.svelte';
 import { StateCurrentContextInfo } from './current-context.svelte';
+import { StateUpdateResourceInfo } from './update-resource.svelte';
 
 @injectable()
 export class States {
@@ -42,5 +43,12 @@ export class States {
 
   get stateCurrentContextInfoUI(): StateCurrentContextInfo {
     return this._stateCurrentContextInfoUI;
+  }
+
+  @inject(StateUpdateResourceInfo)
+  private _stateUpdateResourceInfoUI: StateUpdateResourceInfo;
+
+  get stateUpdateResourceInfoUI(): StateUpdateResourceInfo {
+    return this._stateUpdateResourceInfoUI;
   }
 }

--- a/packages/webview/src/state/update-resource.svelte.ts
+++ b/packages/webview/src/state/update-resource.svelte.ts
@@ -23,12 +23,13 @@ import { RpcBrowser } from '/@common/rpc/rpc';
 
 import { AbsStateObjectImpl, type StateObject } from './util/state-object.svelte';
 import type { UpdateResourceInfo } from '/@common/model/update-resource-info';
+import type { UpdateResourceOptions } from '/@common/model/update-resource-options';
 
 // Define a state for the UpdateResourceInfo
 @injectable()
 export class StateUpdateResourceInfo
-  extends AbsStateObjectImpl<UpdateResourceInfo>
-  implements StateObject<UpdateResourceInfo>
+  extends AbsStateObjectImpl<UpdateResourceInfo, UpdateResourceOptions>
+  implements StateObject<UpdateResourceInfo, UpdateResourceOptions>
 {
   constructor(@inject(RpcBrowser) rpcBrowser: RpcBrowser) {
     super(rpcBrowser);

--- a/packages/webview/src/state/update-resource.svelte.ts
+++ b/packages/webview/src/state/update-resource.svelte.ts
@@ -16,8 +16,25 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ContextResourceItems } from './context-resources-items';
+import { inject, injectable } from 'inversify';
 
-export interface UpdateResourceInfo {
-  resources: ContextResourceItems[];
+import { UPDATE_RESOURCE } from '/@common/channels';
+import { RpcBrowser } from '/@common/rpc/rpc';
+
+import { AbsStateObjectImpl, type StateObject } from './util/state-object.svelte';
+import type { UpdateResourceInfo } from '/@common/model/update-resource-info';
+
+// Define a state for the UpdateResourceInfo
+@injectable()
+export class StateUpdateResourceInfo
+  extends AbsStateObjectImpl<UpdateResourceInfo>
+  implements StateObject<UpdateResourceInfo>
+{
+  constructor(@inject(RpcBrowser) rpcBrowser: RpcBrowser) {
+    super(rpcBrowser);
+  }
+
+  async init(): Promise<void> {
+    await this.initChannel(UPDATE_RESOURCE);
+  }
 }

--- a/packages/webview/src/state/util/state-object.svelte.ts
+++ b/packages/webview/src/state/util/state-object.svelte.ts
@@ -66,9 +66,9 @@ export abstract class AbsStateObjectImpl<T> implements StateObject<T> {
     return ++this.#subscriberUID;
   }
 
-  subscribe(): Unsubscriber {
+  subscribe(options?: unknown): Unsubscriber {
     const subscription = this.getNextUID();
-    this.#subscribeApi.subscribeToChannel(this.#channelName, subscription).catch(console.error);
+    this.#subscribeApi.subscribeToChannel(this.#channelName, options, subscription).catch(console.error);
     return () => {
       this.#subscribeApi.unsubscribeFromChannel(this.#channelName, subscription).catch(console.error);
     };

--- a/packages/webview/src/state/util/state-object.svelte.ts
+++ b/packages/webview/src/state/util/state-object.svelte.ts
@@ -23,13 +23,13 @@ import type { RpcBrowser, RpcChannel } from '/@common/rpc/rpc';
 import type { IDisposable } from '/@common/types/disposable';
 
 export const StateObject = Symbol.for('StateObject');
-export interface StateObject<T> extends IDisposable {
+export interface StateObject<T, U> extends IDisposable {
   get data(): T | undefined;
   init(): Promise<void>;
 }
 
 // Allow to receive event for a given object
-export abstract class AbsStateObjectImpl<T> implements StateObject<T> {
+export abstract class AbsStateObjectImpl<T, U> implements StateObject<T, U> {
   #channelName: string;
   #data = $state<{ value: T | undefined }>({ value: undefined });
   #subscriberUID: number;
@@ -66,9 +66,9 @@ export abstract class AbsStateObjectImpl<T> implements StateObject<T> {
     return ++this.#subscriberUID;
   }
 
-  subscribe(options?: unknown): Unsubscriber {
+  subscribe(options: U): Unsubscriber {
     const subscription = this.getNextUID();
-    this.#subscribeApi.subscribeToChannel(this.#channelName, options, subscription).catch(console.error);
+    this.#subscribeApi.subscribeToChannel<U>(this.#channelName, options, subscription).catch(console.error);
     return () => {
       this.#subscribeApi.unsubscribeFromChannel(this.#channelName, subscription).catch(console.error);
     };


### PR DESCRIPTION
This PR updates the UPDATE_RESOURCE channel, so svelte components can subscribe on this channel for specific contexts/resources, and only objects of these resource types in these contexts are sent through the channel.

The PodsList and ConfigsList components illustrate how to use this channel (test by changing current context, creating/deleting pods, configmaps, secrets, unset current context, etc).
