### PR TITLE
feat: icon image component

### DIFF
--- a/packages/webview/src/component/icons/IconImage.spec.ts
+++ b/packages/webview/src/component/icons/IconImage.spec.ts
@@ -1,0 +1,56 @@
+/**********************************************************************
+ * Copyright (C) 2023-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import IconImage from './IconImage.svelte';
+
+test('Expect valid source and alt text with dark mode', async () => {
+  const image = render(IconImage, { image: { light: 'light.png', dark: 'dark.png' }, alt: 'this is alt text' });
+
+  const imageElement = image.getByRole('img');
+
+  expect(imageElement).toHaveAttribute('src', 'dark.png');
+  expect(imageElement).toHaveAttribute('alt', 'this is alt text');
+
+  await image.rerender({ image: { light: 'light2.png', dark: 'dark2.png' }, alt: 'this is another alt text' });
+  expect(imageElement).toHaveAttribute('src', 'dark2.png');
+});
+
+test('Expect no alt attribute if missing and default image', async () => {
+  const image = render(IconImage, { image: 'image.png' });
+
+  const imageElement = image.getByRole('img');
+  expect(imageElement).toHaveAttribute('src', 'image.png');
+  expect(imageElement).not.toHaveAttribute('alt');
+});
+
+test('Expect string as image', async () => {
+  const image = render(IconImage, { image: 'image1', alt: 'this is alt text' });
+
+  const imageElement = image.getByRole('img');
+
+  expect(imageElement).toHaveAttribute('src', 'image1');
+  expect(imageElement).toHaveAttribute('alt', 'this is alt text');
+
+  await image.rerender({ image: 'image2', alt: 'this is another alt text' });
+  expect(imageElement).toHaveAttribute('src', 'image2');
+});

--- a/packages/webview/src/component/icons/IconImage.svelte
+++ b/packages/webview/src/component/icons/IconImage.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+import type { Snippet } from 'svelte';
+
+type Image = string | { light: string; dark: string };
+
+interface Props {
+  image?: Image;
+  alt?: string;
+  class?: string;
+  children?: Snippet;
+}
+let { image, alt, class: className, children }: Props = $props();
+
+let imgSrc = $state<string>();
+
+$effect(() => {
+  image;
+  getImgSrc(image);
+});
+
+function getImage(icon?: Image): string | undefined {
+  if (!icon) {
+    return undefined;
+  }
+
+  if (typeof icon === 'string') {
+    return icon;
+  }
+
+  // TODO: add light/dark mode support (https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/369)
+  if (/*isDarkTheme &&*/ icon.dark) {
+    return icon.dark;
+  } else if (/*!isDarkTheme &&*/ icon.light) {
+    return icon.light;
+  }
+  return undefined;
+}
+
+function getImgSrc(image: string | { light: string; dark: string } | undefined): void {
+  imgSrc = getImage(image);
+}
+</script>
+
+{#if imgSrc}
+  <img src={imgSrc} alt={alt} class={className} />
+{:else}
+  {@render children?.()}
+{/if}


### PR DESCRIPTION
Needed for #315 

limitation: Displaying Light icon for providers is not supported, only the all-themes icon, or the dark icon will be displayed. In light mode, the dark icon would be used. Note that there is currently no impact in the UI, as all providers return an all-themes icon, which is correctly displayed (https://github.com/podman-desktop/extension-kubernetes-dashboard/pull/368)