### PR TITLE
feat: added cronstrue to have readable schedules

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@vitest/eslint-plugin": "^1.3.14",
     "autoprefixer": "^10.4.21",
     "concurrently": "^9.1.2",
+    "cronstrue": "^3.3.0",
     "eslint": "^9.35.0",
     "eslint-import-resolver-custom-alias": "^1.3.2",
     "eslint-import-resolver-typescript": "^4.3.4",

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -16,6 +16,7 @@
     "watch": "vite --mode development build -w"
   },
   "dependencies": {
+    "cronstrue": "^3.3.0",
     "inversify": "^7.9.1",
     "moment": "^2.30.1",
     "svelte-preprocess": "^6.0.3",

--- a/packages/webview/src/component/cronjobs/CronJobsList.svelte
+++ b/packages/webview/src/component/cronjobs/CronJobsList.svelte
@@ -8,6 +8,7 @@ import { getContext } from 'svelte';
 import { DependencyAccessor } from '/@/inject/dependency-accessor';
 import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
 import ActionsColumn from '/@/component/cronjobs/columns/Actions.svelte';
+import ScheduleColumn from '/@/component/cronjobs/columns/Schedule.svelte';
 import { CronJobHelper } from './cronjob-helper';
 import type { CronJobUI } from './CronJobUI';
 import CronJobIcon from '../icons/CronJobIcon.svelte';
@@ -38,7 +39,7 @@ let ageColumn = new TableColumn<CronJobUI, Date | undefined>('Age', {
 
 let scheduleColumn = new TableColumn<CronJobUI, string>('Schedule', {
   renderMapping: (cronjob): string => cronjob.schedule,
-  renderer: TableSimpleColumn,
+  renderer: ScheduleColumn,
   comparator: (a, b): number => a.schedule.localeCompare(b.schedule),
 });
 

--- a/packages/webview/src/component/cronjobs/columns/Schedule.svelte
+++ b/packages/webview/src/component/cronjobs/columns/Schedule.svelte
@@ -11,6 +11,8 @@ function getScheduleReadableText(schedule: string): string {
   try {
     return cronstrue.toString(schedule);
   } catch (error) {
+    // If cronstrue cannot parse the schedule, return the original cron expression
+    console.warn(`Failed to parse cron expression: ${schedule}`, error);
     return schedule;
   }
 }

--- a/packages/webview/src/component/cronjobs/columns/Schedule.svelte
+++ b/packages/webview/src/component/cronjobs/columns/Schedule.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+import cronstrue from 'cronstrue';
+
+interface Props {
+  object: string;
+}
+
+let { object }: Props = $props();
+
+function getScheduleReadableText(schedule: string): string {
+  try {
+    return cronstrue.toString(schedule);
+  } catch (error) {
+    return schedule;
+  }
+}
+</script>
+
+<div class="text-[var(--pd-table-body-text)] max-w-full text-wrap line-clamp-2">
+  <span>{getScheduleReadableText(object)}</span>
+</div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
 
   packages/webview:
     dependencies:
+      cronstrue:
+        specifier: ^3.3.0
+        version: 3.3.0
       inversify:
         specifier: ^7.9.1
         version: 7.10.2(reflect-metadata@0.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       concurrently:
         specifier: ^9.1.2
         version: 9.2.1
+      cronstrue:
+        specifier: ^3.3.0
+        version: 3.3.0
       eslint:
         specifier: ^9.35.0
         version: 9.36.0(jiti@2.6.1)
@@ -1675,6 +1678,10 @@ packages:
 
   core-js-compat@3.45.1:
     resolution: {integrity: sha512-tqTt5T4PzsMIZ430XGviK4vzYSoeNJ6CXODi6c/voxOT6IZqBht5/EKaSNnYiEjjRYxjVz7DQIsOsY0XNi8PIA==}
+
+  cronstrue@3.3.0:
+    resolution: {integrity: sha512-iwJytzJph1hosXC09zY8F5ACDJKerr0h3/2mOxg9+5uuFObYlgK0m35uUPk4GCvhHc2abK7NfnR9oMqY0qZFAg==}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -5139,6 +5146,8 @@ snapshots:
   core-js-compat@3.45.1:
     dependencies:
       browserslist: 4.25.4
+
+  cronstrue@3.3.0: {}
 
   cross-spawn@7.0.6:
     dependencies:


### PR DESCRIPTION
In order to have readable schedules for cronjobs, this PR adds cronstrue dependency.

Before having cronstrue:

<img width="1509" height="936" alt="Captura de pantalla 2025-10-06 a las 12 14 16" src="https://github.com/user-attachments/assets/38a010c3-741a-4b27-a7f2-fef3a57c09e2" />

After adding construe:

<img width="1510" height="949" alt="Captura de pantalla 2025-10-06 a las 12 11 58" src="https://github.com/user-attachments/assets/f65260b6-fc3f-4a30-9602-dc71a5163cc6" />

Closes #169 

##Testing##
1- Create a kubernetes cluster
2- Apply a cronjob
3- Check in the cronjob section, in the schedule column, the text should be readable.
