### PR TITLE
feat: select timestamp in pod logs UI

### DIFF
--- a/packages/webview/src/component/pods/PodLogs.spec.ts
+++ b/packages/webview/src/component/pods/PodLogs.spec.ts
@@ -18,7 +18,7 @@
 
 import { render } from '@testing-library/svelte';
 import { RemoteMocks } from '/@/tests/remote-mocks';
-import { API_POD_LOGS, type PodLogsChunk, type PodLogsApi } from '@kubernetes-dashboard/channels';
+import { API_POD_LOGS, type PodLogsChunk, type PodLogsApi, type PodLogsOptions } from '@kubernetes-dashboard/channels';
 import { StreamsMocks } from '/@/tests/stream-mocks';
 import { FakeStreamObject } from '/@/stream/util/fake-stream-object.svelte';
 import PodLogs from './PodLogs.svelte';
@@ -37,13 +37,13 @@ const remoteMocks = new RemoteMocks();
 const streamMocks = new StreamsMocks();
 const dependencyMocks = new DependencyMocks();
 
-const streamPodLogsMock = new FakeStreamObject<PodLogsChunk, void>();
+const streamPodLogsMock = new FakeStreamObject<PodLogsChunk, PodLogsOptions>();
 
 beforeEach(() => {
   vi.resetAllMocks();
   vi.useFakeTimers();
   streamMocks.reset();
-  streamMocks.mock<PodLogsChunk, void>('streamPodLogs', streamPodLogsMock);
+  streamMocks.mock<PodLogsChunk, PodLogsOptions>('streamPodLogs', streamPodLogsMock);
 
   remoteMocks.reset();
   remoteMocks.mock(API_POD_LOGS, {} as unknown as PodLogsApi);
@@ -75,7 +75,7 @@ describe('pod with one container', async () => {
   });
 
   test('display No Log with no logs', async () => {
-    render(PodLogs, { object: pod, colorizer: 'no colors' });
+    render(PodLogs, { object: pod, colorizer: 'no colors', timestamps: false });
     await vi.advanceTimersByTimeAsync(1_100);
     expect(EmptyScreen).toHaveBeenCalled();
   });
@@ -90,7 +90,7 @@ describe('pod with one container', async () => {
       props.terminal = mockedTerminal;
       return {};
     });
-    render(PodLogs, { object: pod, colorizer: 'no colors' });
+    render(PodLogs, { object: pod, colorizer: 'no colors', timestamps: false });
     expect(mockedTerminal.write).not.toHaveBeenCalledWith();
     expect(mockedTerminal.clear).toHaveBeenCalled();
     expect(TerminalWindow).toHaveBeenCalled();
@@ -133,7 +133,7 @@ describe('pod with two containers', async () => {
   });
 
   test('display No Log with no logs', async () => {
-    render(PodLogs, { object: pod, colorizer: 'no colors' });
+    render(PodLogs, { object: pod, colorizer: 'no colors', timestamps: false });
     await vi.advanceTimersByTimeAsync(1_100);
     expect(EmptyScreen).toHaveBeenCalled();
   });
@@ -148,7 +148,7 @@ describe('pod with two containers', async () => {
       props.terminal = mockedTerminal;
       return {};
     });
-    render(PodLogs, { object: pod, colorizer: 'no colors' });
+    render(PodLogs, { object: pod, colorizer: 'no colors', timestamps: false });
     expect(mockedTerminal.write).not.toHaveBeenCalledWith();
     expect(mockedTerminal.clear).toHaveBeenCalled();
     expect(TerminalWindow).toHaveBeenCalled();
@@ -193,7 +193,7 @@ describe('pod with two containers, one container selected', async () => {
   });
 
   test('display No Log with no logs', async () => {
-    render(PodLogs, { object: pod, containerName: 'cnt1', colorizer: 'no colors' });
+    render(PodLogs, { object: pod, containerName: 'cnt1', colorizer: 'no colors', timestamps: false });
     await vi.advanceTimersByTimeAsync(1_100);
     expect(EmptyScreen).toHaveBeenCalled();
   });
@@ -208,7 +208,7 @@ describe('pod with two containers, one container selected', async () => {
       props.terminal = mockedTerminal;
       return {};
     });
-    render(PodLogs, { object: pod, containerName: 'cnt1', colorizer: 'no colors' });
+    render(PodLogs, { object: pod, containerName: 'cnt1', colorizer: 'no colors', timestamps: false });
     expect(mockedTerminal.write).not.toHaveBeenCalledWith();
     expect(mockedTerminal.clear).toHaveBeenCalled();
     expect(TerminalWindow).toHaveBeenCalled();

--- a/packages/webview/src/component/pods/PodLogs.svelte
+++ b/packages/webview/src/component/pods/PodLogs.svelte
@@ -15,8 +15,9 @@ interface Props {
   // undefined means logs for all containers are displayed
   containerName?: string;
   colorizer: string;
+  timestamps: boolean;
 }
-let { object, containerName, colorizer }: Props = $props();
+let { object, containerName, colorizer, timestamps }: Props = $props();
 
 // Logs has been initialized
 let noLogs = $state<boolean>();
@@ -44,7 +45,7 @@ onMount(async () => {
         object.metadata?.name ?? '',
         object.metadata?.namespace ?? '',
         name,
-        undefined,
+        { timestamps },
         chunk => {
           const data = podLogsHelper.transformPodLogs(name, chunk.data);
           if (noLogs !== false) {

--- a/packages/webview/src/component/pods/PodLogsCustomizable.spec.ts
+++ b/packages/webview/src/component/pods/PodLogsCustomizable.spec.ts
@@ -80,6 +80,7 @@ test('renders with 2 containers running', async () => {
     object: fakePod2containersRunning,
     containerName: '',
     colorizer: 'colorizer 1',
+    timestamps: false,
   });
 
   await userEvent.click(containerDropdownButton);
@@ -89,6 +90,7 @@ test('renders with 2 containers running', async () => {
     object: fakePod2containersRunning,
     containerName: 'container2',
     colorizer: 'colorizer 1',
+    timestamps: false,
   });
 
   await userEvent.click(colorizerDropdownButton);
@@ -98,6 +100,7 @@ test('renders with 2 containers running', async () => {
     object: fakePod2containersRunning,
     containerName: 'container2',
     colorizer: 'colorizer 2',
+    timestamps: false,
   });
 });
 
@@ -115,5 +118,6 @@ test('renders with 1 container running', async () => {
     object: fakePod1containerRunning,
     containerName: '',
     colorizer: 'colorizer 2',
+    timestamps: false,
   });
 });

--- a/packages/webview/src/component/pods/PodLogsCustomizable.svelte
+++ b/packages/webview/src/component/pods/PodLogsCustomizable.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { V1Pod } from '@kubernetes/client-node';
-import { Dropdown, EmptyScreen } from '@podman-desktop/ui-svelte';
+import { Checkbox, Dropdown, EmptyScreen } from '@podman-desktop/ui-svelte';
 import NoLogIcon from '/@/component/icons/NoLogIcon.svelte';
 import PodLogs from '/@/component/pods/PodLogs.svelte';
 import { getContext } from 'svelte';
@@ -19,6 +19,7 @@ const runningContainers = $derived(object.status?.containerStatuses?.filter(stat
 
 // If no container is selected, logs for all containers are displayed
 let selectedContainerName = $state<string>('');
+let selectedTimestamps = $state<boolean>(false);
 
 let containerSelection = $derived([
   { label: 'All containers', value: '' },
@@ -53,12 +54,20 @@ let colorizerSelection = podLogsHelper.getColorizers().map(colorizer => ({ label
           options={colorizerSelection}>
         </Dropdown>
       </div>
+      <div class="w-48">
+        <Checkbox class="pt-2" name="timestamps" title="Show timestamps" bind:checked={selectedTimestamps}
+          >Show timestamps</Checkbox>
+      </div>
     </div>
 
     <div class="flex w-full h-full min-h-0">
-      {#key [selectedContainerName, selectedColorizer]}
+      {#key [selectedContainerName, selectedColorizer, selectedTimestamps]}
         {#if selectedContainerName !== undefined}
-          <PodLogs object={object} containerName={selectedContainerName} colorizer={selectedColorizer} />
+          <PodLogs
+            object={object}
+            containerName={selectedContainerName}
+            colorizer={selectedColorizer}
+            timestamps={selectedTimestamps} />
         {/if}
       {/key}
     </div>

--- a/packages/webview/src/stream/pod-logs.spec.ts
+++ b/packages/webview/src/stream/pod-logs.spec.ts
@@ -55,22 +55,10 @@ test('StreamPodLogs', async () => {
   const callback1: (chunk: PodLogsChunk) => void = vi.fn();
   const callback2: (chunk: PodLogsChunk) => void = vi.fn();
 
-  const subscribeResult1 = await streamPodLogs.subscribe(
-    'podName',
-    'namespace',
-    'containerName1',
-    undefined,
-    callback1,
-  );
-  const subscribeResult2 = await streamPodLogs.subscribe(
-    'podName',
-    'namespace',
-    'containerName2',
-    undefined,
-    callback2,
-  );
-  expect(podLogsApiMock.streamPodLogs).toHaveBeenCalledWith('podName', 'namespace', 'containerName1');
-  expect(podLogsApiMock.streamPodLogs).toHaveBeenCalledWith('podName', 'namespace', 'containerName2');
+  const subscribeResult1 = await streamPodLogs.subscribe('podName', 'namespace', 'containerName1', {}, callback1);
+  const subscribeResult2 = await streamPodLogs.subscribe('podName', 'namespace', 'containerName2', {}, callback2);
+  expect(podLogsApiMock.streamPodLogs).toHaveBeenCalledWith('podName', 'namespace', 'containerName1', {});
+  expect(podLogsApiMock.streamPodLogs).toHaveBeenCalledWith('podName', 'namespace', 'containerName2', {});
   expect(rpcBrowserMock.on).toHaveBeenCalledTimes(2);
   const chunkCallback1 = vi.mocked(rpcBrowserMock.on).mock.calls[0][1];
   const chunkCallback2 = vi.mocked(rpcBrowserMock.on).mock.calls[1][1];

--- a/packages/webview/src/stream/pod-logs.ts
+++ b/packages/webview/src/stream/pod-logs.ts
@@ -24,11 +24,12 @@ import {
   type PodLogsApi,
   type PodLogsChunk,
   type IDisposable,
+  type PodLogsOptions,
 } from '@kubernetes-dashboard/channels';
 import { RpcBrowser } from '@kubernetes-dashboard/rpc';
 import type { StreamObject } from './util/stream-object';
 
-export class StreamPodLogs implements StreamObject<PodLogsChunk, void> {
+export class StreamPodLogs implements StreamObject<PodLogsChunk, PodLogsOptions> {
   #podLogsApi: PodLogsApi;
 
   constructor(
@@ -41,7 +42,7 @@ export class StreamPodLogs implements StreamObject<PodLogsChunk, void> {
     podName: string,
     namespace: string,
     containerName: string,
-    options: void,
+    options: PodLogsOptions,
     callback: (data: PodLogsChunk) => void,
   ): Promise<IDisposable> {
     const disposable = this.rpcBrowser.on(POD_LOGS, chunk => {
@@ -50,7 +51,7 @@ export class StreamPodLogs implements StreamObject<PodLogsChunk, void> {
       }
       callback(chunk);
     });
-    await this.#podLogsApi.streamPodLogs(podName, namespace, containerName);
+    await this.#podLogsApi.streamPodLogs(podName, namespace, containerName, options);
     return {
       dispose: () => {
         disposable.dispose();

--- a/packages/webview/src/stream/pod-terminals.ts
+++ b/packages/webview/src/stream/pod-terminals.ts
@@ -36,7 +36,7 @@ export class StreamPodTerminals implements StreamObject<PodTerminalChunk, void> 
     podName: string,
     namespace: string,
     containerName: string,
-    options: void,
+    _: void,
     callback: (data: PodTerminalChunk) => void,
   ): Promise<IDisposable> {
     const disposable = this.rpcBrowser.on(POD_TERMINAL_DATA, chunk => {

--- a/packages/webview/src/tests/stream-mocks.ts
+++ b/packages/webview/src/tests/stream-mocks.ts
@@ -27,12 +27,12 @@ import type { StreamObject } from '/@/stream/util/stream-object';
  *
  * ```
  *  const streamMocks = new StreamsMocks();
- *  const streamPodTerminalsMock = new FakeStreamObject<PodTerminalChunk, Options>();
+ *  const streamPodTerminalsMock = new FakeStreamObject<PodTerminalChunk, void>();
  *
  *  beforeEach(() => {
  *    vi.resetAllMocks();
  *    streamMocks.reset();
- *    streamMocks.mock<PodTerminalChunk, Options>('streamPodTerminals', streamPodTerminalsMock);
+ *    streamMocks.mock<PodTerminalChunk, void>('streamPodTerminals', streamPodTerminalsMock);
  *  });
  *
  *  test('test with states', () => {


### PR DESCRIPTION
Adds a "Show timestamps" in the Pod Logs page, to select if timestamps must be displayed at the beginning of each log line.

https://github.com/user-attachments/assets/f458b4af-4635-4a21-8495-f4070d03fc83


Related to #524 