### PR TITLE
feat: add the Refresh connection

### DIFF
--- a/packages/common/src/channels.ts
+++ b/packages/common/src/channels.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContextsApi } from './interface/contexts-api';
 import type { SubscribeApi } from './interface/subscribe-api';
 import type { ActiveResourcesCountInfo } from './model/active-resources-count-info';
 import type { ContextsHealthsInfo } from './model/contexts-healths-info';
@@ -27,6 +28,7 @@ import type { UpdateResourceInfo } from './model/update-resource-info';
 import { createRpcChannel } from './rpc';
 
 // RPC channels (used by the webview to send requests to the extension)
+export const API_CONTEXTS = createRpcChannel<ContextsApi>('ContextsApi');
 export const API_SUBSCRIBE = createRpcChannel<SubscribeApi>('SubscribeApi');
 
 // Broadcast events (sent by extension and received by the webview)

--- a/packages/common/src/interface/contexts-api.ts
+++ b/packages/common/src/interface/contexts-api.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export const ContextsApi = Symbol.for('ContextsApi');
+
+export interface ContextsApi {
+  refreshContextState(contextName: string): Promise<void>;
+}

--- a/packages/extension/src/dashboard-extension.ts
+++ b/packages/extension/src/dashboard-extension.ts
@@ -28,7 +28,7 @@ import { KubeConfig } from '@kubernetes/client-node';
 import { ContextsStatesDispatcher } from '/@/manager/contexts-states-dispatcher';
 import { InversifyBinding } from '/@/inject/inversify-binding';
 import type { Container } from 'inversify';
-import { API_SUBSCRIBE } from '/@common/channels';
+import { API_CONTEXTS, API_SUBSCRIBE } from '/@common/channels';
 
 export class DashboardExtension {
   #container: Container | undefined;
@@ -65,6 +65,7 @@ export class DashboardExtension {
     console.log('activation time:', afterFirst - now);
 
     rpcExtension.registerInstance(API_SUBSCRIBE, this.#contextsStatesDispatcher);
+    rpcExtension.registerInstance(API_CONTEXTS, this.#contextsManager);
 
     await this.listenMonitoring();
     await this.startMonitoring();

--- a/packages/webview/src/component/connection/CheckConnection.spec.ts
+++ b/packages/webview/src/component/connection/CheckConnection.spec.ts
@@ -1,0 +1,117 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { assert, beforeEach, expect, test, vi } from 'vitest';
+
+import { StatesMocks } from '/@/tests/context-mocks';
+import { FakeStateObject } from '/@/state/util/fake-state-object.svelte';
+import type { CurrentContextInfo } from '/@common/model/current-context-info';
+import type { ContextsHealthsInfo } from '/@common/model/contexts-healths-info';
+import CheckConnection from './CheckConnection.svelte';
+import { Remote } from '/@/remote/remote';
+import * as svelte from 'svelte';
+import type { ContextsApi } from '/@common/interface/contexts-api';
+import userEvent from '@testing-library/user-event';
+
+const statesMocks = new StatesMocks();
+
+let currentContextMock: FakeStateObject<CurrentContextInfo, void>;
+let contextsHealthsMock: FakeStateObject<ContextsHealthsInfo, void>;
+
+const refreshContextStateMock = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.spyOn(svelte, 'getContext').mockImplementation(key => {
+    if (key === Remote) {
+      return {
+        getProxy: (): ContextsApi => {
+          return {
+            refreshContextState: refreshContextStateMock,
+          };
+        },
+      };
+    }
+  });
+  refreshContextStateMock.mockResolvedValue(undefined);
+
+  currentContextMock = new FakeStateObject();
+  contextsHealthsMock = new FakeStateObject();
+
+  statesMocks.reset();
+  statesMocks.mock<CurrentContextInfo, void>('stateCurrentContextInfoUI', currentContextMock);
+  statesMocks.mock<ContextsHealthsInfo, void>('stateContextsHealthsInfoUI', contextsHealthsMock);
+});
+
+test('button is displayed and active if current context is defined and is not reachable', async () => {
+  currentContextMock.setData({
+    contextName: 'ctx1',
+  });
+  contextsHealthsMock.setData({
+    healths: [{ contextName: 'ctx1', reachable: false, checking: false, offline: false }],
+  });
+
+  render(CheckConnection);
+
+  const button = screen.queryByRole('button');
+  assert(button);
+  expect(button).toHaveProperty('disabled', false);
+
+  await userEvent.click(button);
+  expect(refreshContextStateMock).toHaveBeenCalled();
+});
+
+test('button is not displayed if current context is defined and is reachable', async () => {
+  currentContextMock.setData({
+    contextName: 'ctx1',
+  });
+  contextsHealthsMock.setData({
+    healths: [{ contextName: 'ctx1', reachable: true, checking: false, offline: false }],
+  });
+
+  render(CheckConnection);
+
+  render(CheckConnection);
+  expect(screen.queryByRole('button')).toBeNull();
+});
+
+test('button is not displayed if no current context', async () => {
+  currentContextMock.setData({
+    contextName: undefined,
+  });
+
+  render(CheckConnection);
+  expect(screen.queryByRole('button')).toBeNull();
+});
+
+test('button is displayed and disabled if current context is defined, is not reacahble and is being checked', async () => {
+  currentContextMock.setData({
+    contextName: 'ctx1',
+  });
+  contextsHealthsMock.setData({
+    healths: [{ contextName: 'ctx1', reachable: false, checking: true, offline: false }],
+  });
+
+  render(CheckConnection);
+  const button = screen.getByRole('button');
+  expect(button).toHaveProperty('disabled', true);
+});

--- a/packages/webview/src/component/connection/CheckConnection.svelte
+++ b/packages/webview/src/component/connection/CheckConnection.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+import { faRefresh } from '@fortawesome/free-solid-svg-icons';
+import { Button } from '@podman-desktop/ui-svelte';
+import { getContext, onDestroy, onMount } from 'svelte';
+import { Remote } from '/@/remote/remote';
+import { API_CONTEXTS } from '/@common/channels';
+import { States } from '/@/state/states';
+import type { Unsubscriber } from 'svelte/store';
+
+const remote = getContext<Remote>(Remote);
+const contextsApi = remote.getProxy(API_CONTEXTS);
+
+const states = getContext<States>(States);
+const currentContext = states.stateCurrentContextInfoUI;
+const contextsHealths = states.stateContextsHealthsInfoUI;
+
+let unsubscribers: Unsubscriber[] = [];
+
+onMount(() => {
+  unsubscribers.push(currentContext.subscribe());
+  unsubscribers.push(contextsHealths.subscribe());
+});
+
+onDestroy(() => {
+  unsubscribers.forEach(unsubscriber => unsubscriber());
+});
+
+const inProgress = $derived.by(() => {
+  if (!currentContext.data?.contextName) {
+    return false;
+  }
+  return contextsHealths.data?.healths.find(health => health.contextName === currentContext.data?.contextName)
+    ?.checking;
+});
+
+const isReachableAndNotOffline = $derived.by(() => {
+  if (!currentContext.data?.contextName) {
+    return false;
+  }
+  const health = contextsHealths.data?.healths.find(health => health.contextName === currentContext.data?.contextName);
+  return health?.reachable && !health.offline;
+});
+
+let error = $state<string>('');
+
+function refresh(): void {
+  if (currentContext.data?.contextName) {
+    contextsApi.refreshContextState(currentContext.data.contextName).catch((err: unknown) => {
+      error = String(err);
+    });
+  }
+}
+</script>
+
+{#if currentContext.data?.contextName && !isReachableAndNotOffline}
+  <Button on:click={refresh} icon={faRefresh} inProgress={inProgress}>Refresh</Button>
+  {#if error}<div class="p-2 text-[var(--pd-state-error)]">{error}</div>{/if}
+{/if}

--- a/packages/webview/src/component/objects/KubernetesEmptyScreen.svelte
+++ b/packages/webview/src/component/objects/KubernetesEmptyScreen.svelte
@@ -54,7 +54,7 @@ const info: Info = $derived.by(() => {
   const currentContextName = currentContext.data?.contextName;
 
   const health = contextsHealths.data?.healths.find(health => health.contextName === currentContextName);
-  if (!health?.reachable) {
+  if (!health?.reachable || health.offline) {
     return {
       title: 'Context not reachable',
       text: 'The current context is not reachable',


### PR DESCRIPTION
Implements the `CheckConnection` component displayed in the Nodes list page when no node is available