### PR TITLE
feat: service details

### DIFF
--- a/packages/webview/src/App.svelte
+++ b/packages/webview/src/App.svelte
@@ -17,6 +17,7 @@ import JobsList from './component/jobs/JobsList.svelte';
 import CronJobsList from './component/cronjobs/CronJobsList.svelte';
 import PodsList from './component/pods/PodsList.svelte';
 import DeploymentDetails from './component/deployments/DeploymentDetails.svelte';
+import ServiceDetails from './component/services/ServiceDetails.svelte';
 
 let isMounted = false;
 </script>
@@ -61,6 +62,10 @@ let isMounted = false;
 
         <Route path="/services">
           <ServicesList />
+        </Route>
+
+        <Route path="/services/:name/:namespace/*" let:meta>
+          <ServiceDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
         </Route>
 
         <Route path="/ingressesRoutes">

--- a/packages/webview/src/component/services/ServiceDetails.svelte
+++ b/packages/webview/src/component/services/ServiceDetails.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { ServiceHelper } from './service-helper';
+import type { ServiceUI } from './ServiceUI';
+import type { V1Service } from '@kubernetes/client-node';
+import ServiceDetailsSummary from './ServiceDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const serviceHelper = dependencyAccessor.get<ServiceHelper>(ServiceHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1Service}
+  typedUI={{} as ServiceUI}
+  kind="Service"
+  resourceName="services"
+  listName="Services"
+  name={name}
+  namespace={namespace}
+  transformer={serviceHelper.getServiceUI.bind(serviceHelper)}
+  ActionsComponent={Actions}
+  SummaryComponent={ServiceDetailsSummary} />

--- a/packages/webview/src/component/services/ServiceDetailsSummary.spec.ts
+++ b/packages/webview/src/component/services/ServiceDetailsSummary.spec.ts
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { V1Service } from '@kubernetes/client-node';
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import ServiceDetailsSummary from './ServiceDetailsSummary.svelte';
+
+const service: V1Service = {
+  metadata: {
+    name: 'my-service',
+    namespace: 'default',
+  },
+  spec: {
+    clusterIP: '10.10.10.1',
+    ports: [
+      {
+        name: 'http',
+        port: 8080,
+        targetPort: 8080,
+      },
+    ],
+  },
+  status: {},
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect basic rendering', async () => {
+  render(ServiceDetailsSummary, { props: { object: service, events: [] } });
+
+  expect(screen.getByText('my-service')).toBeInTheDocument();
+});
+
+test('Check more properties', async () => {
+  render(ServiceDetailsSummary, { props: { object: service, events: [] } });
+
+  expect(screen.getByText('my-service')).toBeInTheDocument();
+  expect(screen.getByText('default')).toBeInTheDocument();
+  expect(screen.getByText('10.10.10.1')).toBeInTheDocument();
+});

--- a/packages/webview/src/component/services/ServiceDetailsSummary.svelte
+++ b/packages/webview/src/component/services/ServiceDetailsSummary.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+import type { V1Service } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+import ServiceStatusDetails from './details/ServiceStatusDetails.svelte';
+import ServiceSpecDetails from './details/ServiceSpecDetails.svelte';
+
+interface Props {
+  object: V1Service;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  {#if object.status}
+    <ServiceStatusDetails status={object.status} />
+  {/if}
+  {#if object.spec}
+    <ServiceSpecDetails serviceName={object.metadata?.name} namespace={object.metadata?.namespace} spec={object.spec} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/services/details/ServiceSpecDetails.spec.ts
+++ b/packages/webview/src/component/services/details/ServiceSpecDetails.spec.ts
@@ -1,0 +1,70 @@
+/**********************************************************************
+ * Copyright (C) 2023-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import KubeServiceSpecArtifact from './ServiceSpecDetails.svelte';
+
+const fakeServiceSpec = {
+  type: 'ClusterIP',
+  clusterIP: '10.96.0.1',
+  externalIPs: ['192.168.1.1', '192.168.1.2'],
+  sessionAffinity: 'None',
+  ports: [
+    { name: 'http', port: 80, protocol: 'TCP' },
+    { name: 'http2', port: 80, nodePort: 12345, protocol: 'TCP' },
+    { port: 443, protocol: 'TCP' },
+  ],
+  selector: {
+    app: 'myApp',
+    department: 'engineering',
+  },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Renders service spec correctly', () => {
+  render(KubeServiceSpecArtifact, { spec: fakeServiceSpec });
+
+  // Verify static details
+  expect(screen.getByText('Details')).toBeInTheDocument();
+  expect(screen.getByText('Type')).toBeInTheDocument();
+  expect(screen.getByText('ClusterIP')).toBeInTheDocument();
+  expect(screen.getByText('Cluster IP')).toBeInTheDocument();
+  expect(screen.getByText('10.96.0.1')).toBeInTheDocument();
+  expect(screen.getByText('External IPs')).toBeInTheDocument();
+  expect(screen.getByText('192.168.1.1, 192.168.1.2')).toBeInTheDocument();
+  expect(screen.getByText('Session Affinity')).toBeInTheDocument();
+  expect(screen.getByText('None')).toBeInTheDocument();
+
+  // Verify ports are displayed correctly
+  //  expect(screen.getByText('Ports')).toBeInTheDocument();
+  //  expect(screen.getByText('http:80/TCP')).toBeInTheDocument();
+  //  expect(screen.getByText('http2:80:12345/TCP')).toBeInTheDocument();
+  //  expect(screen.getByText('443/TCP')).toBeInTheDocument();
+
+  // Verify selectors are displayed correctly
+  expect(screen.getByText('Selectors')).toBeInTheDocument();
+  expect(screen.getByText('app: myApp')).toBeInTheDocument();
+  expect(screen.getByText('department: engineering')).toBeInTheDocument();
+});

--- a/packages/webview/src/component/services/details/ServiceSpecDetails.svelte
+++ b/packages/webview/src/component/services/details/ServiceSpecDetails.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+import type { V1ServiceSpec } from '@kubernetes/client-node';
+
+import Cell from '/@/component/details/Cell.svelte';
+import Title from '/@/component/details/Title.svelte';
+
+interface Props {
+  spec: V1ServiceSpec;
+  serviceName?: string;
+  namespace?: string;
+}
+let { spec: spec, serviceName, namespace }: Props = $props();
+</script>
+
+{#if spec}
+  <tr>
+    <Title>Details</Title>
+  </tr>
+  <tr>
+    <Cell>Type</Cell>
+    <Cell>{spec?.type}</Cell>
+  </tr>
+  <tr>
+    <Cell>Cluster IP</Cell>
+    <Cell>{spec?.clusterIP}</Cell>
+  </tr>
+  {#if spec?.externalIPs}
+    <tr>
+      <Cell>External IPs</Cell>
+      <Cell>{spec?.externalIPs?.join(', ') || ''}</Cell>
+    </tr>
+  {/if}
+  <tr>
+    <Cell>Session Affinity</Cell>
+    <Cell>{spec?.sessionAffinity}</Cell>
+  </tr>
+  <!--KubePorts namespace={namespace} resourceName={serviceName} kind={WorkloadKind.SERVICE} ports={artifact.ports?.map((port) => ({
+    name: port.name,
+    value: port.port,
+    protocol: port.protocol,
+    displayValue: `${port.name ? port.name + ':' : ''}${port.port}${port.nodePort ? ':' + port.nodePort : ''}/${port.protocol}`,
+  }))}/-->
+  {#if spec.selector}
+    <tr>
+      <Cell>Selectors</Cell>
+      <Cell>
+        {#each Object.entries(spec.selector) as [key, value] (key)}
+          <div>{key}: {value}</div>
+        {/each}
+      </Cell>
+    </tr>
+  {/if}
+{/if}

--- a/packages/webview/src/component/services/details/ServiceStatusDetails.spec.ts
+++ b/packages/webview/src/component/services/details/ServiceStatusDetails.spec.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2023-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { V1ServiceStatus } from '@kubernetes/client-node';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import ServiceStatusDetails from './ServiceStatusDetails.svelte';
+
+const fakeServiceStatus: V1ServiceStatus = {
+  loadBalancer: {
+    ingress: [{ ip: '192.0.2.1' }, { hostname: 'example.com' }],
+  },
+};
+
+test('Renders service status correctly', () => {
+  render(ServiceStatusDetails, { status: fakeServiceStatus });
+
+  expect(screen.getByText('Status')).toBeInTheDocument();
+  expect(screen.getByText('Load Balancer')).toBeInTheDocument();
+  expect(screen.getByText('192.0.2.1')).toBeInTheDocument(); // Verifying the IP address is rendered
+  expect(screen.getByText('example.com')).toBeInTheDocument(); // Verifying the hostname is rendered
+});

--- a/packages/webview/src/component/services/details/ServiceStatusDetails.svelte
+++ b/packages/webview/src/component/services/details/ServiceStatusDetails.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import type { V1ServiceStatus } from '@kubernetes/client-node';
+
+import Cell from '/@/component/details/Cell.svelte';
+import Title from '/@/component/details/Title.svelte';
+
+interface Props {
+  status: V1ServiceStatus;
+}
+let { status }: Props = $props();
+</script>
+
+<!-- This artifact is a bit weird as it only contains one object
+    so do not bother showing unless we have both loadBalancer AND loadBalancer.ingress -->
+{#if status.loadBalancer?.ingress}
+  <tr>
+    <Title>Status</Title>
+  </tr>
+  <tr>
+    <Cell>Load Balancer</Cell>
+    <Cell>
+      {#each status.loadBalancer?.ingress as ingress, index (index)}
+        <div>{ingress.ip ?? ingress.hostname}</div>
+      {/each}
+    </Cell>
+  </tr>
+{/if}


### PR DESCRIPTION
Add details page for services (summary tab only)

Part of https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/61