### PR TITLE
fix: make npmjs-publish triggered when release is cut

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
+          token: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
+          
       - name: Generate tag utilities
         id: TAG_UTIL
         run: |


### PR DESCRIPTION
Related problem on podman-desktop: https://github.com/podman-desktop/podman-desktop/issues/15279

Fixes #601 