### PR TITLE
feat: make contextName optional when subscribing to UPDATE_RESOURCE

### DIFF
--- a/packages/common/src/model/context-resources-items.ts
+++ b/packages/common/src/model/context-resources-items.ts
@@ -19,7 +19,8 @@
 import type { KubernetesObject } from '@kubernetes/client-node';
 
 export interface ContextResourceItems {
-  contextName: string;
+  // default context if not set
+  contextName?: string;
   resourceName: string;
   items: readonly KubernetesObject[];
 }

--- a/packages/common/src/model/update-resource-options.ts
+++ b/packages/common/src/model/update-resource-options.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 export interface UpdateResourceOptions {
-  contextName: string;
+  // default context if not set
+  contextName?: string;
   resourceName: string;
 }

--- a/packages/extension/src/dispatcher/update-resource-dispatcher.ts
+++ b/packages/extension/src/dispatcher/update-resource-dispatcher.ts
@@ -39,7 +39,9 @@ export class UpdateResourceDispatcher
 
   getData(options: UpdateResourceOptions[]): UpdateResourceInfo {
     return {
-      resources: options.flatMap(option => this.manager.getResources([option.contextName], option.resourceName)),
+      resources: options.flatMap(option =>
+        this.manager.getResources(option.contextName ? [option.contextName] : [], option.resourceName),
+      ),
     };
   }
 }

--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -216,11 +216,22 @@ export class ContextsManager {
       .filter(f => !!f);
   }
 
+  // getResources returns the resources for the given contexts and resource name
+  // if no context names are provided, the current context is used
   getResources(contextNames: string[], resourceName: string): ContextResourceItems[] {
+    let useCurrentContext = false;
+    if (contextNames.length === 0) {
+      const currentContextName = this.currentContext?.getKubeConfig().currentContext;
+      if (!currentContextName) {
+        return [];
+      }
+      contextNames = [currentContextName];
+      useCurrentContext = true;
+    }
     return this.#objectCaches.getForContextsAndResource(contextNames, resourceName).map(({ contextName, value }) => {
       return {
         resourceName,
-        contextName,
+        contextName: useCurrentContext ? undefined : contextName,
         items: value.list(),
       };
     });

--- a/packages/extension/src/manager/contexts-states-dispatcher.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.ts
@@ -75,6 +75,7 @@ export class ContextsStatesDispatcher extends ChannelSubscriber implements Subsc
     });
     this.manager.onCurrentContextChange(async () => {
       await this.dispatch(CURRENT_CONTEXT);
+      await this.dispatch(UPDATE_RESOURCE);
     });
 
     this.onSubscribe(channelName => this.dispatchByChannelName(channelName));

--- a/packages/webview/src/component/objects/KubernetesObjectsList.spec.ts
+++ b/packages/webview/src/component/objects/KubernetesObjectsList.spec.ts
@@ -93,7 +93,7 @@ test('empty screen because of no resource', () => {
     resources: [
       // resources subscribed from this component
       {
-        contextName: 'ctx1',
+        contextName: undefined,
         resourceName: 'seals',
         items: [], // no resource
       },
@@ -104,7 +104,7 @@ test('empty screen because of no resource', () => {
         items: [{ metadata: { name: 'podman' } }],
       },
       {
-        contextName: 'ctx1',
+        contextName: undefined,
         resourceName: 'dolphin',
         items: [{ metadata: { name: 'flipper' } }],
       },
@@ -117,7 +117,7 @@ test('empty screen because of no resource', () => {
   screen.getByRole('region', { name: 'Seals' });
 
   expect(updateResourceMock.subscribe).toHaveBeenCalledWith({
-    contextName: 'ctx1',
+    contextName: undefined,
     resourceName: 'seals',
   });
 
@@ -136,7 +136,7 @@ describe('resources exist', () => {
       resources: [
         // resources subscribed from this component
         {
-          contextName: 'ctx1',
+          contextName: undefined,
           resourceName: 'seals',
           items: [{ metadata: { name: 'podman' } }], // no resource
         },
@@ -147,7 +147,7 @@ describe('resources exist', () => {
           items: [{ metadata: { name: 'podman2' } }],
         },
         {
-          contextName: 'ctx1',
+          contextName: undefined,
           resourceName: 'dolphin',
           items: [{ metadata: { name: 'flipper' } }],
         },
@@ -159,7 +159,7 @@ describe('resources exist', () => {
     render(KubernetesObjectsListSpec);
 
     expect(updateResourceMock.subscribe).toHaveBeenCalledWith({
-      contextName: 'ctx1',
+      contextName: undefined,
       resourceName: 'seals',
     });
     expect(screen.queryByText('No Seals')).toBeNull();

--- a/packages/webview/src/component/objects/NamespaceDropdown.spec.ts
+++ b/packages/webview/src/component/objects/NamespaceDropdown.spec.ts
@@ -84,7 +84,8 @@ beforeEach(() => {
   updateResourceMock.setData({
     resources: [
       {
-        contextName: 'context1',
+        // this will be the one used by the component
+        contextName: undefined,
         resourceName: 'namespaces',
         items: [
           {
@@ -100,6 +101,7 @@ beforeEach(() => {
         ],
       },
       {
+        // this one will be ignored by the component
         contextName: 'context2',
         resourceName: 'namespaces',
         items: [


### PR DESCRIPTION
Webview components are all doing the same logic when subscribing to resources of the current context: they are subscribing to the CURRENT_CONTEXT, then when current context changes, they are unsubscribing from the UPDATE_RESOURCE and subscribing to it again with the new context

With this change, the components can now subscribe to UPDATE_RESOURCE with an undefined contextName, meaning that they want to receive the resources for the current context (not at the time of subscription, but at any time).

