### PR TITLE
ci(e2e): start envtest cluster for e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -138,7 +138,7 @@ jobs:
           path: tests/playwright/tests/playwright/output/kubernetes-dashboard-tests/plugins/
 
       # Run envtest cluster
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version: '1.25'
 
@@ -189,10 +189,10 @@ jobs:
         env:
           ENVTEST_START_PID: ${{ steps.run-envtest.outputs.ENVTEST_START_PID }}
         shell: bash
+        # These commands are working on both Linux and Windows, change carefully
         run: |
-          kill $ENVTEST_START_PID
-          # give some time for the cluster to be stopped gracefully
-          sleep 3
+          kill ${ENVTEST_START_PID}
+          timeout 10s bash -c "while ps | grep envtest-start > /dev/null; do sleep 1; done"
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()


### PR DESCRIPTION
Start a Kubernetes cluster using envtest for e2e tests. The cluster is not used for the moment in the tests, this will come in follow-up PRs.

Check the action result, to see if the cluster s started correctly:

<img width="667" height="103" alt="envtest-running" src="https://github.com/user-attachments/assets/5c778950-b45c-4e75-ab79-68d87683b6c5" />

Fixes #76 