### PR TITLE
refactor: move single channelSubscriber as the first subscriber

### DIFF
--- a/packages/extension/src/dashboard-extension.ts
+++ b/packages/extension/src/dashboard-extension.ts
@@ -45,6 +45,7 @@ import { PodLogsApiImpl } from './manager/pod-logs-api-impl';
 import { PodTerminalsApiImpl } from './manager/pod-terminals-api-impl';
 import { NavigationApiImpl } from '/@/manager/navigation-api';
 import { KubernetesProvidersManager } from '/@/manager/kubernetes-providers';
+import { ChannelSubscriber } from '/@/types/channel-subscriber';
 
 export class DashboardExtension {
   #container: Container | undefined;
@@ -61,6 +62,7 @@ export class DashboardExtension {
   #podTerminalsApiImpl: PodTerminalsApiImpl;
   #navigationApiImpl: NavigationApiImpl;
   #kubernetesProvidersManager: KubernetesProvidersManager;
+  #webviewSubscriber: ChannelSubscriber;
 
   constructor(readonly extensionContext: ExtensionContext) {
     this.#extensionContext = extensionContext;
@@ -89,6 +91,7 @@ export class DashboardExtension {
     this.#podTerminalsApiImpl = await this.#container.getAsync(PodTerminalsApiImpl);
     this.#navigationApiImpl = await this.#container.getAsync(NavigationApiImpl);
     this.#kubernetesProvidersManager = await this.#container.getAsync(KubernetesProvidersManager);
+    this.#webviewSubscriber = await this.#container.getAsync(ChannelSubscriber);
 
     this.#kubernetesProvidersManager.init();
 
@@ -96,7 +99,7 @@ export class DashboardExtension {
 
     console.log('activation time:', afterFirst - now);
 
-    rpcExtension.registerInstance(API_SUBSCRIBE, this.#contextsStatesDispatcher);
+    rpcExtension.registerInstance(API_SUBSCRIBE, this.#webviewSubscriber);
     rpcExtension.registerInstance(API_CONTEXTS, this.#contextsManager);
     rpcExtension.registerInstance(API_SYSTEM, this.#systemApiImpl);
     rpcExtension.registerInstance(API_PORT_FORWARD, this.#portForwardApiImpl);

--- a/packages/extension/src/inject/inversify-binding.ts
+++ b/packages/extension/src/inject/inversify-binding.ts
@@ -26,6 +26,7 @@ import { RpcExtension } from '@kubernetes-dashboard/rpc';
 import { managersModule } from '/@/manager/_manager-module';
 import { dispatchersModule } from '/@/dispatcher/_dispatcher-module';
 import { portForwardModule } from '/@/port-forward/_port-forward-module';
+import { typesModule } from '/@/types/_types_modules';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -56,6 +57,7 @@ export class InversifyBinding {
     await this.#container.load(managersModule);
     await this.#container.load(dispatchersModule);
     await this.#container.load(portForwardModule);
+    await this.#container.load(typesModule);
 
     return this.#container;
   }

--- a/packages/extension/src/types/_types_modules.ts
+++ b/packages/extension/src/types/_types_modules.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { ChannelSubscriber } from '/@/types/channel-subscriber';
+
+const typesModule = new ContainerModule(options => {
+  options.bind<ChannelSubscriber>(ChannelSubscriber).toSelf().inSingletonScope();
+});
+
+export { typesModule };


### PR DESCRIPTION
`ContextsStatesDispatcher` currently supports only the webview to subscribe to events.

To be able to expose these events through an API to other extensions, the dispatcher needs to accept several subscribers: webview and extensions.

This first PR changes how the dispatcher supports the webview subscriber: before as the only one (by extending it), with this PR as one subscriber (by embedding it).

Part of #94 