### PR TITLE
fix: set kind during the list operation

### DIFF
--- a/packages/extension/src/manager/contexts-manager.spec.ts
+++ b/packages/extension/src/manager/contexts-manager.spec.ts
@@ -874,8 +874,8 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
         list: listMock,
         get: getMock,
       } as ObjectCache<KubernetesObject>);
-      listMock.mockReturnValue([{ metadata: { name: 'obj1', namespace: 'ns1' } }]);
-      getMock.mockReturnValue({ metadata: { name: 'obj1', namespace: 'ns1' } });
+      listMock.mockReturnValue([{ kind: 'Resource1', metadata: { name: 'obj1', namespace: 'ns1' } }]);
+      getMock.mockReturnValue({ kind: 'Resource1', metadata: { name: 'obj1', namespace: 'ns1' } });
       await manager.update(kc);
 
       const result = manager.getResourceDetails('context1', 'resource1', 'obj1', 'ns1');
@@ -889,7 +889,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
         list: listMock,
         get: getMock,
       } as ObjectCache<KubernetesObject>);
-      listMock.mockReturnValue([{ metadata: { name: 'obj1', namespace: 'ns1' } }]);
+      listMock.mockReturnValue([{ kind: 'Resource1', metadata: { name: 'obj1', namespace: 'ns1' } }]);
       getMock.mockReturnValue(undefined);
       await manager.update(kc);
 

--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -278,12 +278,7 @@ export class ContextsManager {
     namespace?: string,
   ): KubernetesObject | undefined {
     const value = this.#objectCaches.get(contextName, resourceName);
-    let details = value?.get(name, namespace);
-    if (details) {
-      const kind = this.#resourceFactoryHandler.getResourceFactoryByResourceName(resourceName)?.kind;
-      details = { ...details, kind };
-    }
-    return details;
+    return value?.get(name, namespace);
   }
 
   getResourceEvents(contextName: string, uid: string): CoreV1Event[] {

--- a/packages/extension/src/resources/configmaps-resource-factory.ts
+++ b/packages/extension/src/resources/configmaps-resource-factory.ts
@@ -46,7 +46,7 @@ export class ConfigmapsResourceFactory extends ResourceFactoryBase implements Re
       ],
     });
     this.setInformer({
-      createInformer: this.createInformer,
+      createInformer: this.createInformer.bind(this),
     });
     this.setDeleteObject(this.deleteConfigMap);
   }

--- a/packages/extension/src/resources/cronjobs-resource-factory.ts
+++ b/packages/extension/src/resources/cronjobs-resource-factory.ts
@@ -47,7 +47,7 @@ export class CronjobsResourceFactory extends ResourceFactoryBase implements Reso
       ],
     });
     this.setInformer({
-      createInformer: this.createInformer,
+      createInformer: this.createInformer.bind(this),
     });
     this.setDeleteObject(this.deleteCronJob);
   }

--- a/packages/extension/src/resources/deployments-resource-factory.ts
+++ b/packages/extension/src/resources/deployments-resource-factory.ts
@@ -47,7 +47,7 @@ export class DeploymentsResourceFactory extends ResourceFactoryBase implements R
       ],
     });
     this.setInformer({
-      createInformer: this.createInformer,
+      createInformer: this.createInformer.bind(this),
     });
     this.setIsActive(this.isDeploymentActive);
     this.setDeleteObject(this.deleteDeployment);

--- a/packages/extension/src/resources/endpoint-slices-resource-factory.ts
+++ b/packages/extension/src/resources/endpoint-slices-resource-factory.ts
@@ -52,7 +52,7 @@ export class EndpointSlicesResourceFactory extends ResourceFactoryBase implement
       ],
     });
     this.setInformer({
-      createInformer: this.createInformer,
+      createInformer: this.createInformer.bind(this),
     });
 
     this.setSearchByTargetRef(this.searchEndpointSlicesByTargetRef);

--- a/packages/extension/src/resources/events-resource-factory.ts
+++ b/packages/extension/src/resources/events-resource-factory.ts
@@ -46,7 +46,7 @@ export class EventsResourceFactory extends ResourceFactoryBase implements Resour
       ],
     });
     this.setInformer({
-      createInformer: this.createInformer,
+      createInformer: this.createInformer.bind(this),
     });
   }
 

--- a/packages/extension/src/resources/ingresses-resource-factory.ts
+++ b/packages/extension/src/resources/ingresses-resource-factory.ts
@@ -49,7 +49,7 @@ export class IngressesResourceFactory extends ResourceFactoryBase implements Res
       ],
     });
     this.setInformer({
-      createInformer: this.createInformer,
+      createInformer: this.createInformer.bind(this),
     });
     this.setDeleteObject(this.deleteIngress);
     this.setSearchByTargetRef(this.searchIngressesByTargetRef);

--- a/packages/extension/src/resources/jobs-resource-factory.ts
+++ b/packages/extension/src/resources/jobs-resource-factory.ts
@@ -48,7 +48,7 @@ export class JobsResourceFactory extends ResourceFactoryBase implements Resource
       ],
     });
     this.setInformer({
-      createInformer: this.createInformer,
+      createInformer: this.createInformer.bind(this),
     });
     this.setDeleteObject(this.deleteJob);
     this.setReadObject(this.readJob);

--- a/packages/extension/src/resources/namespaces-resource-factory.ts
+++ b/packages/extension/src/resources/namespaces-resource-factory.ts
@@ -51,7 +51,7 @@ export class NamespacesResourceFactory extends ResourceFactoryBase implements Re
       ],
     });
     this.setInformer({
-      createInformer: this.createInformer,
+      createInformer: this.createInformer.bind(this),
     });
     this.setDeleteObject(this.deleteNamespace);
     this.setSearchBySelector(this.searchNamespacesBySelector);

--- a/packages/extension/src/resources/nodes-resource-factory.ts
+++ b/packages/extension/src/resources/nodes-resource-factory.ts
@@ -46,7 +46,7 @@ export class NodesResourceFactory extends ResourceFactoryBase implements Resourc
       ],
     });
     this.setInformer({
-      createInformer: this.createInformer,
+      createInformer: this.createInformer.bind(this),
     });
     this.setIsActive(this.isNodeActive);
   }

--- a/packages/extension/src/resources/pods-resource-factory.ts
+++ b/packages/extension/src/resources/pods-resource-factory.ts
@@ -48,7 +48,7 @@ export class PodsResourceFactory extends ResourceFactoryBase implements Resource
       ],
     });
     this.setInformer({
-      createInformer: this.createInformer,
+      createInformer: this.createInformer.bind(this),
     });
     this.setDeleteObject(this.deletePod);
     this.setSearchBySelector(this.searchPodsBySelector);

--- a/packages/extension/src/resources/pvcs-resource-factory.ts
+++ b/packages/extension/src/resources/pvcs-resource-factory.ts
@@ -51,7 +51,7 @@ export class PVCsResourceFactory extends ResourceFactoryBase implements Resource
       ],
     });
     this.setInformer({
-      createInformer: this.createInformer,
+      createInformer: this.createInformer.bind(this),
     });
     this.setDeleteObject(this.deletePVC);
   }

--- a/packages/extension/src/resources/routes-resource-factory.ts
+++ b/packages/extension/src/resources/routes-resource-factory.ts
@@ -50,7 +50,7 @@ export class RoutesResourceFactory extends ResourceFactoryBase implements Resour
       ],
     });
     this.setInformer({
-      createInformer: this.createInformer,
+      createInformer: this.createInformer.bind(this),
     });
     this.setDeleteObject(this.deleteRoute);
     this.setSearchByTargetRef(this.searchRoutesByTargetRef);

--- a/packages/extension/src/resources/secrets-resource-factory.ts
+++ b/packages/extension/src/resources/secrets-resource-factory.ts
@@ -46,7 +46,7 @@ export class SecretsResourceFactory extends ResourceFactoryBase implements Resou
       ],
     });
     this.setInformer({
-      createInformer: this.createInformer,
+      createInformer: this.createInformer.bind(this),
     });
     this.setDeleteObject(this.deleteSecret);
   }

--- a/packages/extension/src/resources/services-resource-factory.ts
+++ b/packages/extension/src/resources/services-resource-factory.ts
@@ -46,7 +46,7 @@ export class ServicesResourceFactory extends ResourceFactoryBase implements Reso
       ],
     });
     this.setInformer({
-      createInformer: this.createInformer,
+      createInformer: this.createInformer.bind(this),
     });
     this.setDeleteObject(this.deleteService);
   }


### PR DESCRIPTION
The `kind` field of the resources was expected to be set during the list operation in `createInformer`, but `this` being undefined in `createInformer`, it did not work, and the kind was set every time a resource was accessed with `get`