### PR TITLE
ci: remove podman install

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -61,14 +61,6 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      # ==============================================
-      # Installing Podman
-      # ==============================================
-      - name: Install Podman v5 using external action
-        uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
         if: runner.os == 'Linux'
         run: |

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -17,12 +17,7 @@
  ***********************************************************************/
 
 import type { ExtensionsPage } from '@podman-desktop/tests-playwright';
-import {
-  expect as playExpect,
-  test,
-  RunnerOptions,
-  waitForPodmanMachineStartup,
-} from '@podman-desktop/tests-playwright';
+import { expect as playExpect, test, RunnerOptions } from '@podman-desktop/tests-playwright';
 import { KubernetesDashboardDetailsPage } from './model/kd-details-page';
 
 const EXTENSION_OCI_IMAGE =
@@ -53,12 +48,11 @@ test.use({
   }),
 });
 
-test.beforeAll(async ({ runner, welcomePage, page }) => {
+test.beforeAll(async ({ runner, welcomePage }) => {
   test.setTimeout(80_000);
 
   runner.setVideoAndTraceName('kubernetes-dashboard-e2e');
   await welcomePage.handleWelcomePage(true);
-  await waitForPodmanMachineStartup(page, 80_000); // default is 30s let's increase that to 80s
 });
 
 test.afterAll(async ({ runner }) => {


### PR DESCRIPTION
Remove podman install from CI and the check that the machine is running from tests

Podman is not necessary for the moment, as the tests will be done on an envtest env, which does not propagate resources to the containers provider.

https://github.com/podman-desktop/extension-kubernetes-dashboard/pull/507#discussion_r2620037059