### PR TITLE
fix: port forwarding

### DIFF
--- a/packages/common/src/interface/port-forward-api.ts
+++ b/packages/common/src/interface/port-forward-api.ts
@@ -20,7 +20,11 @@ import type { ForwardConfig, ForwardOptions } from '../model/port-forward';
 
 export const PortForwardApi = Symbol.for('PortForwardApi');
 
+export type DeletePortForwardOptions = {
+  askConfirmation: boolean;
+};
+
 export interface PortForwardApi {
   createPortForward(config: ForwardOptions): Promise<void>;
-  deletePortForward(config: ForwardConfig): Promise<void>;
+  deletePortForward(config: ForwardConfig, options?: DeletePortForwardOptions): Promise<void>;
 }

--- a/packages/extension/src/manager/port-forward-api-impl.ts
+++ b/packages/extension/src/manager/port-forward-api-impl.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { inject, injectable } from 'inversify';
-import { PortForwardApi } from '/@common/interface/port-forward-api';
+import { DeletePortForwardOptions, PortForwardApi } from '/@common/interface/port-forward-api';
 import { ForwardConfig, ForwardOptions } from '/@common/model/port-forward';
 import { PortForwardService, PortForwardServiceProvider } from '/@/port-forward/port-forward-service';
 
@@ -38,8 +38,8 @@ export class PortForwardApiImpl implements PortForwardApi {
     }
   }
 
-  async deletePortForward(config: ForwardConfig): Promise<void> {
-    return this.ensurePortForwardService().deleteForward(config);
+  async deletePortForward(config: ForwardConfig, options?: DeletePortForwardOptions): Promise<void> {
+    return this.ensurePortForwardService().deleteForward(config, options);
   }
 
   getPortForwards(): ForwardConfig[] {

--- a/packages/extension/src/port-forward/port-forward-service.spec.ts
+++ b/packages/extension/src/port-forward/port-forward-service.spec.ts
@@ -44,6 +44,8 @@ describe('KubernetesPortForwardService', () => {
     forward: { localPort: 8080, remotePort: 80 },
   };
 
+  const onForwardsChange = vi.fn();
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockConfigManagementService = {
@@ -58,6 +60,7 @@ describe('KubernetesPortForwardService', () => {
     } as unknown as PortForwardConnectionService;
 
     service = new PortForwardService(mockConfigManagementService, mockForwardingConnectionService);
+    service.onForwardsChange(onForwardsChange);
     vi.mocked(randomUUID).mockReturnValue('fake-id' as UUID);
   });
 
@@ -74,13 +77,13 @@ describe('KubernetesPortForwardService', () => {
     });
     expect(result).toEqual(sampleForwardConfig);
     expect(mockConfigManagementService.createForward).toHaveBeenCalledWith(sampleForwardConfig);
-    // TODO test event is sent
+    expect(onForwardsChange).toHaveBeenCalled();
   });
 
   test('should delete a forward configuration', async () => {
     await service.deleteForward(sampleForwardConfig);
     expect(mockConfigManagementService.deleteForward).toHaveBeenCalledWith(sampleForwardConfig);
-    // TODO test event is sent
+    expect(onForwardsChange).toHaveBeenCalled();
   });
 
   test('should list all forward configurations', async () => {

--- a/packages/webview/src/component/port-forward/columns/Actions.spec.ts
+++ b/packages/webview/src/component/port-forward/columns/Actions.spec.ts
@@ -95,5 +95,7 @@ test('remove should call deleteKubernetesPortForward', async () => {
   const deleteBtn = getByTitle('Delete forwarded port');
   await fireEvent.click(deleteBtn);
 
-  expect(remoteMocks.get(API_PORT_FORWARD).deletePortForward).toHaveBeenCalledWith(MOCKED_USER_FORWARD_CONFIG);
+  expect(remoteMocks.get(API_PORT_FORWARD).deletePortForward).toHaveBeenCalledWith(MOCKED_USER_FORWARD_CONFIG, {
+    askConfirmation: true,
+  });
 });

--- a/packages/webview/src/component/port-forward/columns/Actions.svelte
+++ b/packages/webview/src/component/port-forward/columns/Actions.svelte
@@ -32,7 +32,7 @@ let userConfigForward: ForwardConfig | undefined = $derived(
 
 async function deletePortForward(): Promise<void> {
   if (!userConfigForward) return;
-  await portForwardApi.deletePortForward($state.snapshot(userConfigForward));
+  await portForwardApi.deletePortForward($state.snapshot(userConfigForward), { askConfirmation: true });
 }
 
 async function openExternal(): Promise<void> {


### PR DESCRIPTION
Fix TODOs remaining from #215 

- test events are sent when port forwardings are created/deleted
- ask confirmation when deleting a port forwarding from the list
- really check if port is free