### PR TITLE
chore: eslint vitest plugin

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,6 +74,7 @@ export default [
     plugins: {
       // compliant v9 plug-ins
       unicorn,
+      vitest,
       // non-compliant v9 plug-ins
       etc: fixupPluginRules(etc),
       import: fixupPluginRules(importPlugin),
@@ -166,14 +167,14 @@ export default [
       'import/newline-after-import': 'error',
       'redundant-undefined/redundant-undefined': 'error',
       'import/no-extraneous-dependencies': 'error',
-      'vitest/consistent-test-filename': 'off',
-      'vitest/no-hooks': 'off',
-      'vitest/require-top-level-describe': 'off',
       'import/no-unresolved': 'off',
       'sonarjs/no-nested-functions': 'off',
       'import/default': 'off',
       'import/no-named-as-default-member': 'off',
-      'import/no-named-as-default': 'off'
+      'import/no-named-as-default': 'off',
+      ...vitest.configs.recommended.rules,
+      'vitest/prefer-called-exactly-once-with': 'off',
+      'vitest/valid-title': 'off',
     },
   },
 

--- a/packages/extension/src/dashboard-extension.spec.ts
+++ b/packages/extension/src/dashboard-extension.spec.ts
@@ -94,7 +94,8 @@ describe('a kubeconfig file is not present', () => {
 
   test('should deactivate correctly', async () => {
     await dashboardExtension.activate();
-    await dashboardExtension.deactivate();
+    const p = await dashboardExtension.deactivate();
+    expect(p).toBeUndefined();
   });
 });
 
@@ -121,6 +122,7 @@ describe('a kubeconfig file is present', () => {
 
   test('should deactivate correctly', async () => {
     await dashboardExtension.activate();
-    await dashboardExtension.deactivate();
+    const p = await dashboardExtension.deactivate();
+    expect(p).toBeUndefined();
   });
 });

--- a/packages/extension/src/pod-terminal/exec-transmitter.spec.ts
+++ b/packages/extension/src/pod-terminal/exec-transmitter.spec.ts
@@ -27,7 +27,7 @@ import {
   StringLineReader,
 } from './exec-transmitter.js';
 
-test('Test should verify string line reader', () => {
+test('should verify string line reader', () => {
   const reader = new StringLineReader();
 
   reader.on('data', chunk => {
@@ -37,7 +37,7 @@ test('Test should verify string line reader', () => {
   reader.push('foo');
 });
 
-test('Test should verify buffered stream writer', () => {
+test('should verify buffered stream writer', () => {
   const writer = new BufferedStreamWriter((data: Buffer) => {
     expect(data.toString()).toEqual('foo');
   });
@@ -45,7 +45,7 @@ test('Test should verify buffered stream writer', () => {
   writer.write(Buffer.from('foo'));
 });
 
-test('Test should verify resizable terminal writer', () => {
+test('should verify resizable terminal writer', () => {
   const writer = new ResizableTerminalWriter(
     new BufferedStreamWriter((data: Buffer) => {
       expect(data.toString()).toEqual('foo');

--- a/packages/webview/src/component/connection/CurrentContextConnectionBadge.spec.ts
+++ b/packages/webview/src/component/connection/CurrentContextConnectionBadge.spec.ts
@@ -146,7 +146,7 @@ describe('current context is not reachable', () => {
   test('tooltip', async () => {
     render(CurrentContextConnectionBadge);
 
-    screen.getByLabelText('tooltip');
+    expect(screen.getByLabelText('tooltip')).toBeDefined();
   });
 });
 

--- a/packages/webview/src/component/pods/PodTerminalBrowser.spec.ts
+++ b/packages/webview/src/component/pods/PodTerminalBrowser.spec.ts
@@ -55,7 +55,7 @@ const fakePodNoContainerRunning: V1Pod = {
 
 test('renders with no container running', () => {
   render(PodTerminalBrowser, { object: fakePodNoContainerRunning });
-  screen.getByText('No container running');
+  expect(screen.getByText('No container running')).toBeDefined();
 });
 
 test('renders with 2 containers running', async () => {

--- a/packages/webview/src/component/pods/columns/OpenLinks.spec.ts
+++ b/packages/webview/src/component/pods/columns/OpenLinks.spec.ts
@@ -58,7 +58,7 @@ beforeEach(() => {
   } as unknown as SystemApi);
 });
 
-test('test', () => {
+test('OpenLinks component', () => {
   currentContextMock.setData({
     contextName: 'ctx1',
   });

--- a/packages/webview/src/component/pods/dots/Dots.spec.ts
+++ b/packages/webview/src/component/pods/dots/Dots.spec.ts
@@ -83,7 +83,7 @@ beforeEach(() => {
   dependencyMocks.mock(KubernetesObjectUIHelper);
 });
 
-test('test getStatusColor returns the correct colors', () => {
+test('getStatusColor returns the correct colors', () => {
   expect(getStatusColor('running')).toBe('bg-[var(--pd-status-running)]');
   expect(getStatusColor('terminated')).toBe('bg-[var(--pd-status-terminated)]');
   expect(getStatusColor('waiting')).toBe('bg-[var(--pd-status-waiting)]');
@@ -96,7 +96,7 @@ test('test getStatusColor returns the correct colors', () => {
   expect(getStatusColor('unknown')).toBe('bg-[var(--pd-status-unknown)]');
 });
 
-test('test organizeContainers returns a record of containers organized by status', () => {
+test('organizeContainers returns a record of containers organized by status', () => {
   const organizedContainers = organizeContainers(mockContainers);
   expect(organizedContainers.running.length).toBe(1);
   expect(organizedContainers.terminated.length).toBe(1);

--- a/packages/webview/src/component/port-forward/KubePort.spec.ts
+++ b/packages/webview/src/component/port-forward/KubePort.spec.ts
@@ -74,7 +74,7 @@ describe('port forwarding', () => {
     expect(port80).toBeDefined();
   });
 
-  test('forward button should call ', async () => {
+  test('forward button should call', async () => {
     vi.mocked(remoteMocks.get(API_SYSTEM).getFreePort).mockResolvedValue(55_001);
 
     const { getByTitle } = render(KubePort, {

--- a/packages/webview/src/navigation/navigator.spec.ts
+++ b/packages/webview/src/navigation/navigator.spec.ts
@@ -47,109 +47,109 @@ beforeEach(() => {
   navigator = container.get<Navigator>(Navigator);
 });
 
-test(`Test navigation to Nodes`, () => {
+test(`navigation to Nodes`, () => {
   navigator.navigateTo({ kind: 'Node' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/nodes');
 });
 
-test(`Test navigation to a Node`, () => {
+test(`navigation to a specific Node`, () => {
   navigator.navigateTo({ kind: 'Node', name: 'dummy-name' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/nodes/dummy-name/summary');
 });
 
-test(`Test navigation to Services`, () => {
+test(`navigation to Services`, () => {
   navigator.navigateTo({ kind: 'Service' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/services');
 });
 
-test(`Test navigation to a Service`, () => {
+test(`navigation to a specific Service`, () => {
   navigator.navigateTo({ kind: 'Service', name: 'dummy-name', namespace: 'dummy-ns' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/services/dummy-name/dummy-ns/summary');
 });
 
-test(`Test navigation to Deployments`, () => {
+test(`navigation to Deployments`, () => {
   navigator.navigateTo({ kind: 'Deployment' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/deployments');
 });
 
-test(`Test navigation to a Deployment`, () => {
+test(`navigation to a specific Deployment`, () => {
   navigator.navigateTo({ kind: 'Deployment', name: 'dummy-name', namespace: 'dummy-ns' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/deployments/dummy-name/dummy-ns/summary');
 });
 
-test(`Test navigation to Pods`, () => {
+test(`navigation to Pods`, () => {
   navigator.navigateTo({ kind: 'Pod' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/pods');
 });
 
-test(`Test navigation to a Pod`, () => {
+test(`navigation to a specific Pod`, () => {
   navigator.navigateTo({ kind: 'Pod', name: 'dummy-name', namespace: 'dummy-ns' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/pods/dummy-name/dummy-ns/summary');
 });
 
-test(`Test navigation to PersistentVolumeClaims`, () => {
+test(`navigation to PersistentVolumeClaims`, () => {
   navigator.navigateTo({ kind: 'PersistentVolumeClaim' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/persistentvolumeclaims');
 });
 
-test(`Test navigation to a PersistentVolumeClaim`, () => {
+test(`navigation to a specific PersistentVolumeClaim`, () => {
   navigator.navigateTo({ kind: 'PersistentVolumeClaim', name: 'dummy-name', namespace: 'dummy-ns' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/persistentvolumeclaims/dummy-name/dummy-ns/summary');
 });
 
-test(`Test navigation to Ingresses`, () => {
+test(`navigation to Ingresses`, () => {
   navigator.navigateTo({ kind: 'Ingress' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/ingressesRoutes');
 });
 
-test(`Test navigation to a Ingress`, () => {
+test(`navigation to a specific Ingress`, () => {
   navigator.navigateTo({ kind: 'Ingress', name: 'dummy-name', namespace: 'dummy-ns' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/ingressesRoutes/ingress/dummy-name/dummy-ns/summary');
 });
 
-test(`Test navigation to Routes`, () => {
+test(`navigation to Routes`, () => {
   navigator.navigateTo({ kind: 'Route' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/ingressesRoutes');
 });
 
-test(`Test navigation to a Route`, () => {
+test(`navigation to a specific Route`, () => {
   navigator.navigateTo({ kind: 'Route', name: 'dummy-name', namespace: 'dummy-ns' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/ingressesRoutes/route/dummy-name/dummy-ns/summary');
 });
 
-test(`Test navigation to ConfigMaps`, () => {
+test(`navigation to ConfigMaps`, () => {
   navigator.navigateTo({ kind: 'ConfigMap' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/configmapsSecrets');
 });
 
-test(`Test navigation to a ConfigMap`, () => {
+test(`navigation to a specific ConfigMap`, () => {
   navigator.navigateTo({ kind: 'ConfigMap', name: 'dummy-name', namespace: 'dummy-ns' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/configmapsSecrets/configmap/dummy-name/dummy-ns/summary');
 });
 
-test(`Test navigation to Secrets`, () => {
+test(`navigation to Secrets`, () => {
   navigator.navigateTo({ kind: 'Secret' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/configmapsSecrets');
 });
 
-test(`Test navigation to a Secret`, () => {
+test(`navigation to a specific Secret`, () => {
   navigator.navigateTo({ kind: 'Secret', name: 'dummy-name', namespace: 'dummy-ns' });
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/configmapsSecrets/secret/dummy-name/dummy-ns/summary');


### PR DESCRIPTION
Activate the vitest eslint plugin, with recommended rules (expect `prefer-called-exactly-once-with` and `valid-title`)