### PR TITLE
feat: delete object

### DIFF
--- a/packages/webview/src/component/button/IconButton.spec.ts
+++ b/packages/webview/src/component/button/IconButton.spec.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2023-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { faRocket } from '@fortawesome/free-solid-svg-icons';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import IconButton from './IconButton.svelte';
+
+test('expect button to not have inline-flex when hidden is true', async () => {
+  const title = 'title';
+
+  render(IconButton, {
+    title,
+    icon: faRocket,
+    hidden: true,
+  });
+
+  const buttonSpan = screen.getByTitle(title);
+  expect(buttonSpan).toHaveClass('hidden');
+  expect(buttonSpan).not.toHaveClass('inline-flex');
+});
+
+test('expect button to have inline-flex when hidden is false', async () => {
+  const title = 'title';
+
+  render(IconButton, {
+    title,
+    icon: faRocket,
+    hidden: false,
+  });
+
+  const buttonSpan = screen.getByTitle(title);
+  expect(buttonSpan).not.toHaveClass('hidden');
+  expect(buttonSpan).toHaveClass('inline-flex');
+});

--- a/packages/webview/src/component/button/IconButton.svelte
+++ b/packages/webview/src/component/button/IconButton.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+import Fa from 'svelte-fa';
+import { isFontAwesomeIcon } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+import type { IconDefinition } from '@fortawesome/free-regular-svg-icons';
+
+interface Props {
+  title: string;
+  icon: IconDefinition | string;
+  fontAwesomeIcon?: IconDefinition;
+  hidden?: boolean;
+  enabled?: boolean;
+  onClick?: () => void;
+  detailed?: boolean;
+  inProgress?: boolean;
+  iconOffset?: string;
+}
+
+let {
+  title,
+  icon,
+  fontAwesomeIcon,
+  hidden = false,
+  enabled = true,
+  onClick = (): void => {},
+  detailed = false,
+  inProgress = false,
+  iconOffset = '',
+}: Props = $props();
+
+const buttonDetailedClass =
+  'text-[var(--pd-action-button-details-text)] bg-[var(--pd-action-button-details-bg)] hover:text-[var(--pd-action-button-details-hover-text)] font-medium rounded-lg text-sm items-center px-3 py-2 text-center';
+const buttonDetailedDisabledClass =
+  'text-[var(--pd-action-button-details-disabled-text)] bg-[var(--pd-action-button-details-disabled-bg)] font-medium rounded-lg text-sm  items-center px-3 py-2 text-center';
+const buttonClass =
+  'text-[var(--pd-action-button-text)] hover:bg-[var(--pd-action-button-hover-bg)] hover:text-[var(--pd-action-button-hover-text)] font-medium rounded-full items-center px-2 py-2 text-center';
+const buttonDisabledClass =
+  'text-[var(--pd-action-button-disabled-text)] font-medium rounded-full items-center px-2 py-2 text-center';
+
+const styleClass = $derived(
+  detailed
+    ? enabled && !inProgress
+      ? buttonDetailedClass
+      : buttonDetailedDisabledClass
+    : enabled && !inProgress
+      ? buttonClass
+      : buttonDisabledClass,
+);
+
+let positionLeftClass = $state('left-1');
+if (detailed) positionLeftClass = 'left-2';
+
+let positionTopClass = $state('top-1');
+if (detailed) positionTopClass = '[0.2rem]';
+
+onMount(() => {
+  if (isFontAwesomeIcon(icon)) {
+    fontAwesomeIcon = icon;
+  }
+});
+
+function handleClick(): void {
+  if (enabled && !inProgress) {
+    onClick();
+  }
+}
+</script>
+
+<button
+  title={title}
+  aria-label={title}
+  onclick={handleClick}
+  class="{styleClass} relative"
+  class:disabled={inProgress}
+  class:hidden={hidden}
+  class:inline-flex={!hidden}
+  disabled={!enabled}>
+  {#if fontAwesomeIcon}
+    <Fa class="h-4 w-4 {iconOffset}" icon={fontAwesomeIcon} />
+  {/if}
+
+  <div
+    aria-label="spinner"
+    class="w-6 h-6 rounded-full animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent absolute {positionTopClass} {positionLeftClass}"
+    class:hidden={!inProgress}>
+  </div>
+</button>

--- a/packages/webview/src/component/configmaps-secrets/ConfigMapSecretList.svelte
+++ b/packages/webview/src/component/configmaps-secrets/ConfigMapSecretList.svelte
@@ -11,6 +11,7 @@ import { getContext } from 'svelte';
 import { DependencyAccessor } from '/@/inject/dependency-accessor';
 import ConfigMapSecretIcon from '../icons/ConfigMapSecretIcon.svelte';
 import KubernetesEmptyScreen from '../objects/KubernetesEmptyScreen.svelte';
+import ActionsColumn from '/@/component/configmaps-secrets/columns/Actions.svelte';
 
 const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
 const configmapSecretHelper = dependencyAccessor.get<ConfigMapSecretHelper>(ConfigMapSecretHelper);
@@ -47,7 +48,14 @@ let typeColumn = new TableColumn<ConfigMapSecretUI>('Type', {
   comparator: (a, b): number => a.type.localeCompare(b.type),
 });
 
-const columns = [statusColumn, nameColumn, typeColumn, keysColumn, ageColumn];
+const columns = [
+  statusColumn,
+  nameColumn,
+  typeColumn,
+  keysColumn,
+  ageColumn,
+  new TableColumn<ConfigMapSecretUI>('Actions', { align: 'right', renderer: ActionsColumn }),
+];
 
 const row = new TableRow<ConfigMapSecretUI>({ selectable: (_configmapSecret): boolean => true });
 </script>

--- a/packages/webview/src/component/configmaps-secrets/columns/Actions.svelte
+++ b/packages/webview/src/component/configmaps-secrets/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/configmaps-secrets/columns/props.ts
+++ b/packages/webview/src/component/configmaps-secrets/columns/props.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export const ContextsApi = Symbol.for('ContextsApi');
+import type { ConfigMapSecretUI } from '../ConfigMapSecretUI';
 
-export interface ContextsApi {
-  refreshContextState(contextName: string): Promise<void>;
-  deleteObject(kind: string, name: string, namespace?: string): Promise<void>;
+export interface Props {
+  object: ConfigMapSecretUI;
 }

--- a/packages/webview/src/component/connection/CheckConnection.spec.ts
+++ b/packages/webview/src/component/connection/CheckConnection.spec.ts
@@ -42,6 +42,7 @@ beforeEach(() => {
   remoteMocks.reset();
   remoteMocks.mock(API_CONTEXTS, {
     refreshContextState: vi.fn(),
+    deleteObject: vi.fn(),
   });
 
   vi.mocked(remoteMocks.get(API_CONTEXTS).refreshContextState).mockResolvedValue(undefined);

--- a/packages/webview/src/component/namespaces/NamespacesList.svelte
+++ b/packages/webview/src/component/namespaces/NamespacesList.svelte
@@ -11,6 +11,7 @@ import type { NamespaceUI } from './NamespaceUI';
 import { NamespaceHelper } from './namespace-helper';
 import KubernetesIcon from '../icons/KubernetesIcon.svelte';
 import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import ActionsColumn from '/@/component/namespaces/columns/Actions.svelte';
 
 const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
 const namespaceHelper = dependencyAccessor.get<NamespaceHelper>(NamespaceHelper);
@@ -33,7 +34,12 @@ let ageColumn = new TableColumn<NamespaceUI, Date | undefined>('Age', {
   comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
 });
 
-const columns = [statusColumn, nameColumn, ageColumn];
+const columns = [
+  statusColumn,
+  nameColumn,
+  ageColumn,
+  new TableColumn<NamespaceUI>('Actions', { align: 'right', renderer: ActionsColumn }),
+];
 
 const row = new TableRow<NamespaceUI>({});
 </script>

--- a/packages/webview/src/component/namespaces/columns/Actions.svelte
+++ b/packages/webview/src/component/namespaces/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/namespaces/columns/props.ts
+++ b/packages/webview/src/component/namespaces/columns/props.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export const ContextsApi = Symbol.for('ContextsApi');
+import type { NamespaceUI } from '../NamespaceUI';
 
-export interface ContextsApi {
-  refreshContextState(contextName: string): Promise<void>;
-  deleteObject(kind: string, name: string, namespace?: string): Promise<void>;
+export interface Props {
+  object: NamespaceUI;
 }

--- a/packages/webview/src/component/objects/columns/DeleteAction.spec.ts
+++ b/packages/webview/src/component/objects/columns/DeleteAction.spec.ts
@@ -1,0 +1,109 @@
+/**********************************************************************
+ * Copyright (C) 2024-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import DeleteAction from './DeleteAction.svelte';
+import type { ConfigMapSecretUI } from '/@/component/configmaps-secrets/ConfigMapSecretUI';
+import { RemoteMocks } from '/@/tests/remote-mocks';
+import { API_CONTEXTS } from '/@common/channels';
+import { DependencyMocks } from '/@/tests/dependency-mocks';
+import { KubernetesObjectUIHelper } from '../kubernetes-object-ui-helper';
+import type { NamespaceUI } from '../../namespaces/NamespaceUI';
+
+const fakeConfigMap: ConfigMapSecretUI = {
+  kind: 'ConfigMap',
+  name: 'my-configmap',
+  namespace: 'ns1',
+  selected: false,
+  type: 'ConfigMap',
+  status: '',
+  keys: [],
+};
+
+const fakeSecret: ConfigMapSecretUI = {
+  kind: 'Secret',
+  name: 'my-secret',
+  namespace: 'ns1',
+  selected: false,
+  type: 'Secret',
+  status: '',
+  keys: [],
+};
+
+const fakeNamespace: NamespaceUI = {
+  kind: 'Namespace',
+  name: 'my-namespace',
+  status: '',
+};
+
+const dependencyMocks = new DependencyMocks();
+
+const remoteMocks = new RemoteMocks();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  dependencyMocks.reset();
+  dependencyMocks.mock(KubernetesObjectUIHelper);
+
+  remoteMocks.reset();
+  remoteMocks.mock(API_CONTEXTS, {
+    refreshContextState: vi.fn(),
+    deleteObject: vi.fn(),
+  });
+});
+
+test('Expect no error when deleting configmap', async () => {
+  vi.mocked(dependencyMocks.get(KubernetesObjectUIHelper).isNamespaced).mockReturnValue(true);
+  render(DeleteAction, { object: fakeConfigMap });
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete ConfigMap' });
+  await fireEvent.click(deleteButton);
+
+  // wait for the delete function to be called
+  expect(remoteMocks.get(API_CONTEXTS).deleteObject).toHaveBeenCalledWith('ConfigMap', 'my-configmap', 'ns1');
+});
+
+test('Expect no error when deleting secret', async () => {
+  vi.mocked(dependencyMocks.get(KubernetesObjectUIHelper).isNamespaced).mockReturnValue(true);
+  render(DeleteAction, { object: fakeSecret });
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Secret' });
+  await fireEvent.click(deleteButton);
+
+  // wait for the delete function to be called
+  expect(remoteMocks.get(API_CONTEXTS).deleteObject).toHaveBeenCalledWith('Secret', 'my-secret', 'ns1');
+});
+
+test('Expect no error when deleting namespace', async () => {
+  vi.mocked(dependencyMocks.get(KubernetesObjectUIHelper).isNamespaced).mockReturnValue(false);
+  render(DeleteAction, { object: fakeNamespace });
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Namespace' });
+  await fireEvent.click(deleteButton);
+
+  // wait for the delete function to be called
+  expect(remoteMocks.get(API_CONTEXTS).deleteObject).toHaveBeenCalledWith('Namespace', 'my-namespace');
+});

--- a/packages/webview/src/component/objects/columns/DeleteAction.svelte
+++ b/packages/webview/src/component/objects/columns/DeleteAction.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+
+import IconButton from '/@/component/button/IconButton.svelte';
+
+import type { ObjectProps } from './object-props';
+import { getContext } from 'svelte';
+import { Remote } from '/@/remote/remote';
+import { API_CONTEXTS } from '/@common/channels';
+import type { KubernetesObjectUI } from '../KubernetesObjectUI';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { KubernetesObjectUIHelper } from '../kubernetes-object-ui-helper';
+
+let { object }: ObjectProps = $props();
+
+const remote = getContext<Remote>(Remote);
+const contextsApi = remote.getProxy(API_CONTEXTS);
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const objectHelper = dependencyAccessor.get<KubernetesObjectUIHelper>(KubernetesObjectUIHelper);
+
+async function deleteKubernetesObject(obj: KubernetesObjectUI): Promise<void> {
+  obj.status = 'DELETING';
+  if (objectHelper.isNamespaced(obj)) {
+    await contextsApi.deleteObject(obj.kind, obj.name, obj.namespace);
+  } else {
+    await contextsApi.deleteObject(obj.kind, obj.name);
+  }
+}
+</script>
+
+<IconButton
+  enabled={object.status !== 'DELETING'}
+  title={`Delete ${object.kind}`}
+  onClick={(): Promise<void> => deleteKubernetesObject(object)}
+  icon={faTrash} />


### PR DESCRIPTION
Implement the `deleteObject` API call, and use it for deleting Namespaces and Configmaps/secrets

Fixes #59