### PR TITLE
fix: add spacing between event columns

### DIFF
--- a/packages/webview/src/component/objects/details/EventsTable.svelte
+++ b/packages/webview/src/component/objects/details/EventsTable.svelte
@@ -24,19 +24,22 @@ function getAgeAndCount(event: EventUI): string {
 
 <tr>
   <td colspan="2">
-    <table class="w-full ml-2.5" aria-label="events">
+    <table class="w-full ml-2.5 border-separate border-spacing-x-3 border-spacing-y-1" aria-label="events">
       <tbody>
         <tr>
-          <th align="left">Type</th><th align="left">Reason</th><th align="left">Age</th><th align="left">From</th><th
-            align="left">Message</th>
+          <th scope="col" class="px-2 py-1 text-left">Type</th>
+          <th scope="col" class="px-2 py-1 text-left">Reason</th>
+          <th scope="col" class="px-2 py-1 text-left">Age</th>
+          <th scope="col" class="px-2 py-1 text-left">From</th>
+          <th scope="col" class="px-2 py-1 text-left">Message</th>
         </tr>
         {#each sortedEvents as event, index (index)}
           <tr>
-            <td>{event.type}</td>
-            <td>{event.reason}</td>
-            <td>{getAgeAndCount(event)}</td>
-            <td>{event.reportingComponent}</td>
-            <td>{event.message}</td>
+            <td class="px-2 py-1 align-top">{event.type}</td>
+            <td class="px-2 py-1 align-top">{event.reason}</td>
+            <td class="px-2 py-1 align-top">{getAgeAndCount(event)}</td>
+            <td class="px-2 py-1 align-top">{event.reportingComponent}</td>
+            <td class="px-2 py-1 align-top">{event.message}</td>
           </tr>
         {/each}
       </tbody>


### PR DESCRIPTION
## Summary
- space out the events table so each column has readable padding
- add column scopes for accessibility and keep existing aria label

Fixes #210.

## Testing
- `pnpm run test:webview`