### PR TITLE
refactor: use tailwindcss canonical form

### DIFF
--- a/packages/webview/index.html
+++ b/packages/webview/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0" />
     <title>Kubernetes Dashboard Extension</title>
   </head>
-  <body class="overflow-auto text-base text-[var(--pd-default-text)]">
+  <body class="overflow-auto text-base text-(--pd-default-text)">
     <div id="app"></div>
     <script type="module" src="./src/index.ts"></script>
   </body>

--- a/packages/webview/src/App.svelte
+++ b/packages/webview/src/App.svelte
@@ -32,7 +32,7 @@ function waitThrottleDelay(): Promise<void> {
 </script>
 
 <Route path="/*" isAppMounted={isMounted} let:meta>
-  <main class="flex flex-col w-screen h-screen overflow-hidden bg-[var(--pd-content-bg)] text-base">
+  <main class="flex flex-col w-screen h-screen overflow-hidden bg-(--pd-content-bg) text-base">
     <div class="flex flex-row w-full h-full overflow-hidden">
       {#if !currentContextName}
         {#await waitThrottleDelay() then _}

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -16,11 +16,11 @@ const navigator = dependencyAccessor.get<Navigator>(Navigator);
 </script>
 
 <nav
-  class="z-1 w-leftsidebar min-w-leftsidebar shadow-xs flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
+  class="z-1 w-leftsidebar min-w-leftsidebar shadow-xs flex-col justify-between flex transition-all duration-500 ease-in-out bg-(--pd-secondary-nav-bg) border-(--pd-global-nav-bg-border) border-r-[1px]"
   aria-label="PreferencesNavigation">
   <div class="flex items-center">
     <div class="pt-4 pl-3 px-5 mb-10 flex items-center ml-[4px]">
-      <p class="text-xl first-letter:uppercase text-[color:var(--pd-secondary-nav-header-text)]">Kubernetes</p>
+      <p class="text-xl first-letter:uppercase text-(--pd-secondary-nav-header-text)">Kubernetes</p>
     </div>
   </div>
   <div class="h-full overflow-hidden hover:overflow-y-auto" style="margin-bottom:auto">

--- a/packages/webview/src/component/button/IconButton.svelte
+++ b/packages/webview/src/component/button/IconButton.svelte
@@ -29,13 +29,13 @@ let {
 }: Props = $props();
 
 const buttonDetailedClass =
-  'text-[var(--pd-action-button-details-text)] bg-[var(--pd-action-button-details-bg)] hover:text-[var(--pd-action-button-details-hover-text)] font-medium rounded-lg text-sm items-center px-3 py-2 text-center';
+  'text-(--pd-action-button-details-text) bg-(--pd-action-button-details-bg) hover:text-(--pd-action-button-details-hover-text) font-medium rounded-lg text-sm items-center px-3 py-2 text-center';
 const buttonDetailedDisabledClass =
-  'text-[var(--pd-action-button-details-disabled-text)] bg-[var(--pd-action-button-details-disabled-bg)] font-medium rounded-lg text-sm  items-center px-3 py-2 text-center';
+  'text-(--pd-action-button-details-disabled-text) bg-(--pd-action-button-details-disabled-bg) font-medium rounded-lg text-sm  items-center px-3 py-2 text-center';
 const buttonClass =
-  'text-[var(--pd-action-button-text)] hover:bg-[var(--pd-action-button-hover-bg)] hover:text-[var(--pd-action-button-hover-text)] font-medium rounded-full items-center px-2 py-2 text-center';
+  'text-(--pd-action-button-text) hover:bg-(--pd-action-button-hover-bg) hover:text-(--pd-action-button-hover-text) font-medium rounded-full items-center px-2 py-2 text-center';
 const buttonDisabledClass =
-  'text-[var(--pd-action-button-disabled-text)] font-medium rounded-full items-center px-2 py-2 text-center';
+  'text-(--pd-action-button-disabled-text) font-medium rounded-full items-center px-2 py-2 text-center';
 
 const styleClass = $derived(
   detailed
@@ -81,7 +81,7 @@ function handleClick(): void {
 
   <div
     aria-label="spinner"
-    class="w-6 h-6 rounded-full animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent absolute {positionTopClass} {positionLeftClass}"
+    class="w-6 h-6 rounded-full animate-spin border border-solid border-(--pd-action-button-spinner) border-t-transparent absolute {positionTopClass} {positionLeftClass}"
     class:hidden={!inProgress}>
   </div>
 </button>

--- a/packages/webview/src/component/configmaps-secrets/columns/Type.spec.ts
+++ b/packages/webview/src/component/configmaps-secrets/columns/Type.spec.ts
@@ -41,7 +41,7 @@ test('Expect type display for ConfigMap', async () => {
   expect(text).toBeInTheDocument();
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-running)]');
+  expect(svg).toHaveClass('text-(--pd-status-running)');
 });
 
 test('Expect type display for Secret', async () => {
@@ -61,5 +61,5 @@ test('Expect type display for Secret', async () => {
   expect(text).toBeInTheDocument();
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-running)]');
+  expect(svg).toHaveClass('text-(--pd-status-running)');
 });

--- a/packages/webview/src/component/configmaps-secrets/columns/Type.svelte
+++ b/packages/webview/src/component/configmaps-secrets/columns/Type.svelte
@@ -11,7 +11,7 @@ let { object }: Props = $props();
 function getTypeAttributes(type: string): { color: string; icon: IconDefinition } {
   const isConfigMap = type === 'ConfigMap';
   return {
-    color: 'text-[var(--pd-status-running)]',
+    color: 'text-(--pd-status-running)',
     icon: isConfigMap ? faFileAlt : faKey,
   };
 }

--- a/packages/webview/src/component/connection/CheckConnection.svelte
+++ b/packages/webview/src/component/connection/CheckConnection.svelte
@@ -54,5 +54,5 @@ function refresh(): void {
 
 {#if currentContext.data?.contextName && !isReachableAndNotOffline}
   <Button on:click={refresh} icon={faRefresh} inProgress={inProgress}>Refresh</Button>
-  {#if error}<div class="p-2 text-[var(--pd-state-error)]">{error}</div>{/if}
+  {#if error}<div class="p-2 text-(--pd-state-error)">{error}</div>{/if}
 {/if}

--- a/packages/webview/src/component/connection/CurrentContextConnectionBadge.spec.ts
+++ b/packages/webview/src/component/connection/CurrentContextConnectionBadge.spec.ts
@@ -95,7 +95,7 @@ describe('current context is reachable', () => {
     render(CurrentContextConnectionBadge);
 
     const status = screen.getByRole('status');
-    expect(status.firstChild).toHaveClass('bg-[var(--pd-status-connected)]');
+    expect(status.firstChild).toHaveClass('bg-(--pd-status-connected)');
   });
 
   test('no tooltip', async () => {
@@ -139,7 +139,7 @@ describe('current context is not reachable', () => {
     render(CurrentContextConnectionBadge);
 
     const status = screen.getByRole('status');
-    expect(status.firstChild).toHaveClass('bg-[var(--pd-status-disconnected)]');
+    expect(status.firstChild).toHaveClass('bg-(--pd-status-disconnected)');
   });
 
   test('tooltip', async () => {
@@ -183,7 +183,7 @@ describe('current context is offline', () => {
     render(CurrentContextConnectionBadge);
 
     const status = screen.getByRole('status');
-    expect(status.firstChild).toHaveClass('bg-[var(--pd-status-paused)]');
+    expect(status.firstChild).toHaveClass('bg-(--pd-status-paused)');
   });
 
   test('expect tooltip when offline', async () => {

--- a/packages/webview/src/component/connection/CurrentContextConnectionBadge.svelte
+++ b/packages/webview/src/component/connection/CurrentContextConnectionBadge.svelte
@@ -61,9 +61,9 @@ function getText(health: ContextHealth): string {
 }
 
 function getClassColor(health: ContextHealth): string {
-  if (health.offline) return 'bg-[var(--pd-status-paused)]';
-  if (health.reachable) return 'bg-[var(--pd-status-connected)]';
-  return 'bg-[var(--pd-status-disconnected)]';
+  if (health.offline) return 'bg-(--pd-status-paused)';
+  if (health.reachable) return 'bg-(--pd-status-connected)';
+  return 'bg-(--pd-status-disconnected)';
 }
 
 function getTip(health: ContextHealth): string {

--- a/packages/webview/src/component/cronjobs/columns/Schedule.svelte
+++ b/packages/webview/src/component/cronjobs/columns/Schedule.svelte
@@ -18,6 +18,6 @@ function getScheduleReadableText(schedule: string): string {
 }
 </script>
 
-<div class="text-[var(--pd-table-body-text)] max-w-full text-wrap line-clamp-2">
+<div class="text-(--pd-table-body-text) max-w-full text-wrap line-clamp-2">
   <span>{getScheduleReadableText(object)}</span>
 </div>

--- a/packages/webview/src/component/dashboard/Dashboard.svelte
+++ b/packages/webview/src/component/dashboard/Dashboard.svelte
@@ -43,7 +43,7 @@ onDestroy(() => {
       <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
       {#snippet title()}
         <div class="flex flex-row w-full items-center">
-          <div class="text-xl font-bold capitalize text-[var(--pd-content-header)]">Dashboard</div>
+          <div class="text-xl font-bold capitalize text-(--pd-content-header)">Dashboard</div>
           <div class="flex grow justify-end"><CurrentContextConnectionBadge /></div>
         </div>
       {/snippet}
@@ -63,7 +63,7 @@ onDestroy(() => {
   <div class="flex w-full h-full overflow-auto">
     <div class="flex min-w-full h-full justify-center">
       <div class="flex flex-col space-y-4 min-w-full overflow-y-auto">
-        <div class="flex flex-col gap-4 bg-[var(--pd-content-card-bg)] grow p-5">
+        <div class="flex flex-col gap-4 bg-(--pd-content-card-bg) grow p-5">
           {#if currentContextName}
             <!-- Metrics - non-collapsible -->
             <div class="flex flex-row">

--- a/packages/webview/src/component/dashboard/DashboardGuideCard.spec.ts
+++ b/packages/webview/src/component/dashboard/DashboardGuideCard.spec.ts
@@ -43,12 +43,12 @@ test('Verify basic card format', async () => {
 
   const titleComp = screen.getByText(title);
   expect(titleComp).toBeInTheDocument();
-  expect(titleComp).toHaveClass('text-[var(--pd-content-card-carousel-card-header-text)]');
+  expect(titleComp).toHaveClass('text-(--pd-content-card-carousel-card-header-text)');
   expect(titleComp).toHaveClass('text-center');
   expect(titleComp).toHaveClass('font-semibold');
 
-  expect(titleComp.parentElement).toHaveClass('bg-[var(--pd-content-card-carousel-card-bg)]');
-  expect(titleComp.parentElement).toHaveClass('hover:bg-[var(--pd-content-card-carousel-card-hover-bg)]');
+  expect(titleComp.parentElement).toHaveClass('bg-(--pd-content-card-carousel-card-bg)');
+  expect(titleComp.parentElement).toHaveClass('hover:bg-(--pd-content-card-carousel-card-hover-bg)');
   expect(titleComp.parentElement).toHaveClass('rounded-md');
   expect(titleComp.parentElement).toHaveClass('items-center');
 

--- a/packages/webview/src/component/dashboard/DashboardGuideCard.svelte
+++ b/packages/webview/src/component/dashboard/DashboardGuideCard.svelte
@@ -21,8 +21,8 @@ async function openLink(): Promise<void> {
 </script>
 
 <div
-  class="flex flex-col gap-4 p-4 bg-[var(--pd-content-card-carousel-card-bg)] hover:bg-[var(--pd-content-card-carousel-card-hover-bg)] rounded-md items-center">
-  <img src={image} class="max-w-[100%] object-contain rounded-md self-start" alt={`${title} image`} />
-  <div class="text-[var(--pd-content-card-carousel-card-header-text)] text-center font-semibold">{title}</div>
+  class="flex flex-col gap-4 p-4 bg-(--pd-content-card-carousel-card-bg) hover:bg-(--pd-content-card-carousel-card-hover-bg) rounded-md items-center">
+  <img src={image} class="max-w-full object-contain rounded-md self-start" alt={`${title} image`} />
+  <div class="text-(--pd-content-card-carousel-card-header-text) text-center font-semibold">{title}</div>
   <Button on:click={openLink}>Read more</Button>
 </div>

--- a/packages/webview/src/component/dashboard/DashboardResourceCard.spec.ts
+++ b/packages/webview/src/component/dashboard/DashboardResourceCard.spec.ts
@@ -96,18 +96,18 @@ describe('all resources permitted', () => {
     });
 
     const type = screen.getByText('Seals and Dolphins');
-    expect(type).toHaveClass('text-[var(--pd-invert-content-card-text)]');
+    expect(type).toHaveClass('text-(--pd-invert-content-card-text)');
     expect(type).toHaveClass('font-semibold');
 
     const activeCount = screen.getByLabelText('Seals and Dolphins active count');
     expect(activeCount).toHaveTextContent('3');
     expect(activeCount).toHaveClass('text-2xl');
-    expect(activeCount).toHaveClass('text-[var(--pd-invert-content-card-text)]');
+    expect(activeCount).toHaveClass('text-(--pd-invert-content-card-text)');
 
     const count = screen.getByLabelText('Seals and Dolphins count');
     expect(count).toHaveTextContent('23');
     expect(count).toHaveClass('text-2xl');
-    expect(count).toHaveClass('text-[var(--pd-invert-content-card-text)]');
+    expect(count).toHaveClass('text-(--pd-invert-content-card-text)');
   });
 });
 
@@ -147,18 +147,18 @@ describe('one resource permitted', () => {
     });
 
     const type = screen.getByText('Seals and Dolphins');
-    expect(type).toHaveClass('text-[var(--pd-invert-content-card-text)]');
+    expect(type).toHaveClass('text-(--pd-invert-content-card-text)');
     expect(type).toHaveClass('font-semibold');
 
     const activeCount = screen.getByLabelText('Seals and Dolphins active count');
     expect(activeCount).toHaveTextContent('1');
     expect(activeCount).toHaveClass('text-2xl');
-    expect(activeCount).toHaveClass('text-[var(--pd-invert-content-card-text)]');
+    expect(activeCount).toHaveClass('text-(--pd-invert-content-card-text)');
 
     const count = screen.getByLabelText('Seals and Dolphins count');
     expect(count).toHaveTextContent('11');
     expect(count).toHaveClass('text-2xl');
-    expect(count).toHaveClass('text-[var(--pd-invert-content-card-text)]');
+    expect(count).toHaveClass('text-(--pd-invert-content-card-text)');
   });
 });
 
@@ -194,7 +194,7 @@ describe('one resource permitted, resource cannot be active', () => {
     });
 
     const type = screen.getByText('Seals and Dolphins');
-    expect(type).toHaveClass('text-[var(--pd-invert-content-card-text)]');
+    expect(type).toHaveClass('text-(--pd-invert-content-card-text)');
     expect(type).toHaveClass('font-semibold');
 
     expect(screen.queryByLabelText('Seals and Dolphins active count')).toBeNull();
@@ -202,7 +202,7 @@ describe('one resource permitted, resource cannot be active', () => {
     const count = screen.getByLabelText('Seals and Dolphins count');
     expect(count).toHaveTextContent('11');
     expect(count).toHaveClass('text-2xl');
-    expect(count).toHaveClass('text-[var(--pd-invert-content-card-text)]');
+    expect(count).toHaveClass('text-(--pd-invert-content-card-text)');
   });
 
   test('clicking on the card', async () => {
@@ -257,18 +257,18 @@ describe('no resource permitted', () => {
     expect(button).toHaveClass('opacity-60');
 
     const type = screen.getByText('Seals and Dolphins');
-    expect(type).toHaveClass('text-[var(--pd-invert-content-card-text)]');
+    expect(type).toHaveClass('text-(--pd-invert-content-card-text)');
     expect(type).toHaveClass('font-semibold');
 
     const activeCount = screen.getByLabelText('Seals and Dolphins active count');
     expect(activeCount).toHaveTextContent('-');
     expect(activeCount).toHaveClass('text-2xl');
-    expect(activeCount).toHaveClass('text-[var(--pd-invert-content-card-text)]');
+    expect(activeCount).toHaveClass('text-(--pd-invert-content-card-text)');
 
     const count = screen.getByLabelText('Seals and Dolphins count');
     expect(count).toHaveTextContent('-');
     expect(count).toHaveClass('text-2xl');
-    expect(count).toHaveClass('text-[var(--pd-invert-content-card-text)]');
+    expect(count).toHaveClass('text-(--pd-invert-content-card-text)');
   });
 
   test('clicking on the card', async () => {

--- a/packages/webview/src/component/dashboard/DashboardResourceCard.svelte
+++ b/packages/webview/src/component/dashboard/DashboardResourceCard.svelte
@@ -91,11 +91,11 @@ async function openLink(): Promise<void> {
 </script>
 
 <button
-  class="flex flex-col gap-4 p-4 bg-[var(--pd-content-card-carousel-card-bg)] hover:bg-[var(--pd-content-card-carousel-card-hover-bg)] rounded-md"
+  class="flex flex-col gap-4 p-4 bg-(--pd-content-card-carousel-card-bg) hover:bg-(--pd-content-card-carousel-card-hover-bg) rounded-md"
   class:opacity-60={!permitted}
   onclick={openLink}>
   <div class="text-start flex">
-    <span class="text-[var(--pd-invert-content-card-text)] font-semibold grow">{type}</span>
+    <span class="text-(--pd-invert-content-card-text) font-semibold grow">{type}</span>
     {#if !permitted}
       <span class="ml-1"
         ><Tooltip bottom={true} class="" tip={`${type} are not accessible`}
@@ -104,20 +104,20 @@ async function openLink(): Promise<void> {
     {/if}
   </div>
   <div class="grid {activeCount !== undefined ? 'grid-cols-3' : 'grid-cols-2'} gap-4 w-full grow items-end">
-    <div class="justify-self-center text-[var(--pd-button-primary-bg)]">
+    <div class="justify-self-center text-(--pd-button-primary-bg)">
       <KubernetesIcon kind={iconName} size="40" />
     </div>
     {#if activeCount !== undefined}
       <div class="flex flex-col">
-        <span class="text-[var(--pd-invert-content-card-text)]">Active</span>
-        <div class="text-2xl text-[var(--pd-invert-content-card-text)]" aria-label="{type} active count">
+        <span class="text-(--pd-invert-content-card-text)">Active</span>
+        <div class="text-2xl text-(--pd-invert-content-card-text)" aria-label="{type} active count">
           {#if permitted}{activeCount}{:else}-{/if}
         </div>
       </div>
     {/if}
     <div class="flex flex-col">
-      <span class="text-[var(--pd-invert-content-card-text)]">Total</span>
-      <div class="text-2xl text-[var(--pd-invert-content-card-text)]" aria-label="{type} count">
+      <span class="text-(--pd-invert-content-card-text)">Total</span>
+      <div class="text-2xl text-(--pd-invert-content-card-text)" aria-label="{type} count">
         {#if permitted}{count}{:else}-{/if}
       </div>
     </div>

--- a/packages/webview/src/component/dashboard/KubernetesProviderCard.svelte
+++ b/packages/webview/src/component/dashboard/KubernetesProviderCard.svelte
@@ -22,15 +22,15 @@ async function createNew(provider: KubernetesProvider): Promise<void> {
 }
 </script>
 
-<div class="rounded-xl p-5 text-left bg-[var(--pd-content-card-bg)]">
-  <div class="flex justify-left text-[var(--pd-details-empty-icon)] py-2 mb-2">
+<div class="rounded-xl p-5 text-left bg-(--pd-content-card-bg)">
+  <div class="flex justify-left text-(--pd-details-empty-icon) py-2 mb-2">
     <IconImage image={provider?.images?.icon} class="mx-0 max-h-10" alt={provider.creationDisplayName}></IconImage>
   </div>
   <h1 class="text-lg font-semibold mb-4">
     {provider.creationDisplayName ?? 'Create'}
   </h1>
 
-  <p class="text-sm text-[var(--pd-content-text)] mb-6">
+  <p class="text-sm text-(--pd-content-text) mb-6">
     <Markdown markdown={provider.emptyConnectionMarkdownDescription} />
   </p>
 

--- a/packages/webview/src/component/dashboard/NoContextPage.spec.ts
+++ b/packages/webview/src/component/dashboard/NoContextPage.spec.ts
@@ -59,7 +59,7 @@ test('should render the description text', () => {
 
   const description = screen.getByText(/A Kubernetes cluster is a group of nodes/);
   expect(description).toBeInTheDocument();
-  expect(description).toHaveClass('text-[var(--pd-details-empty-sub-header)]', 'text-balance');
+  expect(description).toHaveClass('text-(--pd-details-empty-sub-header)', 'text-balance');
 });
 
 test('should render providers when data is available', () => {

--- a/packages/webview/src/component/dashboard/NoContextPage.svelte
+++ b/packages/webview/src/component/dashboard/NoContextPage.svelte
@@ -21,11 +21,11 @@ onDestroy(() => {
 
 <div class="mt-8 flex justify-center overflow-auto">
   <div class="max-w-[800px] flex flex-col text-center content-center space-y-3">
-    <div class="flex justify-center text-[var(--pd-details-empty-icon)] py-2">
+    <div class="flex justify-center text-(--pd-details-empty-icon) py-2">
       <KubeIcon size="80" />
     </div>
-    <h1 class="text-xl text-[var(--pd-details-empty-header)]">No Kubernetes cluster</h1>
-    <div class="text-[var(--pd-details-empty-sub-header)] text-balance">
+    <h1 class="text-xl text-(--pd-details-empty-header)">No Kubernetes cluster</h1>
+    <div class="text-(--pd-details-empty-sub-header) text-balance">
       A Kubernetes cluster is a group of nodes (virtual or physical) that run Kubernetes, a system for automating the
       deployment and management of containerized applications.
     </div>

--- a/packages/webview/src/component/dashboard/NoSelectedContextPage.svelte
+++ b/packages/webview/src/component/dashboard/NoSelectedContextPage.svelte
@@ -16,14 +16,14 @@ let { availableContexts }: Props = $props();
 
 <div class="mt-8 flex justify-center overflow-auto">
   <div class="max-w-[600px] flex flex-col text-center space-y-3">
-    <div class="flex justify-center text-[var(--pd-details-empty-icon)] py-2">
+    <div class="flex justify-center text-(--pd-details-empty-icon) py-2">
       <KubeIcon size="80" />
     </div>
-    <h1 class="text-xl text-[var(--pd-details-empty-header)]">No Kubernetes context selected</h1>
-    <div class="text-[var(--pd-details-empty-sub-header)] text-pretty">
+    <h1 class="text-xl text-(--pd-details-empty-header)">No Kubernetes context selected</h1>
+    <div class="text-(--pd-details-empty-sub-header) text-pretty">
       No Kubernetes context is currently selected. Please select a context to continue.
     </div>
-    <div class="text-[var(--pd-details-empty-sub-header)] text-pretty">
+    <div class="text-(--pd-details-empty-sub-header) text-pretty">
       Available contexts:
       {#if availableContexts}
         {#each availableContexts as context, index (index)}

--- a/packages/webview/src/component/deployments/columns/Conditions.spec.ts
+++ b/packages/webview/src/component/deployments/columns/Conditions.spec.ts
@@ -49,7 +49,7 @@ test('Expect column styling available', async () => {
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-running)]');
+  expect(svg).toHaveClass('text-(--pd-status-running)');
 });
 
 test('Expect column styling unavailable', async () => {
@@ -63,7 +63,7 @@ test('Expect column styling unavailable', async () => {
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-degraded)]');
+  expect(svg).toHaveClass('text-(--pd-status-degraded)');
 });
 
 test('Expect column styling updated', async () => {
@@ -77,7 +77,7 @@ test('Expect column styling updated', async () => {
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-updated)]');
+  expect(svg).toHaveClass('text-(--pd-status-updated)');
 });
 
 test('Expect column styling new replica set', async () => {
@@ -91,7 +91,7 @@ test('Expect column styling new replica set', async () => {
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-updated)]');
+  expect(svg).toHaveClass('text-(--pd-status-updated)');
 });
 
 test('Expect column styling progressed', async () => {
@@ -105,7 +105,7 @@ test('Expect column styling progressed', async () => {
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-running)]');
+  expect(svg).toHaveClass('text-(--pd-status-running)');
 });
 
 test('Expect column styling scaled up', async () => {
@@ -119,7 +119,7 @@ test('Expect column styling scaled up', async () => {
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-updated)]');
+  expect(svg).toHaveClass('text-(--pd-status-updated)');
 });
 
 test('Expect column styling scaled down', async () => {
@@ -133,7 +133,7 @@ test('Expect column styling scaled down', async () => {
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-updated)]');
+  expect(svg).toHaveClass('text-(--pd-status-updated)');
 });
 
 test('Expect column styling deadline exceeded', async () => {
@@ -147,7 +147,7 @@ test('Expect column styling deadline exceeded', async () => {
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-dead)]');
+  expect(svg).toHaveClass('text-(--pd-status-dead)');
 });
 
 test('Expect column styling replica failure', async () => {
@@ -161,5 +161,5 @@ test('Expect column styling replica failure', async () => {
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-dead)]');
+  expect(svg).toHaveClass('text-(--pd-status-dead)');
 });

--- a/packages/webview/src/component/deployments/columns/Conditions.svelte
+++ b/packages/webview/src/component/deployments/columns/Conditions.svelte
@@ -21,54 +21,54 @@ let { object }: Props = $props();
 function getConditionAttributes(condition: DeploymentCondition): { name: string; color: string; icon: IconDefinition } {
   const defaults = {
     name: condition.type,
-    color: 'text-[var(--pd-status-unknown)]',
+    color: 'text-(--pd-status-unknown)',
     icon: faQuestionCircle,
   };
 
   // Condition map for easier lookup
   const conditionMap: { [key: string]: { name: string; color: string; icon: IconDefinition } } = {
     'Available:MinimumReplicasAvailable': {
-      color: 'text-[var(--pd-status-running)]',
+      color: 'text-(--pd-status-running)',
       name: 'Available',
       icon: faCheckCircle,
     },
     'Available:MinimumReplicasUnavailable': {
-      color: 'text-[var(--pd-status-degraded)]',
+      color: 'text-(--pd-status-degraded)',
       name: 'Unavailable',
       icon: faTimesCircle,
     },
     'Progressing:ReplicaSetUpdated': {
-      color: 'text-[var(--pd-status-updated)]',
+      color: 'text-(--pd-status-updated)',
       name: 'Updated',
       icon: faSync,
     },
     'Progressing:NewReplicaSetCreated': {
-      color: 'text-[var(--pd-status-updated)]',
+      color: 'text-(--pd-status-updated)',
       name: 'New Replica Set',
       icon: faSync,
     },
     'Progressing:NewReplicaSetAvailable': {
-      color: 'text-[var(--pd-status-running)]',
+      color: 'text-(--pd-status-running)',
       name: 'Progressed',
       icon: faSync,
     },
     'Progressing:ReplicaSetScaledUp': {
-      color: 'text-[var(--pd-status-updated)]',
+      color: 'text-(--pd-status-updated)',
       name: 'Scaled Up',
       icon: faArrowUp,
     },
     'Progressing:ReplicaSetScaledDown': {
-      color: 'text-[var(--pd-status-updated)]',
+      color: 'text-(--pd-status-updated)',
       name: 'Scaled Down',
       icon: faArrowDown,
     },
     'Progressing:ProgressDeadlineExceeded': {
-      color: 'text-[var(--pd-status-dead)]',
+      color: 'text-(--pd-status-dead)',
       name: 'Deadline Exceeded',
       icon: faTimesCircle,
     },
     'ReplicaFailure:ReplicaFailure': {
-      color: 'text-[var(--pd-status-dead)]',
+      color: 'text-(--pd-status-dead)',
       name: 'Replica Failure',
       icon: faExclamationTriangle,
     },

--- a/packages/webview/src/component/deployments/columns/Pods.spec.ts
+++ b/packages/webview/src/component/deployments/columns/Pods.spec.ts
@@ -40,5 +40,5 @@ test('Expect simple column styling', async () => {
 
   const text = screen.getByText(deployment.ready + ' / ' + deployment.replicas);
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-[var(--pd-table-body-text)]');
+  expect(text).toHaveClass('text-(--pd-table-body-text)');
 });

--- a/packages/webview/src/component/deployments/columns/Pods.svelte
+++ b/packages/webview/src/component/deployments/columns/Pods.svelte
@@ -4,6 +4,6 @@ import type { Props } from './props';
 let { object }: Props = $props();
 </script>
 
-<div class="text-[var(--pd-table-body-text)]">
+<div class="text-(--pd-table-body-text)">
   {object.ready} / {object.replicas}
 </div>

--- a/packages/webview/src/component/details/Subtitle.svelte
+++ b/packages/webview/src/component/details/Subtitle.svelte
@@ -8,6 +8,6 @@ interface Props {
 let { style, children }: Props = $props();
 </script>
 
-<td class="pl-2 text-md font-semibold text-[var(--pd-table-body-text-sub-secondary)] {style}">
+<td class="pl-2 text-md font-semibold text-(--pd-table-body-text-sub-secondary) {style}">
   {@render children?.()}
 </td>

--- a/packages/webview/src/component/details/Table.svelte
+++ b/packages/webview/src/component/details/Table.svelte
@@ -7,7 +7,7 @@ interface Props {
 let { children }: Props = $props();
 </script>
 
-<div class="flex px-5 py-4 flex-col items-start h-full overflow-auto text-[var(--pd-table-body-text)]">
+<div class="flex px-5 py-4 flex-col items-start h-full overflow-auto text-(--pd-table-body-text)">
   <table class="w-full">
     <tbody>
       {@render children?.()}

--- a/packages/webview/src/component/details/Title.svelte
+++ b/packages/webview/src/component/details/Title.svelte
@@ -7,6 +7,6 @@ interface Props {
 let { children }: Props = $props();
 </script>
 
-<td class="pt-1 text-lg font-semibold text-[var(--pd-table-body-text-sub-secondary)]">
+<td class="pt-1 text-lg font-semibold text-(--pd-table-body-text-sub-secondary)">
   {@render children?.()}
 </td>

--- a/packages/webview/src/component/ingresses-routes/columns/Backend.spec.ts
+++ b/packages/webview/src/component/ingresses-routes/columns/Backend.spec.ts
@@ -67,7 +67,7 @@ test('Expect simple column styling with single path ingress', async () => {
 
   const text = screen.getByText('a backend');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-[var(--pd-table-body-text)]');
+  expect(text).toHaveClass('text-(--pd-table-body-text)');
 });
 
 test('Expect simple column styling with multiple paths ingress', async () => {
@@ -113,10 +113,10 @@ test('Expect simple column styling with multiple paths ingress', async () => {
 
   const firstElement = screen.getByText(backends[0]);
   expect(firstElement).toBeInTheDocument();
-  expect(firstElement).toHaveClass('text-[var(--pd-table-body-text)]');
+  expect(firstElement).toHaveClass('text-(--pd-table-body-text)');
   const secondElement = screen.getByText(backends[1]);
   expect(secondElement).toBeInTheDocument();
-  expect(secondElement).toHaveClass('text-[var(--pd-table-body-text)]');
+  expect(secondElement).toHaveClass('text-(--pd-table-body-text)');
 });
 
 test('Expect simple column styling with route', async () => {
@@ -140,5 +140,5 @@ test('Expect simple column styling with route', async () => {
 
   const text = screen.getByText('a backend');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-[var(--pd-table-body-text)]');
+  expect(text).toHaveClass('text-(--pd-table-body-text)');
 });

--- a/packages/webview/src/component/ingresses-routes/columns/Backend.svelte
+++ b/packages/webview/src/component/ingresses-routes/columns/Backend.svelte
@@ -11,5 +11,5 @@ const ingressRouteHelper = dependencyAccessor.get<IngressRouteHelper>(IngressRou
 </script>
 
 {#each ingressRouteHelper.getBackends(object) as backend, index (index)}
-  <div class="text-[var(--pd-table-body-text)]">{backend}</div>
+  <div class="text-(--pd-table-body-text)">{backend}</div>
 {/each}

--- a/packages/webview/src/component/ingresses-routes/columns/HostPath.spec.ts
+++ b/packages/webview/src/component/ingresses-routes/columns/HostPath.spec.ts
@@ -84,7 +84,7 @@ test('Expect simple column styling with single host/path ingress', async () => {
 
   const parent = link.parentElement;
   expect(parent).toBeInTheDocument();
-  expect(parent).toHaveClass('text-[var(--pd-table-body-text)]');
+  expect(parent).toHaveClass('text-(--pd-table-body-text)');
 });
 
 test('Expect simple column styling with multiple paths ingress', async () => {

--- a/packages/webview/src/component/ingresses-routes/columns/HostPath.svelte
+++ b/packages/webview/src/component/ingresses-routes/columns/HostPath.svelte
@@ -18,7 +18,7 @@ const systemApi = remote.getProxy(API_SYSTEM);
 </script>
 
 {#each ingressRouteHelper.getHostPaths(object) as hostPath, index (index)}
-  <div class="text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis">
+  <div class="text-(--pd-table-body-text) overflow-hidden text-ellipsis">
     {#if hostPath.url}
       <Link
         aria-label={hostPath.label}

--- a/packages/webview/src/component/jobs/columns/Completions.spec.ts
+++ b/packages/webview/src/component/jobs/columns/Completions.spec.ts
@@ -41,5 +41,5 @@ test('Expect simple column styling', async () => {
 
   const text = screen.getByText(job.succeeded + ' / ' + job.completions);
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-[var(--pd-table-body-text)]');
+  expect(text).toHaveClass('text-(--pd-table-body-text)');
 });

--- a/packages/webview/src/component/jobs/columns/Completions.svelte
+++ b/packages/webview/src/component/jobs/columns/Completions.svelte
@@ -4,6 +4,6 @@ import type { Props } from './props';
 let { object }: Props = $props();
 </script>
 
-<div class="text-[var(--pd-table-body-text)]">
+<div class="text-(--pd-table-body-text)">
   {object.succeeded} / {object.completions}
 </div>

--- a/packages/webview/src/component/jobs/columns/Conditions.spec.ts
+++ b/packages/webview/src/component/jobs/columns/Conditions.spec.ts
@@ -47,7 +47,7 @@ test('Expect column styling completed', async () => {
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-running)]');
+  expect(svg).toHaveClass('text-(--pd-status-running)');
 });
 
 test('Expect column styling failed', async () => {
@@ -59,7 +59,7 @@ test('Expect column styling failed', async () => {
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-dead)]');
+  expect(svg).toHaveClass('text-(--pd-status-dead)');
 });
 
 test('Expect column styling running', async () => {
@@ -71,7 +71,7 @@ test('Expect column styling running', async () => {
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-running)]');
+  expect(svg).toHaveClass('text-(--pd-status-running)');
 });
 
 test('Expect column styling pending', async () => {
@@ -83,7 +83,7 @@ test('Expect column styling pending', async () => {
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-starting)]');
+  expect(svg).toHaveClass('text-(--pd-status-starting)');
 });
 
 test('Expect column styling unknown', async () => {
@@ -95,5 +95,5 @@ test('Expect column styling unknown', async () => {
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-degraded)]');
+  expect(svg).toHaveClass('text-(--pd-status-degraded)');
 });

--- a/packages/webview/src/component/jobs/columns/Conditions.svelte
+++ b/packages/webview/src/component/jobs/columns/Conditions.svelte
@@ -19,34 +19,34 @@ let { object }: Props = $props();
 function getConditionAttributes(condition: JobCondition): { name: string; color: string; icon: IconDefinition } {
   const defaults = {
     name: condition,
-    color: 'text-[var(--pd-status-unknown)]',
+    color: 'text-(--pd-status-unknown)',
     icon: faQuestionCircle,
   };
 
   // Condition map for easier lookup
   const conditionMap: { [key: string]: { name: string; color: string; icon: IconDefinition } } = {
     completed: {
-      color: 'text-[var(--pd-status-running)]',
+      color: 'text-(--pd-status-running)',
       name: 'Completed',
       icon: faCheckCircle,
     },
     failed: {
-      color: 'text-[var(--pd-status-dead)]',
+      color: 'text-(--pd-status-dead)',
       name: 'Failed',
       icon: faTimesCircle,
     },
     running: {
-      color: 'text-[var(--pd-status-running)]',
+      color: 'text-(--pd-status-running)',
       name: 'Running',
       icon: faSync,
     },
     pending: {
-      color: 'text-[var(--pd-status-starting)]',
+      color: 'text-(--pd-status-starting)',
       name: 'Pending',
       icon: faSync,
     },
     unknown: {
-      color: 'text-[var(--pd-status-degraded)]',
+      color: 'text-(--pd-status-degraded)',
       name: 'Unknown',
       icon: faExclamationTriangle,
     },

--- a/packages/webview/src/component/label/Label.spec.ts
+++ b/packages/webview/src/component/label/Label.spec.ts
@@ -32,8 +32,8 @@ test('Expect basic styling', async () => {
   });
   const label = screen.getByText(text);
   expect(label).toBeInTheDocument();
-  expect(label.parentElement).toHaveClass('bg-[var(--pd-label-bg)]');
-  expect(label.parentElement).toHaveClass('text-[var(--pd-label-text)]');
+  expect(label.parentElement).toHaveClass('bg-(--pd-label-bg)');
+  expect(label.parentElement).toHaveClass('text-(--pd-label-text)');
   expect(label.parentElement).toHaveClass('text-sm');
   expect(label.parentElement).toHaveClass('rounded-md');
   expect(label.parentElement).toHaveClass('p-1');

--- a/packages/webview/src/component/label/Label.svelte
+++ b/packages/webview/src/component/label/Label.svelte
@@ -14,9 +14,7 @@ let { name = '', tip = '', role, capitalize = false, children }: Props = $props(
 </script>
 
 <Tooltip top tip={tip}>
-  <div
-    role={role}
-    class="flex items-center bg-[var(--pd-label-bg)] p-1 rounded-md text-sm text-[var(--pd-label-text)] gap-x-1">
+  <div role={role} class="flex items-center bg-(--pd-label-bg) p-1 rounded-md text-sm text-(--pd-label-text) gap-x-1">
     {@render children()}
     <span class:capitalize={capitalize}>
       {name}

--- a/packages/webview/src/component/nodes/columns/Roles.svelte
+++ b/packages/webview/src/component/nodes/columns/Roles.svelte
@@ -18,13 +18,13 @@ $effect(() => {
       roleName = 'Control Plane';
       // faSatelliteDish: Represents a satellite dish, suitable for the control plane role
       roleIcon = faSatelliteDish;
-      roleClass = 'text-[var(--pd-status-running)]';
+      roleClass = 'text-(--pd-status-running)';
       break;
     case 'node':
       roleName = 'Node';
       // faServer: Better represents a "node" / server rack
       roleIcon = faServer;
-      roleClass = 'text-[var(--pd-status-updated)]';
+      roleClass = 'text-(--pd-status-updated)';
       break;
   }
 });
@@ -36,7 +36,7 @@ $effect(() => {
   </Label>
   {#if object.hasGpu}
     <Label name="GPU">
-      <Fa size="1x" icon={faMicrochip} class="text-[var(--pd-status-updated)]" />
+      <Fa size="1x" icon={faMicrochip} class="text-(--pd-status-updated)" />
     </Label>
   {/if}
 </div>

--- a/packages/webview/src/component/objects/KubernetesObjectDetails.svelte
+++ b/packages/webview/src/component/objects/KubernetesObjectDetails.svelte
@@ -184,7 +184,7 @@ function navigateToList(): void {
     {/snippet}
     {#snippet detailSnippet()}
       {#if objectUI}
-        <div class="flex py-2 w-full justify-end text-sm text-[var(--pd-content-text)]">
+        <div class="flex py-2 w-full justify-end text-sm text-(--pd-content-text)">
           <StateChange state={objectUI.status} />
         </div>
       {/if}

--- a/packages/webview/src/component/objects/NamespaceDropdown.svelte
+++ b/packages/webview/src/component/objects/NamespaceDropdown.svelte
@@ -67,6 +67,6 @@ onDestroy(() => {
     value: namespace,
   }))}>
   {#snippet left()}
-    <div class="mr-1 text-[var(--pd-input-field-placeholder-text)]">Namespace:</div>
+    <div class="mr-1 text-(--pd-input-field-placeholder-text)">Namespace:</div>
   {/snippet}
 </Dropdown>

--- a/packages/webview/src/component/objects/columns/Name.spec.ts
+++ b/packages/webview/src/component/objects/columns/Name.spec.ts
@@ -55,7 +55,7 @@ test('Expect simple column styling', async () => {
 
   const name = screen.getByText(node.name);
   expect(name).toBeInTheDocument();
-  expect(name).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
+  expect(name).toHaveClass('text-(--pd-table-body-text-highlight)');
   expect(name).toHaveClass('overflow-hidden');
   expect(name).toHaveClass('text-ellipsis');
 
@@ -68,7 +68,7 @@ test('Expect namespaced column styling', async () => {
 
   const name = screen.getByText(deployment.name);
   expect(name).toBeInTheDocument();
-  expect(name).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
+  expect(name).toHaveClass('text-(--pd-table-body-text-highlight)');
   expect(name).toHaveClass('overflow-hidden');
   expect(name).toHaveClass('text-ellipsis');
 
@@ -76,7 +76,7 @@ test('Expect namespaced column styling', async () => {
 
   const namespace = screen.getByText(deployment.namespace);
   expect(namespace).toBeInTheDocument();
-  expect(namespace).toHaveClass('text-[var(--pd-table-body-text)]');
+  expect(namespace).toHaveClass('text-(--pd-table-body-text)');
   expect(namespace).toHaveClass('overflow-hidden');
   expect(namespace).toHaveClass('text-ellipsis');
 });

--- a/packages/webview/src/component/objects/columns/Name.svelte
+++ b/packages/webview/src/component/objects/columns/Name.svelte
@@ -29,11 +29,11 @@ async function openDetails(): Promise<void> {
 </script>
 
 <button class="hover:cursor-pointer flex flex-col max-w-full text-left" onclick={openDetails}>
-  <div class="text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis">
+  <div class="text-(--pd-table-body-text-highlight) overflow-hidden text-ellipsis">
     {object.name}
   </div>
   {#if objectHelper.isNamespaced(object)}
-    <div class="text-[var(--pd-table-body-text)] font-extra-light text-sm overflow-hidden text-ellipsis">
+    <div class="text-(--pd-table-body-text) font-extra-light text-sm overflow-hidden text-ellipsis">
       {object.namespace}
     </div>
   {/if}

--- a/packages/webview/src/component/pods/PodTerminal.svelte
+++ b/packages/webview/src/component/pods/PodTerminal.svelte
@@ -102,4 +102,4 @@ onDestroy(() => {
 });
 </script>
 
-<div class="h-full w-full p-[5px] pr-0 bg-[var(--pd-terminal-background)]" bind:this={terminalXtermDiv}></div>
+<div class="h-full w-full p-[5px] pr-0 bg-(--pd-terminal-background)" bind:this={terminalXtermDiv}></div>

--- a/packages/webview/src/component/pods/columns/Containers.spec.ts
+++ b/packages/webview/src/component/pods/columns/Containers.spec.ts
@@ -53,5 +53,5 @@ test('Expect simple column styling', async () => {
 
   const dot = screen.getByTestId('status-dot');
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('bg-[var(--pd-status-running)]');
+  expect(dot).toHaveClass('bg-(--pd-status-running)');
 });

--- a/packages/webview/src/component/pods/dots/Dots.spec.ts
+++ b/packages/webview/src/component/pods/dots/Dots.spec.ts
@@ -84,16 +84,16 @@ beforeEach(() => {
 });
 
 test('getStatusColor returns the correct colors', () => {
-  expect(getStatusColor('running')).toBe('bg-[var(--pd-status-running)]');
-  expect(getStatusColor('terminated')).toBe('bg-[var(--pd-status-terminated)]');
-  expect(getStatusColor('waiting')).toBe('bg-[var(--pd-status-waiting)]');
-  expect(getStatusColor('stopped')).toBe('outline-[var(--pd-status-stopped)]');
-  expect(getStatusColor('paused')).toBe('bg-[var(--pd-status-paused)]');
-  expect(getStatusColor('exited')).toBe('outline-[var(--pd-status-exited)]');
-  expect(getStatusColor('dead')).toBe('bg-[var(--pd-status-dead)]');
-  expect(getStatusColor('created')).toBe('outline-[var(--pd-status-created)]');
-  expect(getStatusColor('degraded')).toBe('bg-[var(--pd-status-degraded)]');
-  expect(getStatusColor('unknown')).toBe('bg-[var(--pd-status-unknown)]');
+  expect(getStatusColor('running')).toBe('bg-(--pd-status-running)');
+  expect(getStatusColor('terminated')).toBe('bg-(--pd-status-terminated)');
+  expect(getStatusColor('waiting')).toBe('bg-(--pd-status-waiting)');
+  expect(getStatusColor('stopped')).toBe('outline-(--pd-status-stopped)');
+  expect(getStatusColor('paused')).toBe('bg-(--pd-status-paused)');
+  expect(getStatusColor('exited')).toBe('outline-(--pd-status-exited)');
+  expect(getStatusColor('dead')).toBe('bg-(--pd-status-dead)');
+  expect(getStatusColor('created')).toBe('outline-(--pd-status-created)');
+  expect(getStatusColor('degraded')).toBe('bg-(--pd-status-degraded)');
+  expect(getStatusColor('unknown')).toBe('bg-(--pd-status-unknown)');
 });
 
 test('organizeContainers returns a record of containers organized by status', () => {

--- a/packages/webview/src/component/pods/dots/Dots.ts
+++ b/packages/webview/src/component/pods/dots/Dots.ts
@@ -29,23 +29,23 @@ export function getStatusColor(status: string): string {
   // must be either "bg-" or "outline-" for either solid / outline colors
   const colors: Record<string, string> = {
     // Podman & Kubernetes
-    running: 'bg-[var(--pd-status-running)]',
+    running: 'bg-(--pd-status-running)',
 
     // Kubernetes-only
-    terminated: 'bg-[var(--pd-status-terminated)]',
-    waiting: 'bg-[var(--pd-status-waiting)]',
+    terminated: 'bg-(--pd-status-terminated)',
+    waiting: 'bg-(--pd-status-waiting)',
 
     // Podman-only
-    stopped: 'outline-[var(--pd-status-stopped)]',
-    paused: 'bg-[var(--pd-status-paused)]',
-    exited: 'outline-[var(--pd-status-exited)]',
-    dead: 'bg-[var(--pd-status-dead)]',
-    created: 'outline-[var(--pd-status-created)]',
-    degraded: 'bg-[var(--pd-status-degraded)]',
+    stopped: 'outline-(--pd-status-stopped)',
+    paused: 'bg-(--pd-status-paused)',
+    exited: 'outline-(--pd-status-exited)',
+    dead: 'bg-(--pd-status-dead)',
+    created: 'outline-(--pd-status-created)',
+    degraded: 'bg-(--pd-status-degraded)',
   };
 
   // Return the corresponding color class or a default if not found
-  return colors[status] || 'bg-[var(--pd-status-unknown)]';
+  return colors[status] || 'bg-(--pd-status-unknown)';
 }
 
 // Organize the containers by returning their status as the key + an array of containers by order of

--- a/packages/webview/src/component/pods/dots/StatusDot.spec.ts
+++ b/packages/webview/src/component/pods/dots/StatusDot.spec.ts
@@ -40,59 +40,59 @@ beforeEach(() => {
 test('Expect the dot to have the correct color for running status', () => {
   renderStatusDot('running');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('bg-[var(--pd-status-running)]');
+  expect(dot).toHaveClass('bg-(--pd-status-running)');
 });
 
 test('Expect the dot to have the correct color for terminated status', () => {
   renderStatusDot('terminated');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('bg-[var(--pd-status-terminated)]');
+  expect(dot).toHaveClass('bg-(--pd-status-terminated)');
 });
 
 test('Expect the dot to have the correct color for waiting status', () => {
   renderStatusDot('waiting');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('bg-[var(--pd-status-waiting)]');
+  expect(dot).toHaveClass('bg-(--pd-status-waiting)');
 });
 
 test('Expect the dot to have the correct color for stopped status', () => {
   renderStatusDot('stopped');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('outline-[var(--pd-status-stopped)]');
+  expect(dot).toHaveClass('outline-(--pd-status-stopped)');
 });
 
 test('Expect the dot to have the correct color for paused status', () => {
   renderStatusDot('paused');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('bg-[var(--pd-status-paused)]');
+  expect(dot).toHaveClass('bg-(--pd-status-paused)');
 });
 
 test('Expect the dot to have the correct color for exited status', () => {
   renderStatusDot('exited');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('outline-[var(--pd-status-exited)]');
+  expect(dot).toHaveClass('outline-(--pd-status-exited)');
 });
 
 test('Expect the dot to have the correct color for dead status', () => {
   renderStatusDot('dead');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('bg-[var(--pd-status-dead)]');
+  expect(dot).toHaveClass('bg-(--pd-status-dead)');
 });
 
 test('Expect the dot to have the correct color for created status', () => {
   renderStatusDot('created');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('outline-[var(--pd-status-created)]');
+  expect(dot).toHaveClass('outline-(--pd-status-created)');
 });
 
 test('Expect the dot to have the correct color for degraded status', () => {
   renderStatusDot('degraded');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('bg-[var(--pd-status-degraded)]');
+  expect(dot).toHaveClass('bg-(--pd-status-degraded)');
 });
 
 test('Expect the dot to have the correct color for unknown status', () => {
   renderStatusDot('unknown');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('bg-[var(--pd-status-unknown)]');
+  expect(dot).toHaveClass('bg-(--pd-status-unknown)');
 });

--- a/packages/webview/src/component/pods/dots/StatusDot.svelte
+++ b/packages/webview/src/component/pods/dots/StatusDot.svelte
@@ -40,6 +40,6 @@ let dotClass = getStatusColor(status);
   </div>
   <!-- If text -->
   {#if number}
-    <div class="text-sm text-bold text-[var(--pd-content-text)] mr-0.5">{number}</div>
+    <div class="text-sm text-bold text-(--pd-content-text) mr-0.5">{number}</div>
   {/if}
 </Tooltip>

--- a/packages/webview/src/component/port-forward/columns/Name.svelte
+++ b/packages/webview/src/component/port-forward/columns/Name.svelte
@@ -37,12 +37,12 @@ async function openResourceDetails(): Promise<void> {
   class="hover:cursor-pointer flex flex-col max-w-full"
   disabled={object.kind !== WorkloadKind.POD}
   onclick={openResourceDetails}>
-  <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
+  <div class="text-(--pd-table-body-text-highlight) max-w-full overflow-hidden text-ellipsis">
     {object.name}
   </div>
   <div class="flex flex-row text-sm gap-1">
     {#if object.namespace}
-      <div class="font-extra-light text-[var(--pd-table-body-text)]">{object.namespace}</div>
+      <div class="font-extra-light text-(--pd-table-body-text)">{object.namespace}</div>
     {/if}
   </div>
 </button>

--- a/packages/webview/src/component/pvcs/columns/Mode.svelte
+++ b/packages/webview/src/component/pvcs/columns/Mode.svelte
@@ -14,19 +14,19 @@ function getModeAttributes(mode: string): { color: string; icon: IconDefinition 
   switch (mode) {
     case 'ReadOnlyMany':
       // faEye: Symbolizes visibility, suitable for ReadOnlyMany where the volume can be read by many
-      return { color: 'text-[var(--pd-status-running)]', icon: faEye };
+      return { color: 'text-(--pd-status-running)', icon: faEye };
     case 'ReadWriteMany':
       // faTh: Indicates multiple access points, apt for ReadWriteMany where multiple users can read and write
-      return { color: 'text-[var(--pd-status-running)]', icon: faTh };
+      return { color: 'text-(--pd-status-running)', icon: faTh };
     case 'ReadWriteOnce':
       // faLock: Represents exclusive write access (one writer), indicative of the ReadWriteOnce mode
-      return { color: 'text-[var(--pd-status-paused)]', icon: faLock };
+      return { color: 'text-(--pd-status-paused)', icon: faLock };
     case 'ReadWriteOncePod':
       // faSitemap: Represents a specific structure or cluster, used for ReadWriteOncePod where access is restricted to a single pod
-      return { color: 'text-[var(--pd-status-paused)]', icon: faSitemap };
+      return { color: 'text-(--pd-status-paused)', icon: faSitemap };
     default:
       // A generic circle icon for undefined modes
-      return { color: 'text-[var(--pd-status-unknown)]', icon: faCircle };
+      return { color: 'text-(--pd-status-unknown)', icon: faCircle };
   }
 }
 </script>

--- a/packages/webview/src/component/services/columns/Type.spec.ts
+++ b/packages/webview/src/component/services/columns/Type.spec.ts
@@ -44,7 +44,7 @@ test('Expect basic column styling', async () => {
 
   const dot = text.parentElement?.children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('text-[var(--pd-badge-gray)]');
+  expect(dot).toHaveClass('text-(--pd-badge-gray)');
   result.unmount();
 });
 
@@ -57,7 +57,7 @@ test('Expect column styling ClusterIP', async () => {
 
   const dot = text.parentElement?.children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('text-[var(--pd-badge-sky)]');
+  expect(dot).toHaveClass('text-(--pd-badge-sky)');
 });
 
 test('Expect column styling LoadBalancer', async () => {
@@ -69,7 +69,7 @@ test('Expect column styling LoadBalancer', async () => {
 
   const dot = text.parentElement?.children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('text-[var(--pd-badge-purple)]');
+  expect(dot).toHaveClass('text-(--pd-badge-purple)');
 });
 
 test('Expect column styling NodePort', async () => {
@@ -81,5 +81,5 @@ test('Expect column styling NodePort', async () => {
 
   const dot = text.parentElement?.children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('text-[var(--pd-badge-fuschia)]');
+  expect(dot).toHaveClass('text-(--pd-badge-fuschia)');
 });

--- a/packages/webview/src/component/services/columns/Type.svelte
+++ b/packages/webview/src/component/services/columns/Type.svelte
@@ -18,16 +18,16 @@ function getTypeAttributes(type: string): { color: string; icon: IconDefinition 
   switch (type) {
     case 'ClusterIP':
       // faNetworkWired: Represents internal network connections, suitable for ClusterIP
-      return { color: 'text-[var(--pd-badge-sky)]', icon: faNetworkWired };
+      return { color: 'text-(--pd-badge-sky)', icon: faNetworkWired };
     case 'LoadBalancer':
       // faBalanceScale: Symbolizes distribution, fitting for LoadBalancer that distributes traffic
-      return { color: 'text-[var(--pd-badge-purple)]', icon: faBalanceScale };
+      return { color: 'text-(--pd-badge-purple)', icon: faBalanceScale };
     case 'NodePort':
       // faPlug: Indicates a connection point, appropriate for NodePort which exposes services on each Node's IP
-      return { color: 'text-[var(--pd-badge-fuschia)]', icon: faPlug };
+      return { color: 'text-(--pd-badge-fuschia)', icon: faPlug };
     default:
       // faQuestionCircle: Used for unknown or unspecified types
-      return { color: 'text-[var(--pd-badge-gray)]', icon: faQuestionCircle };
+      return { color: 'text-(--pd-badge-gray)', icon: faQuestionCircle };
   }
 }
 </script>

--- a/packages/webview/src/component/terminal/TerminalSearchControls.svelte
+++ b/packages/webview/src/component/terminal/TerminalSearchControls.svelte
@@ -70,13 +70,13 @@ function onKeyUp(e: KeyboardEvent): void {
   <div class="space-x-1">
     <button
       aria-label="Previous Match"
-      class="p-2 rounded-sm hover:bg-[var(--pd-action-button-details-bg)]"
+      class="p-2 rounded-sm hover:bg-(--pd-action-button-details-bg)"
       onclick={(): void => onSearchPrevious(true)}>
       <Fa icon={faArrowUp} />
     </button>
     <button
       aria-label="Next Match"
-      class="p-2 rounded-sm hover:bg-[var(--pd-action-button-details-bg)]"
+      class="p-2 rounded-sm hover:bg-(--pd-action-button-details-bg)"
       onclick={(): void => onSearchNext(true)}>
       <Fa icon={faArrowDown} />
     </button>

--- a/packages/webview/src/component/terminal/TerminalWindow.svelte
+++ b/packages/webview/src/component/terminal/TerminalWindow.svelte
@@ -81,7 +81,7 @@ onDestroy(() => {
 {/if}
 
 <div
-  class="{className} overflow-hidden p-[5px] pr-0 bg-[var(--pd-terminal-background)]"
+  class="{className} overflow-hidden p-[5px] pr-0 bg-(--pd-terminal-background)"
   role="term"
   bind:this={logsXtermDiv}>
 </div>


### PR DESCRIPTION
Use tailwindcss canonical forms, accoring to tailwindcss intellisence: https://github.com/tailwindlabs/tailwindcss-intellisense?tab=readme-ov-file#tailwindcsslintsuggestcanonicalclasses

https://tailwindcss.com/docs/adding-custom-styles#using-arbitrary-values

```
If you're referencing a CSS variable as an arbitrary value, you can use the custom property syntax:

HTML
<div class="fill-(--my-brand-color) ...">
  <!-- ... -->
</div>
This is just a shorthand for fill-[var(--my-brand-color)] that adds the var() function for you automatically.```