### PR TITLE
feat: add a method in system api to get platform name

### DIFF
--- a/packages/channels/src/interface/system-api.ts
+++ b/packages/channels/src/interface/system-api.ts
@@ -22,5 +22,5 @@ export interface SystemApi {
   openExternal(uri: string): Promise<boolean>;
   clipboardWriteText(text: string): Promise<void>;
   getFreePort(startPort: number): Promise<number>;
-  getSystemName(): Promise<'linux' | 'mac' | 'windows' | undefined>;
+  getPlatformName(): Promise<string>;
 }

--- a/packages/extension/src/manager/system-api.spec.ts
+++ b/packages/extension/src/manager/system-api.spec.ts
@@ -16,42 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { SystemApiImpl } from '/@/manager/system-api';
-import * as podmanDesktopApi from '@podman-desktop/api';
+import * as os from 'node:os';
 
-describe('getSystemName', async () => {
+vi.mock(import('node:os'));
+
+describe('getPlatformName', async () => {
   const systemApi = new SystemApiImpl();
 
-  test('should return linux', async () => {
-    (podmanDesktopApi.env.isLinux as boolean) = true;
-    (podmanDesktopApi.env.isMac as boolean) = false;
-    (podmanDesktopApi.env.isWindows as boolean) = false;
-    const systemName = await systemApi.getSystemName();
-    expect(systemName).toBe('linux');
-  });
-
-  test('should return mac', async () => {
-    (podmanDesktopApi.env.isLinux as boolean) = false;
-    (podmanDesktopApi.env.isMac as boolean) = true;
-    (podmanDesktopApi.env.isWindows as boolean) = false;
-    const systemName = await systemApi.getSystemName();
-    expect(systemName).toBe('mac');
-  });
-
-  test('should return windows', async () => {
-    (podmanDesktopApi.env.isLinux as boolean) = false;
-    (podmanDesktopApi.env.isMac as boolean) = false;
-    (podmanDesktopApi.env.isWindows as boolean) = true;
-    const systemName = await systemApi.getSystemName();
-    expect(systemName).toBe('windows');
-  });
-
-  test('should return undefined', async () => {
-    (podmanDesktopApi.env.isLinux as boolean) = false;
-    (podmanDesktopApi.env.isMac as boolean) = false;
-    (podmanDesktopApi.env.isWindows as boolean) = false;
-    const systemName = await systemApi.getSystemName();
-    expect(systemName).toBeUndefined();
+  test('should return value from os.platform', async () => {
+    // testing with a non-tested platform, to be sure that the value is not obtained from the system
+    vi.mocked(os.platform).mockReturnValue('sunos');
+    const platformName = await systemApi.getPlatformName();
+    expect(platformName).toBe('sunos');
   });
 });

--- a/packages/extension/src/manager/system-api.ts
+++ b/packages/extension/src/manager/system-api.ts
@@ -19,6 +19,7 @@
 import { injectable } from 'inversify';
 import type { SystemApi } from '@kubernetes-dashboard/channels';
 import * as podmanDesktopApi from '@podman-desktop/api';
+import * as os from 'node:os';
 
 @injectable()
 export class SystemApiImpl implements SystemApi {
@@ -34,14 +35,7 @@ export class SystemApiImpl implements SystemApi {
     return podmanDesktopApi.net.getFreePort(startPort);
   }
 
-  async getSystemName(): Promise<'linux' | 'mac' | 'windows' | undefined> {
-    if (podmanDesktopApi.env.isLinux) {
-      return 'linux';
-    } else if (podmanDesktopApi.env.isMac) {
-      return 'mac';
-    } else if (podmanDesktopApi.env.isWindows) {
-      return 'windows';
-    }
-    return undefined;
+  async getPlatformName(): Promise<string> {
+    return os.platform();
   }
 }


### PR DESCRIPTION
Adds a method `getPlatformName` to get the system from the podman desktop core (via its extension API)

Necessary for #427 

The value will be 
- 'darwin' on mac
- 'win32' on windows
- 'linux'

Other values should not happen, as Podman Desktop is only supported on these platforms.

How to use it from a svelte component:

```
import { getContext, onDestroy, onMount } from 'svelte'; 
import { Remote } from '/@/remote/remote';
import { API_SYSTEM } from '@kubernetes-dashboard/channels';
 
const remote = getContext<Remote>(Remote);
const systemApi = remote.getProxy(API_SYSTEM);
let platformName = $state<string>();

onMount(async () => {
  platformName = await systemApi.getPlatformName();
  console.log('==> platformName', platformName);
});
```
