### PR TITLE
chore: use projects in vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,7 +19,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    workspace: ['packages/*/vitest.config.ts'],
+    projects: ['packages/*/vitest.config.ts'],
     // use GitHub action reporters when running in CI
     reporters: process.env.GITHUB_ACTIONS?['github-actions', 'default']:['default'],
     coverage: {


### PR DESCRIPTION
workspace option is deprecated in v3.2 and is removed in v4 of vitest replace the usage
https://vitest.dev/guide/projects.html#test-projects

