### PR TITLE
chore(vitest/eslint-plugin): replace toThrow() with its canonical name toThrowError()

### DIFF
--- a/packages/extension/src/manager/contexts-manager.spec.ts
+++ b/packages/extension/src/manager/contexts-manager.spec.ts
@@ -1483,7 +1483,7 @@ test('deleteObject handler throws a non-Status in ApiException', async () => {
       {},
     ),
   );
-  await expect(() => manager.deleteObject('Resource4', 'resource-name', 'other-ns')).rejects.toThrow(
+  await expect(() => manager.deleteObject('Resource4', 'resource-name', 'other-ns')).rejects.toThrowError(
     /Message: Bad Request/,
   );
   expect(window.showInformationMessage).toHaveBeenCalled();
@@ -1502,7 +1502,7 @@ test('deleteObject handler throws a non-ApiException', async () => {
   vi.mocked(window.showInformationMessage).mockImplementation(async (): Promise<string> => 'Yes');
   const error = new Error('an error');
   resource4DeleteObjectMock.mockRejectedValue(error);
-  await expect(() => manager.deleteObject('Resource4', 'resource-name', 'other-ns')).rejects.toThrow(error);
+  await expect(() => manager.deleteObject('Resource4', 'resource-name', 'other-ns')).rejects.toThrowError(error);
   expect(window.showInformationMessage).toHaveBeenCalled();
   expect(resource4DeleteObjectMock).toHaveBeenCalledWith(expect.anything(), 'resource-name', 'other-ns');
   expect(manager.handleStatus).not.toHaveBeenCalled();

--- a/packages/extension/src/port-forward/port-forward-connection.spec.ts
+++ b/packages/extension/src/port-forward/port-forward-connection.spec.ts
@@ -215,7 +215,7 @@ describe('PortForwardConnectionService', () => {
   });
 
   test('should throw an error for unsupported workload kind', async () => {
-    await expect(service.getWorkloadResource('UNSUPPORTED_KIND' as never, 'test', 'default')).rejects.toThrow(
+    await expect(service.getWorkloadResource('UNSUPPORTED_KIND' as never, 'test', 'default')).rejects.toThrowError(
       `Workload kind 'UNSUPPORTED_KIND' currently not supported.`,
     );
   });
@@ -436,7 +436,7 @@ describe('PortForwardConnectionService', () => {
     });
 
     test('should throw an error for unsupported workload kind', async () => {
-      await expect(service.getWorkloadResource('UNSUPPORTED_KIND' as never, 'test', 'default')).rejects.toThrow(
+      await expect(service.getWorkloadResource('UNSUPPORTED_KIND' as never, 'test', 'default')).rejects.toThrowError(
         `Workload kind 'UNSUPPORTED_KIND' currently not supported.`,
       );
     });
@@ -534,7 +534,7 @@ describe('PortForwardConnectionService', () => {
       const invalidResource = { kind: 'InvalidKind' };
       const forward = { localPort: 3000, remotePort: 80 };
 
-      await expect(service.getForwardingSetup(invalidResource as never, forward)).rejects.toThrow(
+      await expect(service.getForwardingSetup(invalidResource as never, forward)).rejects.toThrowError(
         'Found invalid resource type.',
       );
     });
@@ -623,7 +623,7 @@ describe('PortForwardConnectionService', () => {
 
       vi.spyOn(service, 'performForward').mockRejectedValueOnce(new Error('Failed to forward port'));
 
-      await expect(service.startForward(forwardConfig)).rejects.toThrow('Failed to forward port');
+      await expect(service.startForward(forwardConfig)).rejects.toThrowError('Failed to forward port');
 
       expect(service.performForward).toHaveBeenCalledTimes(1);
     });

--- a/packages/extension/src/port-forward/port-forward-storage.spec.ts
+++ b/packages/extension/src/port-forward/port-forward-storage.spec.ts
@@ -70,7 +70,7 @@ describe('PreferenceFolderBasedStorage', () => {
     const storage = new PreferenceFolderBasedStorage(baseDirectory);
     storage['initialized'] = true;
 
-    await expect(storage.initStorage()).rejects.toThrow('Storage has already been initialized.');
+    await expect(storage.initStorage()).rejects.toThrowError('Storage has already been initialized.');
   });
 
   test('should return storage path if initialized', () => {
@@ -83,7 +83,7 @@ describe('PreferenceFolderBasedStorage', () => {
 
   test('should throw error if storage is not initialized when getting path', () => {
     const storage = new PreferenceFolderBasedStorage(baseDirectory);
-    expect(() => storage.getStoragePath()).toThrow('Storage has not been initialized yet.');
+    expect(() => storage.getStoragePath()).toThrowError('Storage has not been initialized yet.');
   });
 
   test('should return true if storage is initialized', () => {
@@ -102,7 +102,7 @@ describe('PreferenceFolderBasedStorage', () => {
     const mkdirMock = vi.spyOn(fs, 'mkdir').mockResolvedValue(undefined);
     const accessMock = vi.spyOn(fs, 'access').mockRejectedValue(new Error('EACCES'));
 
-    await expect(storage.initStorage()).rejects.toThrow('EACCES');
+    await expect(storage.initStorage()).rejects.toThrowError('EACCES');
     expect(mkdirMock).toHaveBeenCalledWith(baseDirectory, { recursive: true });
     expect(accessMock).toHaveBeenCalledWith(`${baseDirectory}${path.sep}port-forwards.json`);
   });
@@ -111,7 +111,7 @@ describe('PreferenceFolderBasedStorage', () => {
     const storage = new PreferenceFolderBasedStorage(baseDirectory);
     const mkdirMock = vi.spyOn(fs, 'mkdir').mockRejectedValue(new Error('EACCES'));
 
-    await expect(storage.initStorage()).rejects.toThrow('EACCES');
+    await expect(storage.initStorage()).rejects.toThrowError('EACCES');
     expect(mkdirMock).toHaveBeenCalledWith(baseDirectory, { recursive: true });
   });
 });
@@ -194,13 +194,15 @@ describe('FileBasedConfigStorage', () => {
     const storage = new TestFileBasedConfigStorage(mockFileStorage, 'test-key');
     storage['configs'] = [sampleConfig];
 
-    expect(() => storage._createForward(sampleConfig)).toThrow('Found existed forward configuration with the same id.');
+    expect(() => storage._createForward(sampleConfig)).toThrowError(
+      'Found existed forward configuration with the same id.',
+    );
   });
 
   test('should throw an error if deleting a non-existing forward configuration', () => {
     const storage = new TestFileBasedConfigStorage(mockFileStorage, 'test-key');
 
-    expect(() => storage._deleteForward(sampleConfig)).toThrow(
+    expect(() => storage._deleteForward(sampleConfig)).toThrowError(
       `Forward configuration with id ${sampleConfig.id} not found.`,
     );
   });
@@ -209,7 +211,7 @@ describe('FileBasedConfigStorage', () => {
     const storage = new TestFileBasedConfigStorage(mockFileStorage, 'test-key');
     const newConfig = { ...sampleConfig, displayName: 'new-display-name' };
 
-    expect(() => storage._updateForward(sampleConfig, newConfig)).toThrow(
+    expect(() => storage._updateForward(sampleConfig, newConfig)).toThrowError(
       `Forward configuration with id ${sampleConfig.id} not found.`,
     );
   });
@@ -291,13 +293,15 @@ describe('MemoryBasedConfigStorage', () => {
     const storage = new MemoryBasedStorage();
     storage['configs'] = [sampleConfig];
 
-    expect(() => storage.createForward(sampleConfig)).toThrow('Found existed forward configuration with the same id.');
+    expect(() => storage.createForward(sampleConfig)).toThrowError(
+      'Found existed forward configuration with the same id.',
+    );
   });
 
   test('should throw an error if deleting a non-existing forward configuration', () => {
     const storage = new MemoryBasedStorage();
 
-    expect(() => storage.deleteForward(sampleConfig)).toThrow(
+    expect(() => storage.deleteForward(sampleConfig)).toThrowError(
       `Forward configuration with id ${sampleConfig.id} not found.`,
     );
   });
@@ -306,7 +310,7 @@ describe('MemoryBasedConfigStorage', () => {
     const storage = new MemoryBasedStorage();
     const newConfig: ForwardConfig = { ...sampleConfig, namespace: 'new-ns' };
 
-    expect(() => storage.updateForward(sampleConfig, newConfig)).toThrow(
+    expect(() => storage.updateForward(sampleConfig, newConfig)).toThrowError(
       `Forward configuration with id ${sampleConfig.id} not found.`,
     );
   });

--- a/packages/extension/src/port-forward/port-forward-validation.spec.ts
+++ b/packages/extension/src/port-forward/port-forward-validation.spec.ts
@@ -42,7 +42,7 @@ describe('ForwardConfigRequirements', () => {
     const requirements = new ForwardConfigRequirements(portChecker);
     const invalidConfig = { ...validConfig, name: '' };
 
-    await expect(requirements.checkRuntimeRequirements(invalidConfig)).rejects.toThrow(
+    await expect(requirements.checkRuntimeRequirements(invalidConfig)).rejects.toThrowError(
       'Found empty resource (Pod, Deployment or Service) name.',
     );
   });
@@ -52,14 +52,14 @@ describe('ForwardConfigRequirements', () => {
     const requirements = new ForwardConfigRequirements(portChecker);
     const invalidConfig = { ...validConfig, namespace: '' };
 
-    await expect(requirements.checkRuntimeRequirements(invalidConfig)).rejects.toThrow('Found empty namespace.');
+    await expect(requirements.checkRuntimeRequirements(invalidConfig)).rejects.toThrowError('Found empty namespace.');
   });
 
   test('should fail if port is not available', async () => {
     const portChecker = vi.fn().mockRejectedValue(new Error('Port is already in use.'));
     const requirements = new ForwardConfigRequirements(portChecker);
 
-    await expect(requirements.checkRuntimeRequirements(validConfig)).rejects.toThrow();
+    await expect(requirements.checkRuntimeRequirements(validConfig)).rejects.toThrowError();
   });
 
   test('should propagate port check failures', async () => {
@@ -70,6 +70,8 @@ describe('ForwardConfigRequirements', () => {
       forward: { localPort: 8080, remotePort: 80 },
     };
 
-    await expect(requirements.checkRuntimeRequirements(multiPortConfig)).rejects.toThrow('Port 8081 is not available');
+    await expect(requirements.checkRuntimeRequirements(multiPortConfig)).rejects.toThrowError(
+      'Port 8081 is not available',
+    );
   });
 });


### PR DESCRIPTION
chore(vitest/eslint-plugin): replace toThrow() with its canonical name toThrowError()

This is done on the base of dependabot branch because it is not passing on main.