### PR TITLE
ci: disable non necessary cache

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -169,7 +169,6 @@ jobs:
           node-version: 22
           registry-url: 'https://npm.pkg.github.com'
           scope: ${{ github.repository_owner }}
-          cache: 'pnpm'
 
       - name: Set api package version
         run: |


### PR DESCRIPTION
The cache is not needed (no dependencies), and make the workflow return an error on cleanup
