### PR TITLE
feat: empty nodes list

### DIFF
--- a/packages/webview/src/component/nodes/NodeEmptyScreen.svelte
+++ b/packages/webview/src/component/nodes/NodeEmptyScreen.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+import NodeIcon from '/@/component/icons/NodeIcon.svelte';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+</script>
+
+<KubernetesEmptyScreen icon={NodeIcon} resources={['nodes']} />

--- a/packages/webview/src/component/nodes/NodesList.svelte
+++ b/packages/webview/src/component/nodes/NodesList.svelte
@@ -11,6 +11,7 @@ import type { NodeUI } from './NodeUI';
 import { NodeHelper } from './node-helper';
 import { getContext } from 'svelte';
 import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import NodeEmptyScreen from './NodeEmptyScreen.svelte';
 
 const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
 const nodeHelper = dependencyAccessor.get<NodeHelper>(NodeHelper);
@@ -75,5 +76,7 @@ const row = new TableRow<NodeUI>({});
   icon={NodeIcon}
   columns={columns}
   row={row}>
-  {#snippet emptySnippet()}No node{/snippet}
+  {#snippet emptySnippet()}
+    <NodeEmptyScreen />
+  {/snippet}
 </KubernetesObjectsList>

--- a/packages/webview/src/component/objects/KubernetesEmptyScreen.spec.ts
+++ b/packages/webview/src/component/objects/KubernetesEmptyScreen.spec.ts
@@ -1,0 +1,237 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as uiSvelte from '@podman-desktop/ui-svelte';
+import { render } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import KubernetesEmptyScreen from './KubernetesEmptyScreen.svelte';
+import CheckConnection from '/@/component/connection/CheckConnection.svelte';
+import { StatesMocks } from '/@/tests/context-mocks';
+import { FakeStateObject } from '/@/state/util/fake-state-object.svelte';
+import type { CurrentContextInfo } from '/@common/model/current-context-info';
+import type { ContextsHealthsInfo } from '/@common/model/contexts-healths-info';
+import type { ContextsPermissionsInfo } from '/@common/model/contexts-permissions-info';
+import NodeIcon from '/@/component/icons/NodeIcon.svelte';
+
+vi.mock(import('/@/component/connection/CheckConnection.svelte'));
+
+const statesMocks = new StatesMocks();
+
+let currentContextMock: FakeStateObject<CurrentContextInfo, void>;
+let contextsHealthsMock: FakeStateObject<ContextsHealthsInfo, void>;
+let contextsPermissionsMock: FakeStateObject<ContextsPermissionsInfo, void>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  currentContextMock = new FakeStateObject();
+  contextsHealthsMock = new FakeStateObject();
+  contextsPermissionsMock = new FakeStateObject();
+
+  statesMocks.reset();
+  statesMocks.mock<CurrentContextInfo, void>('stateCurrentContextInfoUI', currentContextMock);
+  statesMocks.mock<ContextsHealthsInfo, void>('stateContextsHealthsInfoUI', contextsHealthsMock);
+  statesMocks.mock<ContextsPermissionsInfo, void>('stateContextsPermissionsInfoUI', contextsPermissionsMock);
+});
+
+describe('no current context', () => {
+  beforeEach(() => {
+    currentContextMock.setData({
+      contextName: undefined,
+    });
+  });
+
+  test('EmptyScreen is called with correct title and message', () => {
+    vi.spyOn(uiSvelte, 'EmptyScreen');
+    render(KubernetesEmptyScreen, {
+      icon: NodeIcon,
+      resources: ['seals', 'dolphins'],
+    });
+    expect(uiSvelte.EmptyScreen).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        title: 'No current context',
+        message: 'There is no current context selected',
+      }),
+    );
+  });
+
+  test('CheckConnection button is not displayed', async () => {
+    render(KubernetesEmptyScreen);
+    expect(CheckConnection).not.toHaveBeenCalled();
+  });
+});
+
+describe('current context is not reachable', () => {
+  beforeEach(() => {
+    currentContextMock.setData({
+      contextName: 'ctx1',
+    });
+
+    contextsHealthsMock.setData({
+      healths: [
+        {
+          contextName: 'ctx1',
+          reachable: false,
+          checking: false,
+          offline: false,
+        },
+      ],
+    });
+  });
+
+  test('EmptyScreen is called with correct title and message', () => {
+    vi.spyOn(uiSvelte, 'EmptyScreen');
+    render(KubernetesEmptyScreen, {
+      icon: NodeIcon,
+      resources: ['seals', 'dolphins'],
+    });
+    expect(uiSvelte.EmptyScreen).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        title: 'Context not reachable',
+        message: 'The current context is not reachable',
+      }),
+    );
+  });
+
+  test('CheckConnection button is displayed', async () => {
+    render(KubernetesEmptyScreen, {
+      icon: NodeIcon,
+      resources: ['seals', 'dolphins'],
+    });
+
+    expect(CheckConnection).toHaveBeenCalled();
+  });
+});
+
+describe('one resource is not permitted', () => {
+  beforeEach(() => {
+    currentContextMock.setData({
+      contextName: 'ctx1',
+    });
+
+    contextsHealthsMock.setData({
+      healths: [
+        {
+          contextName: 'ctx1',
+          reachable: true,
+          checking: false,
+          offline: false,
+        },
+      ],
+    });
+
+    contextsPermissionsMock.setData({
+      permissions: [
+        {
+          contextName: 'ctx1',
+          resourceName: 'seals',
+          permitted: false,
+        },
+        {
+          contextName: 'ctx1',
+          resourceName: 'dolphins',
+          permitted: true,
+        },
+      ],
+    });
+  });
+
+  test('EmptyScreen is called with correct title and message', () => {
+    vi.spyOn(uiSvelte, 'EmptyScreen');
+    render(KubernetesEmptyScreen, {
+      icon: NodeIcon,
+      resources: ['seals', 'dolphins'],
+    });
+    expect(uiSvelte.EmptyScreen).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        title: 'No seals or dolphins',
+        message: 'No seals or dolphins found',
+      }),
+    );
+  });
+
+  test('CheckConnection button is not displayed', async () => {
+    render(KubernetesEmptyScreen, {
+      icon: NodeIcon,
+      resources: ['seals', 'dolphins'],
+    });
+
+    expect(CheckConnection).not.toHaveBeenCalled();
+  });
+});
+
+describe('all resources are not permitted', () => {
+  beforeEach(() => {
+    currentContextMock.setData({
+      contextName: 'ctx1',
+    });
+
+    contextsHealthsMock.setData({
+      healths: [
+        {
+          contextName: 'ctx1',
+          reachable: true,
+          checking: false,
+          offline: false,
+        },
+      ],
+    });
+
+    contextsPermissionsMock.setData({
+      permissions: [
+        {
+          contextName: 'ctx1',
+          resourceName: 'seals',
+          permitted: false,
+        },
+        {
+          contextName: 'ctx1',
+          resourceName: 'dolphins',
+          permitted: false,
+        },
+      ],
+    });
+  });
+
+  test('EmptyScreen is called with correct title and message', () => {
+    vi.spyOn(uiSvelte, 'EmptyScreen');
+    render(KubernetesEmptyScreen, {
+      icon: NodeIcon,
+      resources: ['seals', 'dolphins'],
+    });
+    expect(uiSvelte.EmptyScreen).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        title: 'Not accessible',
+        message: `You don't have permission to access the seals and dolphins on this context`,
+      }),
+    );
+  });
+
+  test('CheckConnection button is not displayed', async () => {
+    render(KubernetesEmptyScreen, {
+      icon: NodeIcon,
+      resources: ['seals', 'dolphins'],
+    });
+
+    expect(CheckConnection).not.toHaveBeenCalled();
+  });
+});

--- a/packages/webview/src/component/objects/KubernetesEmptyScreen.svelte
+++ b/packages/webview/src/component/objects/KubernetesEmptyScreen.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import { getContext, onDestroy, onMount, type ComponentProps } from 'svelte';
+import CheckConnection from '/@/component/connection/CheckConnection.svelte';
+import { States } from '/@/state/states';
+import type { Unsubscriber } from 'svelte/store';
+
+interface Props extends ComponentProps<EmptyScreen> {
+  resources: string[];
+}
+
+let { resources, ...restProps }: Props = $props();
+
+const states = getContext<States>(States);
+const currentContext = states.stateCurrentContextInfoUI;
+const contextsHealths = states.stateContextsHealthsInfoUI;
+const contextsPermissions = states.stateContextsPermissionsInfoUI;
+
+let unsubscribers: Unsubscriber[] = [];
+
+onMount(() => {
+  subscribeToStates();
+});
+
+onDestroy(() => {
+  unsubscribeFromStates();
+});
+
+function subscribeToStates(): void {
+  unsubscribers.push(currentContext.subscribe());
+  unsubscribers.push(contextsHealths.subscribe());
+  unsubscribers.push(contextsPermissions.subscribe());
+}
+
+function unsubscribeFromStates(): void {
+  unsubscribers.forEach(unsubscriber => unsubscriber());
+}
+
+interface Info {
+  title: string;
+  text: string;
+  tryToConnect: boolean;
+}
+
+const info: Info = $derived.by(() => {
+  if (!currentContext.data?.contextName) {
+    return {
+      title: 'No current context',
+      text: 'There is no current context selected',
+      tryToConnect: false,
+    };
+  }
+
+  const currentContextName = currentContext.data?.contextName;
+
+  const health = contextsHealths.data?.healths.find(health => health.contextName === currentContextName);
+  if (!health?.reachable) {
+    return {
+      title: 'Context not reachable',
+      text: 'The current context is not reachable',
+      tryToConnect: true,
+    };
+  }
+
+  const atLeastOnePermitted =
+    resources.filter(resource =>
+      contextsPermissions.data?.permissions.some(
+        permission =>
+          permission.contextName == currentContextName && permission.resourceName === resource && permission.permitted,
+      ),
+    ).length > 0;
+
+  if (!atLeastOnePermitted) {
+    return {
+      title: 'Not accessible',
+      text: `You don't have permission to access the ${resources.join(' and ')} on this context`,
+      tryToConnect: false,
+    };
+  }
+
+  return {
+    title: `No ${resources.join(' or ')}`,
+    text: `No ${resources.join(' or ')} found`,
+    tryToConnect: false,
+  };
+});
+</script>
+
+<EmptyScreen title={info.title} message={info.text} {...restProps}>
+  {#if info.tryToConnect}
+    <CheckConnection />
+  {/if}
+</EmptyScreen>


### PR DESCRIPTION
- empty page for nodes list when no resources (due to no connection/no permission/no resources)
- generic empty page for all kubernetes objects
- the CheckConnection implementation is empty for the moment, it will be done in a follow-up PR