### PR TITLE
docs: fix label for running ci/e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ After each change, you may have to restart the extension from the `Extensions > 
 
 ### On the CI
 
-When creating a PR on the GitHub repository, the e2e tests are not executed by default. To run the e2e tests, you need to add the `ci/e2e` label to the PR.
+When creating a PR on the GitHub repository, the e2e tests are not executed by default. To run the e2e tests, you need to add the `area/ci/e2e` label to the PR.


### PR DESCRIPTION
I forgot to update the doc in PR #507 to change the label to use for running e2e tests on PR