### PR TITLE
fix: save permissions before broadcasting event

### DIFF
--- a/packages/extension/src/manager/context-permissions-checker.ts
+++ b/packages/extension/src/manager/context-permissions-checker.ts
@@ -108,7 +108,6 @@ export class ContextPermissionsChecker implements Disposable {
   }
 
   private saveAndFireResult(result: ContextPermissionResult): void {
-    this.#onPermissionResult.fire(result);
     for (const resourceName of result.resources) {
       this.#results.push({
         contextName: this.#contextName,
@@ -118,6 +117,7 @@ export class ContextPermissionsChecker implements Disposable {
         reason: result.reason,
       });
     }
+    this.#onPermissionResult.fire(result);
   }
 
   public getPermissions(): ContextResourcePermission[] {


### PR DESCRIPTION
In some circumstances, the permissions are not correct in the dashboard, because the event is sent before the permissions are saved