### PR TITLE
feat: restart pod/job

### DIFF
--- a/packages/common/src/interface/contexts-api.ts
+++ b/packages/common/src/interface/contexts-api.ts
@@ -23,4 +23,5 @@ export interface ContextsApi {
   deleteObject(kind: string, name: string, namespace?: string): Promise<void>;
   deleteObjects(objects: { kind: string; name: string; namespace?: string }[]): Promise<void>;
   setCurrentNamespace(namespace: string): Promise<void>;
+  restartObject(kind: string, name: string, namespace: string): Promise<void>;
 }

--- a/packages/extension/src/resources/jobs-resource-factory.spec.ts
+++ b/packages/extension/src/resources/jobs-resource-factory.spec.ts
@@ -1,0 +1,125 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, type MockedFunction, test, vi } from 'vitest';
+import { JobsResourceFactory } from './jobs-resource-factory';
+import type { ContextsManager } from '/@/manager/contexts-manager';
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context';
+import type { BatchV1Api, KubeConfig, V1Job } from '@kubernetes/client-node';
+
+const contextsManager: ContextsManager = {
+  waitForObjectDeletion: vi.fn(),
+  restartObject: vi.fn(),
+} as unknown as ContextsManager;
+
+const makeApiClientMock = vi.fn() as MockedFunction<KubeConfig['makeApiClient']>;
+
+const kubeconfig: KubeConfigSingleContext = {
+  getKubeConfig: () =>
+    ({
+      makeApiClient: makeApiClientMock,
+    }) as unknown as KubeConfig,
+} as unknown as KubeConfigSingleContext;
+
+test('readObject is set by factory', () => {
+  const factory = new JobsResourceFactory(contextsManager);
+  expect(factory.readObject).toBeDefined();
+});
+
+test('restartObject', async () => {
+  const apiClientMock = {
+    readNamespacedJob: vi.fn(),
+    deleteNamespacedJob: vi.fn(),
+    createNamespacedJob: vi.fn(),
+  } as unknown as BatchV1Api;
+  makeApiClientMock.mockReturnValue(apiClientMock);
+  vi.mocked(apiClientMock.readNamespacedJob).mockResolvedValue({
+    metadata: {
+      name: 'job1',
+      namespace: 'namespace1',
+      creationTimestamp: new Date(),
+      resourceVersion: '1',
+      selfLink: '/apis/batch/v1/namespaces/namespace1/jobs/job1',
+      uid: '1',
+      ownerReferences: [],
+      labels: {
+        'job-name': 'job1',
+        'controller-uid': '1',
+        'batch.kubernetes.io/controller-uid': '1',
+        'batch.kubernetes.io/job-name': 'job1',
+        'other-label': 'other-value',
+      },
+    },
+    spec: {
+      template: {
+        metadata: {
+          name: 'job1',
+          labels: {
+            'job-name': 'job1',
+            'controller-uid': '1',
+            'batch.kubernetes.io/controller-uid': '1',
+            'batch.kubernetes.io/job-name': 'job1',
+            'other-label': 'other-value',
+          },
+        },
+      },
+      selector: {
+        matchLabels: {
+          'job-name': 'job1',
+        },
+      },
+    },
+    status: {
+      conditions: [],
+    },
+  } as unknown as V1Job);
+  const factory = new JobsResourceFactory(contextsManager);
+  expect(factory.restartObject).toBeDefined();
+
+  vi.mocked(contextsManager.waitForObjectDeletion).mockResolvedValue(true);
+
+  await factory.restartObject(kubeconfig, 'job1', 'namespace1');
+
+  expect(apiClientMock.deleteNamespacedJob).toHaveBeenCalledWith({
+    name: 'job1',
+    namespace: 'namespace1',
+    propagationPolicy: 'Foreground',
+  });
+  expect(apiClientMock.createNamespacedJob).toHaveBeenCalledWith({
+    namespace: 'namespace1',
+    body: {
+      metadata: {
+        name: 'job1',
+        namespace: 'namespace1',
+        labels: {
+          'other-label': 'other-value',
+        },
+      },
+      spec: {
+        template: {
+          metadata: {
+            name: 'job1',
+            labels: {
+              'other-label': 'other-value',
+            },
+          },
+        },
+      },
+    },
+  });
+});

--- a/packages/extension/src/resources/objects/metadata-explorer.spec.ts
+++ b/packages/extension/src/resources/objects/metadata-explorer.spec.ts
@@ -1,0 +1,118 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { MetadataExplorer } from './metadata-explorer.js';
+import type { V1ObjectMeta } from '@kubernetes/client-node';
+
+test('MetadataExplorer should return the first controller of the object', () => {
+  const metadata: V1ObjectMeta = {
+    ownerReferences: [
+      { controller: true, name: 'controller', apiVersion: 'v1', kind: 'ReplicaSet', uid: '123' },
+      { controller: true, name: 'controller2', apiVersion: 'v1', kind: 'ReplicaSet', uid: '1234' },
+      { controller: false, name: 'other', apiVersion: 'v1', kind: 'ReplicaSet', uid: '456' },
+    ],
+  };
+  const metadataExplorer = new MetadataExplorer(metadata);
+  const controller = metadataExplorer.getController();
+  expect(controller).toEqual({
+    controller: true,
+    name: 'controller',
+    apiVersion: 'v1',
+    kind: 'ReplicaSet',
+    uid: '123',
+  });
+});
+
+test('MetadataExplorer should return undefined if no controller', () => {
+  const metadata: V1ObjectMeta = {
+    ownerReferences: [{ controller: false, name: 'other', apiVersion: 'v1', kind: 'ReplicaSet', uid: '456' }],
+  };
+  const metadataExplorer = new MetadataExplorer(metadata);
+  const controller = metadataExplorer.getController();
+  expect(controller).toBeUndefined();
+});
+
+test('MetadataExplorer should return undefined if no ownerReference', () => {
+  const metadata: V1ObjectMeta = {};
+  const metadataExplorer = new MetadataExplorer(metadata);
+  const controller = metadataExplorer.getController();
+  expect(controller).toBeUndefined();
+});
+
+test('getUserOnlyMetadata should return the metadata of the object without data populated by the system', () => {
+  const metadata: V1ObjectMeta = {
+    name: 'test',
+    namespace: 'test',
+    labels: { test: 'test' },
+    annotations: { test: 'test' },
+    creationTimestamp: new Date(),
+    ownerReferences: [
+      { controller: true, name: 'controller', apiVersion: 'v1', kind: 'ReplicaSet', uid: '123' },
+      { controller: true, name: 'controller2', apiVersion: 'v1', kind: 'ReplicaSet', uid: '1234' },
+      { controller: false, name: 'other', apiVersion: 'v1', kind: 'ReplicaSet', uid: '456' },
+    ],
+  };
+  const metadataExplorer = new MetadataExplorer(metadata);
+  const userOnlyMetadata = metadataExplorer.getUserOnlyMetadata();
+  expect(userOnlyMetadata).toEqual({
+    name: 'test',
+    namespace: 'test',
+    labels: { test: 'test' },
+    annotations: { test: 'test' },
+  });
+});
+
+test('getUserOnlyMetadata should return the metadata of the object without data populated by the system, with generateName', () => {
+  const metadata: V1ObjectMeta = {
+    generateName: 'test-',
+    namespace: 'test',
+    labels: { test: 'test' },
+    annotations: { test: 'test' },
+    creationTimestamp: new Date(),
+    ownerReferences: [
+      { controller: true, name: 'controller', apiVersion: 'v1', kind: 'ReplicaSet', uid: '123' },
+      { controller: true, name: 'controller2', apiVersion: 'v1', kind: 'ReplicaSet', uid: '1234' },
+      { controller: false, name: 'other', apiVersion: 'v1', kind: 'ReplicaSet', uid: '456' },
+    ],
+  };
+  const metadataExplorer = new MetadataExplorer(metadata);
+  const userOnlyMetadata = metadataExplorer.getUserOnlyMetadata();
+  expect(userOnlyMetadata).toEqual({
+    generateName: 'test-',
+    namespace: 'test',
+    labels: { test: 'test' },
+    annotations: { test: 'test' },
+  });
+});
+
+test('getUserOnlyMetadata should return the metadata of the object without data populated by the system, with only name as user data', () => {
+  const metadata: V1ObjectMeta = {
+    name: 'test',
+    creationTimestamp: new Date(),
+    ownerReferences: [
+      { controller: true, name: 'controller', apiVersion: 'v1', kind: 'ReplicaSet', uid: '123' },
+      { controller: true, name: 'controller2', apiVersion: 'v1', kind: 'ReplicaSet', uid: '1234' },
+      { controller: false, name: 'other', apiVersion: 'v1', kind: 'ReplicaSet', uid: '456' },
+    ],
+  };
+  const metadataExplorer = new MetadataExplorer(metadata);
+  const userOnlyMetadata = metadataExplorer.getUserOnlyMetadata();
+  expect(userOnlyMetadata).toEqual({ name: 'test' });
+});

--- a/packages/extension/src/resources/objects/metadata-explorer.ts
+++ b/packages/extension/src/resources/objects/metadata-explorer.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (C) 2024, 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ObjectMeta, V1OwnerReference } from '@kubernetes/client-node';
+
+export class MetadataExplorer {
+  #metadata: V1ObjectMeta;
+
+  constructor(metadata: V1ObjectMeta) {
+    this.#metadata = metadata;
+  }
+
+  // getController returns the controller of the object, based on the ownerReferences field
+  // and returning the first ownerReference with controller field set to true
+  // returns undefined if there is no controller
+  getController(): V1OwnerReference | undefined {
+    return this.#metadata.ownerReferences?.find((ref: V1OwnerReference) => ref.controller === true);
+  }
+
+  // getUserOnlyMetadata returns the metadata of the object without data populated by the system
+  getUserOnlyMetadata(): V1ObjectMeta {
+    return this.copyExcludingUndefined(this.#metadata, ['name', 'generateName', 'namespace', 'labels', 'annotations']);
+  }
+
+  protected copyExcludingUndefined(obj: V1ObjectMeta, fields: (keyof V1ObjectMeta)[]): V1ObjectMeta {
+    return Object.entries(obj).reduce((a, [k, v]) => {
+      if (fields.includes(k as keyof V1ObjectMeta) && v !== undefined) {
+        a[k as keyof V1ObjectMeta] = v;
+      }
+      return a;
+    }, {} as V1ObjectMeta);
+  }
+}

--- a/packages/extension/src/resources/pods-resource-factory.spec.ts
+++ b/packages/extension/src/resources/pods-resource-factory.spec.ts
@@ -1,0 +1,135 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, type MockedFunction, test, vi } from 'vitest';
+import { PodsResourceFactory } from './pods-resource-factory';
+import type { ContextsManager } from '/@/manager/contexts-manager';
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context';
+import type { CoreV1Api, KubeConfig, V1Pod } from '@kubernetes/client-node';
+
+const contextsManager: ContextsManager = {
+  waitForObjectDeletion: vi.fn(),
+  restartObject: vi.fn(),
+} as unknown as ContextsManager;
+
+const makeApiClientMock = vi.fn() as MockedFunction<KubeConfig['makeApiClient']>;
+
+const kubeconfig: KubeConfigSingleContext = {
+  getKubeConfig: () =>
+    ({
+      makeApiClient: makeApiClientMock,
+    }) as unknown as KubeConfig,
+} as unknown as KubeConfigSingleContext;
+
+test('readObject is set by factory', () => {
+  const factory = new PodsResourceFactory(contextsManager);
+  expect(factory.readObject).toBeDefined();
+});
+
+test('restartObject with standalone pod deletes the pod and recreates a new one', async () => {
+  const apiClientMock = {
+    readNamespacedPod: vi.fn(),
+    deleteNamespacedPod: vi.fn(),
+    createNamespacedPod: vi.fn(),
+  } as unknown as CoreV1Api;
+  makeApiClientMock.mockReturnValue(apiClientMock);
+  vi.mocked(apiClientMock.readNamespacedPod).mockResolvedValue({
+    metadata: {
+      name: 'pod1',
+      namespace: 'namespace1',
+      creationTimestamp: new Date(),
+    },
+  } as unknown as V1Pod);
+  const factory = new PodsResourceFactory(contextsManager);
+  expect(factory.restartObject).toBeDefined();
+
+  vi.mocked(contextsManager.waitForObjectDeletion).mockResolvedValue(true);
+
+  await factory.restartObject(kubeconfig, 'pod1', 'namespace1');
+
+  expect(contextsManager.waitForObjectDeletion).toHaveBeenCalledWith('pods', 'pod1', 'namespace1');
+  expect(apiClientMock.createNamespacedPod).toHaveBeenCalledWith({
+    namespace: 'namespace1',
+    body: {
+      metadata: {
+        name: 'pod1',
+        namespace: 'namespace1',
+      },
+    },
+  });
+});
+
+test('restartObject with a pod managed by a Job restarts the Job', async () => {
+  const apiClientMock = {
+    readNamespacedPod: vi.fn(),
+    deleteNamespacedPod: vi.fn(),
+    createNamespacedPod: vi.fn(),
+  } as unknown as CoreV1Api;
+  makeApiClientMock.mockReturnValue(apiClientMock);
+  vi.mocked(apiClientMock.readNamespacedPod).mockResolvedValue({
+    metadata: {
+      name: 'pod1',
+      namespace: 'namespace1',
+      creationTimestamp: new Date(),
+      ownerReferences: [
+        {
+          controller: true,
+          kind: 'Job',
+          name: 'job1',
+          namespace: 'namespace1',
+        },
+      ],
+    },
+  } as unknown as V1Pod);
+  const factory = new PodsResourceFactory(contextsManager);
+  expect(factory.restartObject).toBeDefined();
+
+  await factory.restartObject(kubeconfig, 'pod1', 'namespace1');
+
+  expect(contextsManager.restartObject).toHaveBeenCalledWith('Job', 'job1', 'namespace1');
+});
+
+test('restartObject with a pod managed by a Deployment deletes the pod', async () => {
+  const apiClientMock = {
+    readNamespacedPod: vi.fn(),
+    deleteNamespacedPod: vi.fn(),
+    createNamespacedPod: vi.fn(),
+  } as unknown as CoreV1Api;
+  makeApiClientMock.mockReturnValue(apiClientMock);
+  vi.mocked(apiClientMock.readNamespacedPod).mockResolvedValue({
+    metadata: {
+      name: 'pod1',
+      namespace: 'namespace1',
+      creationTimestamp: new Date(),
+      ownerReferences: [
+        {
+          controller: true,
+          kind: 'Deployment',
+          name: 'deployment1',
+          namespace: 'namespace1',
+        },
+      ],
+    },
+  } as unknown as V1Pod);
+  const factory = new PodsResourceFactory(contextsManager);
+  expect(factory.restartObject).toBeDefined();
+
+  await factory.restartObject(kubeconfig, 'pod1', 'namespace1');
+
+  expect(apiClientMock.deleteNamespacedPod).toHaveBeenCalledWith({ name: 'pod1', namespace: 'namespace1' });
+});

--- a/packages/extension/src/resources/resource-factory-handler.spec.ts
+++ b/packages/extension/src/resources/resource-factory-handler.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024 - 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,9 @@ import { DeploymentsResourceFactory } from './deployments-resource-factory.js';
 import { PodsResourceFactory } from './pods-resource-factory.js';
 import { ResourceFactoryBase } from './resource-factory.js';
 import { ResourceFactoryHandler } from '/@/manager/resource-factory-handler.js';
+import type { ContextsManager } from '/@/manager/contexts-manager.js';
 
+const contextsManager: ContextsManager = {} as ContextsManager;
 test('with 1 level and same request', () => {
   const factoryHandler = new ResourceFactoryHandler();
 
@@ -445,7 +447,7 @@ test('with 1 level and same request, both namespaced ant not namespaced', () => 
 test('real pods and deployments', () => {
   const factoryHandler = new ResourceFactoryHandler();
 
-  factoryHandler.add(new PodsResourceFactory());
+  factoryHandler.add(new PodsResourceFactory(contextsManager));
   factoryHandler.add(new DeploymentsResourceFactory());
   const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([

--- a/packages/extension/src/resources/resource-factory.spec.ts
+++ b/packages/extension/src/resources/resource-factory.spec.ts
@@ -88,3 +88,39 @@ test('ResourceFactoryBase set informer', () => {
   expect(factory.informer?.createInformer).toEqual(createInformer);
   expect(isResourceFactoryWithPermissions(factory)).toBeFalsy();
 });
+
+test('ResourceFactoryBase set readObject with namespaced object', () => {
+  const factory = new ResourceFactoryBase({ resource: 'resource1', kind: 'kind1' });
+  const readObject = (_kubeconfig: KubeConfigSingleContext, _name: string, _namespace: string): Promise<V1Pod> => {
+    return Promise.resolve({} as V1Pod);
+  };
+  factory.setReadObject(readObject);
+  expect(factory.readObject).toEqual(readObject);
+});
+
+test('ResourceFactoryBase set readObject with non-namespaced object', () => {
+  const factory = new ResourceFactoryBase({ resource: 'resource1', kind: 'kind1' });
+  const readObject = (_kubeconfig: KubeConfigSingleContext, _name: string): Promise<V1Pod> => {
+    return Promise.resolve({} as V1Pod);
+  };
+  factory.setReadObject(readObject);
+  expect(factory.readObject).toEqual(readObject);
+});
+
+test('ResourceFactoryBase set restartObject with namespaced object', () => {
+  const factory = new ResourceFactoryBase({ resource: 'resource1', kind: 'kind1' });
+  const restartObject = (_kubeconfig: KubeConfigSingleContext, _name: string, _namespace: string): Promise<void> => {
+    return Promise.resolve();
+  };
+  factory.setRestartObject(restartObject);
+  expect(factory.restartObject).toEqual(restartObject);
+});
+
+test('ResourceFactoryBase set restartObject with non-namespaced object', () => {
+  const factory = new ResourceFactoryBase({ resource: 'resource1', kind: 'kind1' });
+  const restartObject = (_kubeconfig: KubeConfigSingleContext, _name: string): Promise<void> => {
+    return Promise.resolve();
+  };
+  factory.setRestartObject(restartObject);
+  expect(factory.restartObject).toEqual(restartObject);
+});

--- a/packages/webview/src/component/jobs/columns/Actions.svelte
+++ b/packages/webview/src/component/jobs/columns/Actions.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import RestartAction from '/@/component/objects/columns/RestartAction.svelte';
 import type { Props } from './props';
 
 let { object }: Props = $props();
 </script>
 
 <DeleteAction object={object} />
+<RestartAction object={object} />

--- a/packages/webview/src/component/objects/columns/RestartAction.svelte
+++ b/packages/webview/src/component/objects/columns/RestartAction.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+import { faRotate } from '@fortawesome/free-solid-svg-icons';
+
+import IconButton from '/@/component/button/IconButton.svelte';
+
+import type { ObjectProps } from './object-props';
+import { getContext } from 'svelte';
+import { Remote } from '/@/remote/remote';
+import { API_CONTEXTS } from '/@common/channels';
+import { type KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+let { object }: ObjectProps = $props();
+
+const remote = getContext<Remote>(Remote);
+const contextsApi = remote.getProxy(API_CONTEXTS);
+
+async function restartKubernetesObject(obj: KubernetesNamespacedObjectUI): Promise<void> {
+  await contextsApi.restartObject(obj.kind, obj.name, obj.namespace);
+}
+</script>
+
+<IconButton
+  enabled={object.status !== 'DELETING'}
+  title={`Restart ${object.kind}`}
+  onClick={(): Promise<void> => restartKubernetesObject(object as KubernetesNamespacedObjectUI)}
+  icon={faRotate} />

--- a/packages/webview/src/component/pods/columns/Actions.svelte
+++ b/packages/webview/src/component/pods/columns/Actions.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
 import type { Props } from './props';
+import RestartAction from '../../objects/columns/RestartAction.svelte';
 
 let { object }: Props = $props();
 </script>
 
 <DeleteAction object={object} />
+<RestartAction object={object} />

--- a/packages/webview/src/component/port-forward/KubePortsList.svelte
+++ b/packages/webview/src/component/port-forward/KubePortsList.svelte
@@ -27,10 +27,6 @@ onDestroy(() => {
   portForwardsUnsubscriber?.();
 });
 
-$effect(() => {
-  console.log('port forwards', portForwards.data?.portForwards);
-});
-
 let forwardConfigs: Map<number, ForwardConfig> = $derived(
   new Map(
     portForwards.data?.portForwards


### PR DESCRIPTION
Adds a button to restart a pod or a job in pods/jobs lists and in pods/jobs details

The implementation has been adapted to the extension architecture:
- waiting for object deletion leverages the informers instead of pulling the object regularly
- generic 'restartObject', with pod and job implementation (the pod implementation needing the job's one)

To restart a pod managed by something else than a Job, the pod is simply deleted (instead of scaling the controller to 0 and back to the initial scale), as the controller is expected to restart a pod which has been deleted, and scaling to 0 is not what is expected by the user when the replica is > 1 (all the pods at restarted in this case, instead of only the selected one)

Part of #179 