### PR TITLE
chore: add moment dependency

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -170,7 +170,10 @@ export default [
       'vitest/no-hooks': 'off',
       'vitest/require-top-level-describe': 'off',
       'import/no-unresolved': 'off',
-      'sonarjs/no-nested-functions': 'off'
+      'sonarjs/no-nested-functions': 'off',
+      'import/default': 'off',
+      'import/no-named-as-default-member': 'off',
+      'import/no-named-as-default': 'off'
     },
   },
 

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "inversify": "^7.5.1",
+    "moment": "^2.30.1",
     "svelte-preprocess": "^6.0.3",
     "tinro": "^0.6.12"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       inversify:
         specifier: ^7.5.1
         version: 7.5.4(reflect-metadata@0.2.2)
+      moment:
+        specifier: ^2.30.1
+        version: 2.30.1
       svelte-preprocess:
         specifier: ^6.0.3
         version: 6.0.3(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.6))(postcss@8.5.6)(svelte@5.35.4)(typescript@5.8.3)


### PR DESCRIPTION
Adds the `moment` dependency, and disable some lint features to avoid errors importing this library during the linting