### PR TITLE
chore: specify configMap or secret on details page

### DIFF
--- a/packages/webview/src/component/configmaps-secrets/details/ConfigMapSpecDetails.spec.ts
+++ b/packages/webview/src/component/configmaps-secrets/details/ConfigMapSpecDetails.spec.ts
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { V1ConfigMap } from '@kubernetes/client-node';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import ConfigMapSpecDetails from './ConfigMapSpecDetails.svelte';
+
+const fakeConfigMap: V1ConfigMap = {
+  immutable: false,
+  binaryData: {
+    'bd1': 'some value',
+    'bd2': 'some data',
+  },
+  data: {
+    'key1': 'value1',
+    'key2': 'value2',
+  }
+};
+
+test('ConfigMap details renders with correct values', async () => {
+  render(ConfigMapSpecDetails, { object: fakeConfigMap });
+
+  expect(screen.getByText('Details')).toBeInTheDocument();
+  
+  expect(screen.getByText('Type')).toBeInTheDocument();
+  expect(screen.getByText('ConfigMap')).toBeInTheDocument();
+
+  expect(screen.getByText('Immutable')).toBeInTheDocument();
+  expect(screen.getByText('No')).toBeInTheDocument();
+
+  expect(screen.getByText('Binary Data')).toBeInTheDocument();
+
+  expect(screen.getByText('bd1: 10 bytes')).toBeInTheDocument();
+  expect(screen.getByText('bd2: 9 bytes')).toBeInTheDocument();
+
+  expect(screen.getByText('Data')).toBeInTheDocument();
+
+  expect(screen.getByText('key1')).toBeInTheDocument();
+  expect(screen.getByText('value1')).toBeInTheDocument();
+
+  expect(screen.getByText('key2')).toBeInTheDocument();
+  expect(screen.getByText('value2')).toBeInTheDocument();
+});

--- a/packages/webview/src/component/configmaps-secrets/details/ConfigMapSpecDetails.svelte
+++ b/packages/webview/src/component/configmaps-secrets/details/ConfigMapSpecDetails.svelte
@@ -14,6 +14,10 @@ let { object: object }: Props = $props();
   <Title>Details</Title>
 </tr>
 <tr>
+  <Cell>Type</Cell>
+  <Cell>ConfigMap</Cell>
+</tr>
+<tr>
   <Cell>Immutable</Cell>
   <Cell>{object.immutable ? 'Yes' : 'No'}</Cell>
 </tr>

--- a/packages/webview/src/component/configmaps-secrets/details/SecretSpecDetails.spec.ts
+++ b/packages/webview/src/component/configmaps-secrets/details/SecretSpecDetails.spec.ts
@@ -1,0 +1,54 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { V1Secret } from '@kubernetes/client-node';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import SecretSpecDetails from './SecretSpecDetails.svelte';
+
+const fakeSecret: V1Secret = {
+  immutable: true,
+  type: 'Opaque',
+  data: {
+    'key1': 'value1',
+    'key2': 'value2',
+  }
+};
+
+test('Secret details renders with correct values', async () => {
+  render(SecretSpecDetails, { object: fakeSecret });
+
+  expect(screen.getByText('Details')).toBeInTheDocument();
+  
+  expect(screen.getByText('Secret type')).toBeInTheDocument();
+  expect(screen.getByText('Opaque')).toBeInTheDocument();
+
+  expect(screen.getByText('Immutable')).toBeInTheDocument();
+  expect(screen.getByText('Yes')).toBeInTheDocument();
+
+  expect(screen.getByText('Data')).toBeInTheDocument();
+
+  expect(screen.getByText('key1')).toBeInTheDocument();
+  expect(screen.getByText('value1')).toBeInTheDocument();
+
+  expect(screen.getByText('key2')).toBeInTheDocument();
+  expect(screen.getByText('value2')).toBeInTheDocument();
+});

--- a/packages/webview/src/component/configmaps-secrets/details/SecretSpecDetails.svelte
+++ b/packages/webview/src/component/configmaps-secrets/details/SecretSpecDetails.svelte
@@ -14,7 +14,7 @@ let { object }: Props = $props();
   <Title>Details</Title>
 </tr>
 <tr>
-  <Cell>Type</Cell>
+  <Cell>Secret type</Cell>
   <Cell>{object.type}</Cell>
 </tr>
 <tr>


### PR DESCRIPTION
Adds a visual specification of a configMap or a secret in the details page
<img width="651" height="305" alt="Screenshot 2025-09-08 at 8 57 08 PM" src="https://github.com/user-attachments/assets/69729e70-7429-4674-ad2c-ac47e46b4e9b" />
<img width="648" height="396" alt="Screenshot 2025-09-08 at 8 56 50 PM" src="https://github.com/user-attachments/assets/e459d652-7594-4c3e-b72c-fab9b1d4ef82" />

Closes https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/177
