### PR TITLE
feat: open urls in pod details

### DIFF
--- a/packages/common/src/channels.ts
+++ b/packages/common/src/channels.ts
@@ -24,6 +24,7 @@ import type { ActiveResourcesCountInfo } from './model/active-resources-count-in
 import type { ContextsHealthsInfo } from './model/contexts-healths-info';
 import type { ContextsPermissionsInfo } from './model/contexts-permissions-info';
 import type { CurrentContextInfo } from './model/current-context-info';
+import type { EndpointsInfo } from './model/endpoints-info';
 import type { PortForwardsInfo } from './model/port-forward-info';
 import type { ResourceDetailsInfo } from './model/resource-details-info';
 import type { ResourceEventsInfo } from './model/resource-events-info';
@@ -48,3 +49,4 @@ export const CURRENT_CONTEXT = createRpcChannel<CurrentContextInfo>('CurrentCont
 export const RESOURCE_DETAILS = createRpcChannel<ResourceDetailsInfo>('ResourceDetailsInfo');
 export const RESOURCE_EVENTS = createRpcChannel<ResourceEventsInfo>('ResourceEvents');
 export const PORT_FORWARDS = createRpcChannel<PortForwardsInfo>('PortForwards');
+export const ENDPOINTS = createRpcChannel<EndpointsInfo>('Endpoints');

--- a/packages/common/src/model/endpoint.ts
+++ b/packages/common/src/model/endpoint.ts
@@ -16,9 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { PodUI } from '../PodUI';
+// Endpoint represents an a URL opened by an Ingress or a Route
+// and giving access to a target (Pod only for the moment)
+export interface Endpoint {
+  contextName: string;
+  targetKind: 'Pod';
+  targetName: string;
+  targetNamespace: string;
 
-export interface Props {
-  object: PodUI;
-  details?: boolean;
+  inputKind: 'Ingress' | 'Route';
+  inputName: string;
+  url: string;
 }

--- a/packages/common/src/model/endpoints-info.ts
+++ b/packages/common/src/model/endpoints-info.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { PodUI } from '../PodUI';
+import type { Endpoint } from './endpoint';
 
-export interface Props {
-  object: PodUI;
-  details?: boolean;
+export interface EndpointsInfo {
+  endpoints: Endpoint[];
 }

--- a/packages/common/src/model/endpoints-options.ts
+++ b/packages/common/src/model/endpoints-options.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { PodUI } from '../PodUI';
-
-export interface Props {
-  object: PodUI;
-  details?: boolean;
+export interface EndpointsOptions {
+  contextName: string;
+  targetKind: 'Pod';
+  targetName: string;
+  targetNamespace: string;
 }

--- a/packages/extension/src/dispatcher/_dispatcher-module.ts
+++ b/packages/extension/src/dispatcher/_dispatcher-module.ts
@@ -27,6 +27,7 @@ import { UpdateResourceDispatcher } from './update-resource-dispatcher';
 import { ResourceDetailsDispatcher } from './resource-details-dispatcher';
 import { ResourceEventsDispatcher } from './resource-events-dispatcher';
 import { PortForwardsDispatcher } from './port-forwards-dispatcher';
+import { EndpointsDispatcher } from './endpoints-dispatcher';
 
 const dispatchersModule = new ContainerModule(options => {
   options.bind<ActiveResourcesCountDispatcher>(ActiveResourcesCountDispatcher).toSelf().inSingletonScope();
@@ -55,6 +56,9 @@ const dispatchersModule = new ContainerModule(options => {
 
   options.bind<PortForwardsDispatcher>(PortForwardsDispatcher).toSelf().inSingletonScope();
   options.bind(DispatcherObject).toService(PortForwardsDispatcher);
+
+  options.bind<EndpointsDispatcher>(EndpointsDispatcher).toSelf().inSingletonScope();
+  options.bind(DispatcherObject).toService(EndpointsDispatcher);
 });
 
 export { dispatchersModule };

--- a/packages/extension/src/dispatcher/endpoints-dispatcher.ts
+++ b/packages/extension/src/dispatcher/endpoints-dispatcher.ts
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+import type { DispatcherObject } from './util/dispatcher-object';
+import { AbsDispatcherObjectImpl } from './util/dispatcher-object';
+import { ContextsManager } from '/@/manager/contexts-manager';
+import { ENDPOINTS } from '/@common/channels';
+import { RpcExtension } from '/@common/rpc/rpc';
+import { EndpointsOptions } from '/@common/model/endpoints-options';
+import { EndpointsInfo } from '/@common/model/endpoints-info';
+
+@injectable()
+export class EndpointsDispatcher
+  extends AbsDispatcherObjectImpl<EndpointsOptions[], EndpointsInfo>
+  implements DispatcherObject<EndpointsOptions[]>
+{
+  constructor(
+    @inject(RpcExtension) rpcExtension: RpcExtension,
+    @inject(ContextsManager) private manager: ContextsManager,
+  ) {
+    super(rpcExtension, ENDPOINTS);
+  }
+
+  getData(options: EndpointsOptions[]): EndpointsInfo {
+    return {
+      endpoints: options.flatMap(option =>
+        this.manager.getEndpoints(option.contextName, option.targetKind, option.targetName, option.targetNamespace),
+      ),
+    };
+  }
+}

--- a/packages/extension/src/manager/contexts-manager-endpoints.spec.ts
+++ b/packages/extension/src/manager/contexts-manager-endpoints.spec.ts
@@ -1,0 +1,243 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { EndpointSlicesResourceFactory } from '/@/resources/endpoint-slices-resource-factory';
+import { IngressesResourceFactory } from '/@/resources/ingresses-resource-factory';
+import type { ResourceFactory } from '/@/resources/resource-factory';
+import { RoutesResourceFactory } from '/@/resources/routes-resource-factory';
+import { ContextsManager } from './contexts-manager';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { V1EndpointSlice, V1Ingress } from '@kubernetes/client-node';
+import type { V1Route } from '/@common/model/openshift-types';
+import type { Endpoint } from '/@common/model/endpoint';
+
+class TestContextsManager extends ContextsManager {
+  override getResourceFactories(): ResourceFactory[] {
+    return [
+      new EndpointSlicesResourceFactory(this),
+      new IngressesResourceFactory(this),
+      new RoutesResourceFactory(this),
+    ];
+  }
+}
+
+describe('ContextsManager', () => {
+  let manager: TestContextsManager;
+
+  beforeEach(() => {
+    manager = new TestContextsManager();
+  });
+
+  test.each<{
+    name: string;
+    endpoints: V1EndpointSlice[];
+    ingresses: V1Ingress[];
+    routes: V1Route[];
+    expected: Endpoint[];
+  }>([
+    {
+      name: 'with no endpoints',
+      endpoints: [],
+      ingresses: [],
+      routes: [],
+      expected: [],
+    },
+    {
+      name: 'with one endpoint targeting the pod and no ingress/route',
+      endpoints: [
+        {
+          metadata: {
+            name: 'pod1-abcdef',
+            namespace: 'ns1',
+            ownerReferences: [
+              {
+                apiVersion: 'v1',
+                uid: '123',
+                controller: true,
+                kind: 'Service',
+                name: 'svc1',
+              },
+            ],
+          },
+          addressType: 'IPV4',
+          endpoints: [
+            {
+              addresses: ['10.0.0.1'],
+              targetRef: {
+                name: 'pod1',
+                namespace: 'ns1',
+                kind: 'Pod',
+              },
+            },
+          ],
+        },
+      ],
+      ingresses: [],
+      routes: [],
+      expected: [],
+    },
+    {
+      name: 'with one endpoint targeting the pod and an ingress trageting the service',
+      endpoints: [
+        {
+          metadata: {
+            name: 'pod1-abcdef',
+            namespace: 'ns1',
+            ownerReferences: [
+              {
+                apiVersion: 'v1',
+                uid: '123',
+                controller: true,
+                kind: 'Service',
+                name: 'svc1',
+              },
+            ],
+          },
+          addressType: 'IPV4',
+          endpoints: [
+            {
+              addresses: ['10.0.0.1'],
+              targetRef: {
+                name: 'pod1',
+                namespace: 'ns1',
+                kind: 'Pod',
+              },
+            },
+          ],
+        },
+      ],
+      ingresses: [
+        {
+          metadata: {
+            name: 'ingress1',
+            namespace: 'ns1',
+          },
+          spec: {
+            rules: [
+              {
+                host: 'example.com',
+                http: {
+                  paths: [
+                    {
+                      pathType: 'Prefix',
+                      path: '/subpath',
+                      backend: {
+                        service: {
+                          name: 'svc1',
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+      routes: [],
+      expected: [
+        {
+          contextName: 'ctx1',
+          targetKind: 'Pod',
+          targetName: 'pod1',
+          targetNamespace: 'ns1',
+          inputKind: 'Ingress',
+          inputName: 'ingress1',
+          url: 'http://example.com/subpath',
+        },
+      ],
+    },
+    {
+      name: 'with one endpoint targeting the pod and a route trageting the service',
+      endpoints: [
+        {
+          metadata: {
+            name: 'pod1-abcdef',
+            namespace: 'ns1',
+            ownerReferences: [
+              {
+                apiVersion: 'v1',
+                uid: '123',
+                controller: true,
+                kind: 'Service',
+                name: 'svc1',
+              },
+            ],
+          },
+          addressType: 'IPV4',
+          endpoints: [
+            {
+              addresses: ['10.0.0.1'],
+              targetRef: {
+                name: 'pod1',
+                namespace: 'ns1',
+                kind: 'Pod',
+              },
+            },
+          ],
+        },
+      ],
+      routes: [
+        {
+          metadata: {
+            name: 'route1',
+            namespace: 'ns1',
+          },
+          spec: {
+            tls: {
+              insecureEdgeTerminationPolicy: 'Allow',
+              termination: 'Edge',
+            },
+            to: {
+              kind: 'Service',
+              name: 'svc1',
+              weight: 100,
+            },
+            host: 'example.com',
+            wildcardPolicy: 'None',
+          },
+        },
+      ],
+      ingresses: [],
+      expected: [
+        {
+          contextName: 'ctx1',
+          targetKind: 'Pod',
+          targetName: 'pod1',
+          targetNamespace: 'ns1',
+          inputKind: 'Route',
+          inputName: 'route1',
+          url: 'https://example.com',
+        },
+      ],
+    },
+  ])('getEndpoints $name', ({ endpoints, ingresses, routes, expected }) => {
+    vi.spyOn(manager, 'searchByTargetRef').mockImplementation(kind => {
+      if (kind === 'EndpointSlice') {
+        return endpoints;
+      } else if (kind === 'Ingress') {
+        return ingresses;
+      } else if (kind === 'Route') {
+        return routes;
+      }
+      return [];
+    });
+    const result = manager.getEndpoints('ctx1', 'Pod', 'pod1', 'ns1');
+    expect(result).toEqual(expected);
+  });
+});

--- a/packages/extension/src/manager/contexts-states-dispatcher.spec.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.spec.ts
@@ -38,6 +38,7 @@ import {
   CONTEXTS_HEALTHS,
   CONTEXTS_PERMISSIONS,
   CURRENT_CONTEXT,
+  ENDPOINTS,
   RESOURCE_DETAILS,
   RESOURCE_EVENTS,
   RESOURCES_COUNT,
@@ -56,6 +57,7 @@ const contextsManagerMock: ContextsManager = {
   onResourceUpdated: vi.fn(),
   isContextOffline: vi.fn(),
   onCurrentContextChange: vi.fn(),
+  onEndpointsChange: vi.fn(),
 } as unknown as ContextsManager;
 const rpcExtension: RpcExtension = {
   fire: vi.fn(),
@@ -184,4 +186,17 @@ test('dispatchByChannelName is called when onSubscribe emits an event', async ()
   vi.spyOn(dispatcher, 'onSubscribe').mockImplementation(f => f('channel1') as IDisposable);
   dispatcher.init();
   expect(dispatchByChannelNameSpy).toHaveBeenCalledWith('channel1');
+});
+
+test('ContextsStatesDispatcher should dispatch ENDPOINTS when onEndpointsChange event is fired', async () => {
+  const dispatcherSpy = vi.spyOn(dispatcher, 'dispatch').mockResolvedValue();
+  dispatcher.init();
+  expect(dispatcherSpy).not.toHaveBeenCalled();
+
+  vi.mocked(contextsManagerMock.onEndpointsChange).mockImplementation(f => f() as IDisposable);
+  dispatcher.init();
+  await vi.waitFor(() => {
+    expect(dispatcherSpy).toHaveBeenCalledTimes(1);
+  });
+  expect(dispatcherSpy).toHaveBeenCalledWith(ENDPOINTS);
 });

--- a/packages/extension/src/manager/contexts-states-dispatcher.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.ts
@@ -28,6 +28,7 @@ import {
   CONTEXTS_HEALTHS,
   CONTEXTS_PERMISSIONS,
   CURRENT_CONTEXT,
+  ENDPOINTS,
   PORT_FORWARDS,
   RESOURCE_DETAILS,
   RESOURCE_EVENTS,
@@ -88,6 +89,9 @@ export class ContextsStatesDispatcher extends ChannelSubscriber implements Subsc
     });
     this.portForwardServiceProvider.onForwardsChange(async () => {
       await this.dispatch(PORT_FORWARDS);
+    });
+    this.manager.onEndpointsChange(async () => {
+      await this.dispatch(ENDPOINTS);
     });
     this.onSubscribe(channelName => this.dispatchByChannelName(channelName));
   }

--- a/packages/extension/src/resources/endpoint-slices-resource-factory.spec.ts
+++ b/packages/extension/src/resources/endpoint-slices-resource-factory.spec.ts
@@ -76,7 +76,7 @@ const endpointSlice3 = {
 test('searchEndpointSlicesByTargetRef returns the correct endpoint slices', async () => {
   vi.mocked(contextsManager.getResources).mockReturnValue([endpointSlice1, endpointSlice2, endpointSlice3]);
   const factory = new EndpointSlicesResourceFactory(contextsManager);
-  const endpointSlices = await factory.searchEndpointSlicesByTargetRef(kubeconfig, {
+  const endpointSlices = factory.searchEndpointSlicesByTargetRef(kubeconfig, {
     kind: 'Pod',
     name: 'pod1',
     namespace: 'ns1',

--- a/packages/extension/src/resources/endpoint-slices-resource-factory.ts
+++ b/packages/extension/src/resources/endpoint-slices-resource-factory.ts
@@ -72,10 +72,7 @@ export class EndpointSlicesResourceFactory extends ResourceFactoryBase implement
     });
   }
 
-  async searchEndpointSlicesByTargetRef(
-    kubeconfig: KubeConfigSingleContext,
-    targetRef: TargetRef,
-  ): Promise<V1EndpointSlice[]> {
+  searchEndpointSlicesByTargetRef(kubeconfig: KubeConfigSingleContext, targetRef: TargetRef): V1EndpointSlice[] {
     const list = this.contextsManager.getResources(this.resource, kubeconfig.getKubeConfig().currentContext);
     return list
       .filter(this.isV1EndpointSlice)

--- a/packages/extension/src/resources/ingresses-resource-factory.spec.ts
+++ b/packages/extension/src/resources/ingresses-resource-factory.spec.ts
@@ -108,7 +108,7 @@ const ingress3 = {
 test('searchIngressesByTargetRef returns the correct ingresses', async () => {
   vi.mocked(contextsManager.getResources).mockReturnValue([ingress1, ingress2, ingress3]);
   const factory = new IngressesResourceFactory(contextsManager);
-  const ingresses = await factory.searchIngressesByTargetRef(kubeconfig, {
+  const ingresses = factory.searchIngressesByTargetRef(kubeconfig, {
     kind: 'Service',
     name: 'svc1',
     namespace: 'ns1',
@@ -119,7 +119,7 @@ test('searchIngressesByTargetRef returns the correct ingresses', async () => {
 test('searchIngressesByTargetRef returns no ingress', async () => {
   vi.mocked(contextsManager.getResources).mockReturnValue([ingress2]);
   const factory = new IngressesResourceFactory(contextsManager);
-  const ingresses = await factory.searchIngressesByTargetRef(kubeconfig, {
+  const ingresses = factory.searchIngressesByTargetRef(kubeconfig, {
     kind: 'Service',
     name: 'svc1',
     namespace: 'ns1',

--- a/packages/extension/src/resources/ingresses-resource-factory.ts
+++ b/packages/extension/src/resources/ingresses-resource-factory.ts
@@ -72,7 +72,7 @@ export class IngressesResourceFactory extends ResourceFactoryBase implements Res
     return apiClient.deleteNamespacedIngress({ name, namespace });
   }
 
-  async searchIngressesByTargetRef(kubeconfig: KubeConfigSingleContext, targetRef: TargetRef): Promise<V1Ingress[]> {
+  searchIngressesByTargetRef(kubeconfig: KubeConfigSingleContext, targetRef: TargetRef): V1Ingress[] {
     // We only support targetting services, either by default backend or by rules
     // TODO handle other kinds of targets (through the spec.rules.http.paths.backend.resource)
     if (targetRef.kind !== 'Service') {

--- a/packages/extension/src/resources/resource-factory.ts
+++ b/packages/extension/src/resources/resource-factory.ts
@@ -71,7 +71,7 @@ type RestartNonNamespacedObject = (kubeconfig: KubeConfigSingleContext, name: st
 type SearchByTargetRefNamespacedObject = (
   kubeconfig: KubeConfigSingleContext,
   targetRef: TargetRef,
-) => Promise<KubernetesObject[]>;
+) => KubernetesObject[];
 
 export class ResourceFactoryBase {
   #resource: string;

--- a/packages/extension/src/resources/routes-resource-factory.spec.ts
+++ b/packages/extension/src/resources/routes-resource-factory.spec.ts
@@ -63,7 +63,7 @@ const route2 = {
 test('searchRoutesByTargetRef returns the correct routes', async () => {
   vi.mocked(contextsManager.getResources).mockReturnValue([route1, route2]);
   const factory = new RoutesResourceFactory(contextsManager);
-  const ingresses = await factory.searchRoutesByTargetRef(kubeconfig, {
+  const ingresses = factory.searchRoutesByTargetRef(kubeconfig, {
     kind: 'Service',
     name: 'svc1',
     namespace: 'ns1',

--- a/packages/extension/src/resources/routes-resource-factory.ts
+++ b/packages/extension/src/resources/routes-resource-factory.ts
@@ -86,7 +86,7 @@ export class RoutesResourceFactory extends ResourceFactoryBase implements Resour
     });
   }
 
-  async searchRoutesByTargetRef(kubeconfig: KubeConfigSingleContext, targetRef: TargetRef): Promise<V1Route[]> {
+  searchRoutesByTargetRef(kubeconfig: KubeConfigSingleContext, targetRef: TargetRef): V1Route[] {
     const list = this.contextsManager.getResources(this.resource, kubeconfig.getKubeConfig().currentContext);
     return list.filter(
       (item: V1Route) => item.spec?.to?.name === targetRef.name && item.spec?.to?.kind === targetRef.kind,

--- a/packages/webview/src/component/objects/KubernetesObjectDetails.svelte
+++ b/packages/webview/src/component/objects/KubernetesObjectDetails.svelte
@@ -28,7 +28,7 @@ interface Props<T extends KubernetesObject, U extends KubernetesObjectUI> {
   namespace?: string;
   transformer: (o: T) => U;
   SummaryComponent: Component<{ object: T; events: readonly EventUI[] }>;
-  ActionsComponent?: Component<{ object: U }>;
+  ActionsComponent?: Component<{ object: U; details?: boolean }>;
 }
 let {
   kind,
@@ -153,7 +153,7 @@ function navigateToList(): void {
       {#if object}<StatusIcon icon={icon[kind] ?? KubernetesIcon} size={24} status={objectUI.status} />{/if}
     {/snippet}
     {#snippet actionsSnippet()}
-      {#if ActionsComponent && objectUI}<ActionsComponent object={objectUI} />{/if}
+      {#if ActionsComponent && objectUI}<ActionsComponent details={true} object={objectUI} />{/if}
     {/snippet}
     {#snippet detailSnippet()}
       {#if objectUI}

--- a/packages/webview/src/component/pods/columns/Actions.svelte
+++ b/packages/webview/src/component/pods/columns/Actions.svelte
@@ -2,9 +2,14 @@
 import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
 import type { Props } from './props';
 import RestartAction from '../../objects/columns/RestartAction.svelte';
+import OpenLinks from './OpenLinks.svelte';
 
-let { object }: Props = $props();
+let { object, details = false }: Props = $props();
 </script>
 
 <DeleteAction object={object} />
 <RestartAction object={object} />
+
+{#if details}
+  <OpenLinks object={object} />
+{/if}

--- a/packages/webview/src/component/pods/columns/OpenLinks.spec.ts
+++ b/packages/webview/src/component/pods/columns/OpenLinks.spec.ts
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { FakeStateObject } from '/@/state/util/fake-state-object.svelte';
+import { StatesMocks } from '/@/tests/context-mocks';
+import type { CurrentContextInfo } from '/@common/model/current-context-info';
+import type { EndpointsInfo } from '/@common/model/endpoints-info';
+import type { EndpointsOptions } from '/@common/model/endpoints-options';
+import * as svelte from 'svelte';
+import OpenLinks from './OpenLinks.svelte';
+import { render } from '@testing-library/svelte';
+import { RemoteMocks } from '/@/tests/remote-mocks';
+import { API_SYSTEM } from '/@common/channels';
+import type { SystemApi } from '/@common/interface/system-api';
+import IconButton from '/@/component/button/IconButton.svelte';
+
+vi.mock(import('/@/component/button/IconButton.svelte'), () => ({
+  default: vi.fn(),
+}));
+
+const statesMocks = new StatesMocks();
+const remoteMocks = new RemoteMocks();
+
+let endpointsMock: FakeStateObject<EndpointsInfo, EndpointsOptions>;
+let currentContextMock: FakeStateObject<CurrentContextInfo, void>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  endpointsMock = new FakeStateObject();
+  currentContextMock = new FakeStateObject();
+
+  vi.spyOn(svelte, 'getContext').mockImplementation(() => {});
+
+  statesMocks.reset();
+  statesMocks.mock<EndpointsInfo, EndpointsOptions>('stateEndpointsInfoUI', endpointsMock);
+  statesMocks.mock<CurrentContextInfo, void>('stateCurrentContextInfoUI', currentContextMock);
+
+  remoteMocks.reset();
+  remoteMocks.mock(API_SYSTEM, {
+    openExternal: vi.fn(),
+  } as unknown as SystemApi);
+});
+
+test('test', () => {
+  currentContextMock.setData({
+    contextName: 'ctx1',
+  });
+  endpointsMock.setData({
+    endpoints: [
+      {
+        contextName: 'ctx1',
+        targetKind: 'Pod',
+        targetName: 'pod1',
+        targetNamespace: 'ns1',
+        inputName: 'ingress1',
+        inputKind: 'Ingress',
+        url: 'http://example.com/path/to/pod1',
+      },
+    ],
+  });
+  render(OpenLinks, { object: { name: 'pod1', namespace: 'ns1', containers: [], kind: 'Pod', status: 'Running' } });
+  expect(IconButton).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      title: 'Open ingress1',
+    }),
+  );
+  const call = vi.mocked(IconButton).mock.calls[0][1];
+  call.onClick!();
+  expect(remoteMocks.get(API_SYSTEM).openExternal).toHaveBeenCalledWith('http://example.com/path/to/pod1');
+});

--- a/packages/webview/src/component/pods/columns/OpenLinks.svelte
+++ b/packages/webview/src/component/pods/columns/OpenLinks.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+import type { Props } from './props';
+import { States } from '/@/state/states';
+import { getContext, onDestroy, onMount } from 'svelte';
+import type { Unsubscriber } from 'svelte/store';
+import IconButton from '/@/component/button/IconButton.svelte';
+import { faExternalLinkSquareAlt } from '@fortawesome/free-solid-svg-icons';
+import type { Endpoint } from '/@common/model/endpoint';
+import { Remote } from '/@/remote/remote';
+import { API_SYSTEM } from '/@common/channels';
+
+let { object }: Props = $props();
+
+let initialCurrentContextName: string | undefined = $state(undefined);
+
+let unsubscribers: Unsubscriber[] = [];
+const states = getContext<States>(States);
+const endpoints = states.stateEndpointsInfoUI;
+const currentContext = states.stateCurrentContextInfoUI;
+
+const remote = getContext<Remote>(Remote);
+const systemApi = remote.getProxy(API_SYSTEM);
+
+onMount(() => {
+  initialCurrentContextName = currentContext.data?.contextName;
+  if (!initialCurrentContextName) {
+    return;
+  }
+  unsubscribers.push(currentContext.subscribe());
+  unsubscribers.push(
+    endpoints.subscribe({
+      contextName: initialCurrentContextName,
+      targetKind: 'Pod',
+      targetName: object.name,
+      targetNamespace: object.namespace,
+    }),
+  );
+});
+
+onDestroy(() => {
+  unsubscribers.forEach(unsubscriber => unsubscriber());
+});
+
+function filterEndpoints(endpoints: Endpoint[]): Endpoint[] {
+  return endpoints.filter(
+    endpoint =>
+      endpoint.targetName === object.name &&
+      endpoint.targetNamespace === object.namespace &&
+      endpoint.targetKind === 'Pod',
+  );
+}
+
+async function openEndpoint(endpoint: Endpoint): Promise<void> {
+  await systemApi.openExternal(endpoint.url);
+}
+</script>
+
+{#if endpoints.data?.endpoints}
+  {#each filterEndpoints(endpoints.data?.endpoints) as endpoint, index (index)}
+    <IconButton
+      title={`Open ${endpoint.inputName}`}
+      onClick={(): Promise<void> => openEndpoint(endpoint)}
+      icon={faExternalLinkSquareAlt} />
+  {/each}
+{/if}

--- a/packages/webview/src/state/endpoints.svelte.ts
+++ b/packages/webview/src/state/endpoints.svelte.ts
@@ -16,9 +16,26 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { PodUI } from '../PodUI';
+import { inject, injectable } from 'inversify';
 
-export interface Props {
-  object: PodUI;
-  details?: boolean;
+import { ENDPOINTS } from '/@common/channels';
+import { RpcBrowser } from '/@common/rpc/rpc';
+
+import { AbsStateObjectImpl, type StateObject } from './util/state-object.svelte';
+import type { EndpointsInfo } from '/@common/model/endpoints-info';
+import type { EndpointsOptions } from '/@common/model/endpoints-options';
+
+// Define a state for the EndpointsInfo
+@injectable()
+export class StateEndpointsInfo
+  extends AbsStateObjectImpl<EndpointsInfo, EndpointsOptions>
+  implements StateObject<EndpointsInfo, EndpointsOptions>
+{
+  constructor(@inject(RpcBrowser) rpcBrowser: RpcBrowser) {
+    super(rpcBrowser);
+  }
+
+  async init(): Promise<void> {
+    await this.initChannel(ENDPOINTS);
+  }
 }

--- a/packages/webview/src/state/state-module.ts
+++ b/packages/webview/src/state/state-module.ts
@@ -30,6 +30,7 @@ import { StateContextsHealthsInfo } from './contexts-healths.svelte';
 import { StateResourceDetailsInfo } from './resource-details.svelte';
 import { StateResourceEventsInfo } from './resource-events.svelte';
 import { StatePortForwardsInfo } from './port-forwards.svelte';
+import { StateEndpointsInfo } from './endpoints.svelte';
 
 const statesModule = new ContainerModule(options => {
   options.bind(States).toSelf().inSingletonScope();
@@ -69,6 +70,10 @@ const statesModule = new ContainerModule(options => {
   options.bind(StatePortForwardsInfo).toSelf().inSingletonScope();
   options.bind(StateObject).toService(StatePortForwardsInfo);
   options.bind(IDisposable).toService(StatePortForwardsInfo);
+
+  options.bind(StateEndpointsInfo).toSelf().inSingletonScope();
+  options.bind(StateObject).toService(StateEndpointsInfo);
+  options.bind(IDisposable).toService(StateEndpointsInfo);
 });
 
 export { statesModule };

--- a/packages/webview/src/state/states.ts
+++ b/packages/webview/src/state/states.ts
@@ -26,6 +26,7 @@ import { StateContextsHealthsInfo } from './contexts-healths.svelte';
 import { StateResourceDetailsInfo } from './resource-details.svelte';
 import { StateResourceEventsInfo } from './resource-events.svelte';
 import { StatePortForwardsInfo } from './port-forwards.svelte';
+import { StateEndpointsInfo } from './endpoints.svelte';
 
 @injectable()
 export class States {
@@ -90,5 +91,12 @@ export class States {
 
   get statePortForwardsInfoUI(): StatePortForwardsInfo {
     return this._statePortForwardsInfoUI;
+  }
+
+  @inject(StateEndpointsInfo)
+  private _stateEndpointsInfoUI: StateEndpointsInfo;
+
+  get stateEndpointsInfoUI(): StateEndpointsInfo {
+    return this._stateEndpointsInfoUI;
   }
 }


### PR DESCRIPTION
Fixes #179

With an ingress:

```
apiVersion: v1
kind: Service
metadata:
  name: pod1
spec:
  ports:
  - port: 80
    protocol: TCP
    targetPort: 80
  selector:
    run: pod1
status:
  loadBalancer: {}
---
apiVersion: v1
kind: Pod
metadata:
  labels:
    run: pod1
  name: pod1
spec:
  containers:
  - image: httpd
    name: pod1
    ports:
    - containerPort: 80
---
kind: Ingress
apiVersion: networking.k8s.io/v1
metadata:
  name: ingress2
spec:
  rules:
    - host: example.com
      http:
        paths:
          - backend:
              service:
                name: pod1
                port:
                  number: 80
            path: /
            pathType: Prefix
```

With a route: deploy an app on OpenShift Developer Sandbox
