### PR TITLE
feat: namespaces list

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -49,6 +49,7 @@ import { SecretsResourceFactory } from '/@/resources/secrets-resource-factory.js
 import { ServicesResourceFactory } from '/@/resources/services-resource-factory.js';
 import { injectable } from 'inversify';
 import { ContextResourceItems } from '/@common/model/context-resources-items.js';
+import { NamespacesResourceFactory } from '../resources/namespaces-resource-factory.js';
 
 const HEALTH_CHECK_TIMEOUT_MS = 5_000;
 
@@ -120,6 +121,7 @@ export class ContextsManager {
       new DeploymentsResourceFactory(),
       new EventsResourceFactory(),
       new IngressesResourceFactory(),
+      new NamespacesResourceFactory(),
       new NodesResourceFactory(),
       new PodsResourceFactory(),
       new PVCsResourceFactory(),

--- a/packages/extension/src/resources/namespaces-resource-factory.ts
+++ b/packages/extension/src/resources/namespaces-resource-factory.ts
@@ -1,0 +1,57 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { CoreV1Api, type V1Namespace, type V1NamespaceList } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class NamespacesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'namespaces',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'namespaces',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer,
+    });
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Namespace> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    const listFn = (): Promise<V1NamespaceList> => apiClient.listNamespace();
+    const path = `/api/v1/namespaces`;
+    return new ResourceInformer<V1Namespace>({ kubeconfig, path, listFn, kind: 'Namespace', plural: 'namespaces' });
+  }
+}

--- a/packages/webview/src/App.svelte
+++ b/packages/webview/src/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import NamespacesList from './component/namespaces/NamespacesList.svelte';
 import ActiveResourcesCount from '/@/component/ActiveResourcesCount.svelte';
 import ConfigsList from '/@/component/ConfigsList.svelte';
 import CurrentContext from '/@/component/CurrentContext.svelte';
@@ -28,6 +29,10 @@ let isMounted = false;
 
         <Route path="/nodes/:name/*" let:meta>
           Node details for {meta.params.name}
+        </Route>
+
+        <Route path="/namespaces">
+          <NamespacesList />
         </Route>
 
         <Route path="/current-context">

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -27,9 +27,14 @@ const navigator = dependencyAccessor.get<Navigator>(Navigator);
     <SettingsNavItem title="Dashboard" selected={meta.url === '/'} href="/" />
 
     <SettingsNavItem
-      title="Nodes List"
+      title="Nodes"
       selected={meta.url === navigator.kubernetesResourcesURL('Node')}
       href={navigator.kubernetesResourcesURL('Node')} />
+
+    <SettingsNavItem
+      title="Namespaces"
+      selected={meta.url === navigator.kubernetesResourcesURL('Namespace')}
+      href={navigator.kubernetesResourcesURL('Namespace')} />
 
     <div class="pl-3 mt-2 ml-[4px]">
       <span class="text-[color:var(--pd-secondary-nav-header-text)]">STATES</span>

--- a/packages/webview/src/component/namespaces/NamespaceEmptyScreen.svelte
+++ b/packages/webview/src/component/namespaces/NamespaceEmptyScreen.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+import KubernetesIcon from '../icons/KubernetesIcon.svelte';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+</script>
+
+<KubernetesEmptyScreen icon={KubernetesIcon} resources={['namespaces']} />

--- a/packages/webview/src/component/namespaces/NamespaceUI.ts
+++ b/packages/webview/src/component/namespaces/NamespaceUI.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface NamespaceUI extends KubernetesObjectUI {
+  created?: Date;
+}

--- a/packages/webview/src/component/namespaces/NamespacesList.svelte
+++ b/packages/webview/src/component/namespaces/NamespacesList.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import type { NamespaceUI } from './NamespaceUI';
+import { NamespaceHelper } from './namespace-helper';
+import KubernetesIcon from '../icons/KubernetesIcon.svelte';
+import NamespaceEmptyScreen from './NamespaceEmptyScreen.svelte';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const namespaceHelper = dependencyAccessor.get<NamespaceHelper>(NamespaceHelper);
+
+let statusColumn = new TableColumn<NamespaceUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<NamespaceUI>('Name', {
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let ageColumn = new TableColumn<NamespaceUI, Date | undefined>('Age', {
+  renderMapping: (namespace): Date | undefined => namespace.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [statusColumn, nameColumn, ageColumn];
+
+const row = new TableRow<NamespaceUI>({});
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'namespaces',
+      transformer: namespaceHelper.getNamespaceUI.bind(namespaceHelper),
+    },
+  ]}
+  singular="namespace"
+  plural="namespaces"
+  icon={KubernetesIcon}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <NamespaceEmptyScreen />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/namespaces/_namespaces-module.ts
+++ b/packages/webview/src/component/namespaces/_namespaces-module.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { NamespaceHelper } from './namespace-helper';
+
+const namespacesModule = new ContainerModule(options => {
+  options.bind<NamespaceHelper>(NamespaceHelper).toSelf().inSingletonScope();
+});
+
+export { namespacesModule };

--- a/packages/webview/src/component/namespaces/namespace-helper.ts
+++ b/packages/webview/src/component/namespaces/namespace-helper.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Namespace } from '@kubernetes/client-node';
+import type { NamespaceUI } from './NamespaceUI';
+
+export class NamespaceHelper {
+  getNamespaceUI(namespace: V1Namespace): NamespaceUI {
+    let status = 'RUNNING';
+
+    if (namespace.status?.phase === 'Terminating') {
+      status = 'DELETING';
+    }
+
+    const created = namespace.metadata?.creationTimestamp;
+
+    return {
+      kind: 'Namespace',
+      name: namespace.metadata?.name ?? '',
+      status,
+      created,
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -28,6 +28,7 @@ import { Remote } from '/@/remote/remote';
 import { objectsModule } from '/@/component/objects/_objects-module';
 import { navigationModule } from '/@/navigation/_navigation-module';
 import { nodesModule } from '/@/component/nodes/_nodes-module';
+import { namespacesModule } from '../component/namespaces/_namespaces-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -50,6 +51,7 @@ export class InversifyBinding {
     await this.#container.load(objectsModule);
     await this.#container.load(navigationModule);
     await this.#container.load(nodesModule);
+    await this.#container.load(namespacesModule);
 
     return this.#container;
   }


### PR DESCRIPTION
Adds the namespace resource, and the list of namespaaces

Adding namespaces before working on resource deletion, as namespaces are a good example of non-namespaced resources which can be deleted by user.

We don't have an icon for namespace, using the Kubernetes icon for the moment: #86 