### PR TITLE
feat: select logs colorization

### DIFF
--- a/packages/webview/src/component/pods/PodLogs.spec.ts
+++ b/packages/webview/src/component/pods/PodLogs.spec.ts
@@ -75,7 +75,7 @@ describe('pod with one container', async () => {
   });
 
   test('display No Log with no logs', async () => {
-    render(PodLogs, { object: pod });
+    render(PodLogs, { object: pod, colorizer: 'no colors' });
     await vi.advanceTimersByTimeAsync(1_100);
     expect(EmptyScreen).toHaveBeenCalled();
   });
@@ -90,7 +90,7 @@ describe('pod with one container', async () => {
       props.terminal = mockedTerminal;
       return {};
     });
-    render(PodLogs, { object: pod });
+    render(PodLogs, { object: pod, colorizer: 'no colors' });
     expect(mockedTerminal.write).not.toHaveBeenCalledWith();
     expect(mockedTerminal.clear).toHaveBeenCalled();
     expect(TerminalWindow).toHaveBeenCalled();
@@ -133,7 +133,7 @@ describe('pod with two containers', async () => {
   });
 
   test('display No Log with no logs', async () => {
-    render(PodLogs, { object: pod });
+    render(PodLogs, { object: pod, colorizer: 'no colors' });
     await vi.advanceTimersByTimeAsync(1_100);
     expect(EmptyScreen).toHaveBeenCalled();
   });
@@ -148,7 +148,7 @@ describe('pod with two containers', async () => {
       props.terminal = mockedTerminal;
       return {};
     });
-    render(PodLogs, { object: pod });
+    render(PodLogs, { object: pod, colorizer: 'no colors' });
     expect(mockedTerminal.write).not.toHaveBeenCalledWith();
     expect(mockedTerminal.clear).toHaveBeenCalled();
     expect(TerminalWindow).toHaveBeenCalled();
@@ -193,7 +193,7 @@ describe('pod with two containers, one container selected', async () => {
   });
 
   test('display No Log with no logs', async () => {
-    render(PodLogs, { object: pod, containerName: 'cnt1' });
+    render(PodLogs, { object: pod, containerName: 'cnt1', colorizer: 'no colors' });
     await vi.advanceTimersByTimeAsync(1_100);
     expect(EmptyScreen).toHaveBeenCalled();
   });
@@ -208,7 +208,7 @@ describe('pod with two containers, one container selected', async () => {
       props.terminal = mockedTerminal;
       return {};
     });
-    render(PodLogs, { object: pod, containerName: 'cnt1' });
+    render(PodLogs, { object: pod, containerName: 'cnt1', colorizer: 'no colors' });
     expect(mockedTerminal.write).not.toHaveBeenCalledWith();
     expect(mockedTerminal.clear).toHaveBeenCalled();
     expect(TerminalWindow).toHaveBeenCalled();

--- a/packages/webview/src/component/pods/PodLogs.svelte
+++ b/packages/webview/src/component/pods/PodLogs.svelte
@@ -14,8 +14,9 @@ interface Props {
   object: V1Pod;
   // undefined means logs for all containers are displayed
   containerName?: string;
+  colorizer: string;
 }
-let { object, containerName }: Props = $props();
+let { object, containerName, colorizer }: Props = $props();
 
 // Logs has been initialized
 let noLogs = $state<boolean>();
@@ -28,13 +29,13 @@ const streams = getContext<Streams>(Streams);
 const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
 const podLogsHelper = dependencyAccessor.get<PodLogsHelper>(PodLogsHelper);
 
-// This component is not reactive, it must be unmounted and mounted again when the container name changes
+// This component is not reactive, it must be unmounted and mounted again when options change
 // using the #key directive
 onMount(async () => {
   const containers =
     (containerName ? object.spec?.containers.filter(c => c.name === containerName) : object.spec?.containers) ?? [];
 
-  podLogsHelper.init(containers);
+  podLogsHelper.init(containers, colorizer);
   logsTerminal?.clear();
 
   for (const name of containers.map(c => c.name)) {

--- a/packages/webview/src/component/pods/PodLogsCustomizable.svelte
+++ b/packages/webview/src/component/pods/PodLogsCustomizable.svelte
@@ -3,11 +3,17 @@ import type { V1Pod } from '@kubernetes/client-node';
 import { Dropdown, EmptyScreen } from '@podman-desktop/ui-svelte';
 import NoLogIcon from '/@/component/icons/NoLogIcon.svelte';
 import PodLogs from '/@/component/pods/PodLogs.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { PodLogsHelper } from '/@/component/pods/pod-logs-helper';
 
 interface Props {
   object: V1Pod;
 }
 let { object }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const podLogsHelper = dependencyAccessor.get<PodLogsHelper>(PodLogsHelper);
 
 const runningContainers = $derived(object.status?.containerStatuses?.filter(status => status.state?.running) ?? []);
 
@@ -21,28 +27,38 @@ let containerSelection = $derived([
     value: container.name,
   })),
 ]);
+
+let selectedColorizer = $state<string>(podLogsHelper.getColorizers()[0]);
+let colorizerSelection = podLogsHelper.getColorizers().map(colorizer => ({ label: colorizer, value: colorizer }));
 </script>
 
 {#if runningContainers.length > 0}
   <div class="flex grow flex-col h-full w-full">
-    {#if runningContainers.length > 1}
-      <div class="flex p-2 h-[40px] w-full">
-        <div class="w-full">
+    <div class="flex flex-row p-2 h-[40px] gap-2">
+      {#if runningContainers.length > 1}
+        <div class="w-48">
           <Dropdown
             ariaLabel="Select container"
-            class="w-48"
             name="container"
             bind:value={selectedContainerName}
             options={containerSelection}>
           </Dropdown>
         </div>
+      {/if}
+      <div class="w-48">
+        <Dropdown
+          ariaLabel="Select colorization"
+          name="colorizer"
+          bind:value={selectedColorizer}
+          options={colorizerSelection}>
+        </Dropdown>
       </div>
-    {/if}
+    </div>
 
     <div class="flex w-full h-full min-h-0">
-      {#key selectedContainerName}
+      {#key [selectedContainerName, selectedColorizer]}
         {#if selectedContainerName !== undefined}
-          <PodLogs object={object} containerName={selectedContainerName} />
+          <PodLogs object={object} containerName={selectedContainerName} colorizer={selectedColorizer} />
         {/if}
       {/key}
     </div>

--- a/packages/webview/src/component/pods/pod-logs-helper.spec.ts
+++ b/packages/webview/src/component/pods/pod-logs-helper.spec.ts
@@ -28,11 +28,24 @@ test('should colorize content and container name', () => {
   // we are just testing one case of log level, to be sure the helper is called, the rest is tested in the specs of logs level colorization.
   const multiContainersLogsHelper = new MultiContainersLogsHelper();
   const helper = new PodLogsHelper(multiContainersLogsHelper);
-  helper.init([{ name: 'cnt1' }, { name: 'container2' }]);
+  helper.init([{ name: 'cnt1' }, { name: 'container2' }], 'log level colors');
 
   const result1 = helper.transformPodLogs('cnt1', 'line before\n[ERROR] some logs\nline after\n');
   expect(result1).toEqual(`      \u001b[36mcnt1\u001b[0m|line before
       \u001b[36mcnt1\u001b[0m|\u001b[31;1m[ERROR]\u001b[0m some logs
+      \u001b[36mcnt1\u001b[0m|line after
+`);
+});
+
+test('should colorize container name but no content', () => {
+  // we are just testing one case of log level, to be sure the helper is called, the rest is tested in the specs of logs level colorization.
+  const multiContainersLogsHelper = new MultiContainersLogsHelper();
+  const helper = new PodLogsHelper(multiContainersLogsHelper);
+  helper.init([{ name: 'cnt1' }, { name: 'container2' }], 'no colors');
+
+  const result1 = helper.transformPodLogs('cnt1', 'line before\n[ERROR] some logs\nline after\n');
+  expect(result1).toEqual(`      \u001b[36mcnt1\u001b[0m|line before
+      \u001b[36mcnt1\u001b[0m|[ERROR] some logs
       \u001b[36mcnt1\u001b[0m|line after
 `);
 });


### PR DESCRIPTION
In the Logs page of logs, the user can select how the logs are colorized:
- log level colors: current colorization mode, highlighting the level words (info, error, etc)
- no colors
