### PR TITLE
fix: monaco auto layout

### DIFF
--- a/packages/webview/src/App.svelte
+++ b/packages/webview/src/App.svelte
@@ -36,7 +36,7 @@ let isMounted = false;
     <div class="flex flex-row w-full h-full overflow-hidden">
       <Navigation meta={meta} />
 
-      <div class="flex flex-col w-full h-full">
+      <div class="flex flex-col w-full h-full overflow-hidden">
         <Route path="/">
           <Dashboard />
         </Route>


### PR DESCRIPTION
Monaco has an automaticLayout functionality, but it needs a parent `div` with `overflow-hidden` .

Before:

https://github.com/user-attachments/assets/430f497b-d638-47ed-a34d-9a3f675789bf

After:

https://github.com/user-attachments/assets/b1d93dea-96f8-419b-9565-a75ff24cb55e

