### PR TITLE
feat: configure pod logs colors with annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ A dedicated page lists the existing port forwardings, from which you can visit e
 
 The Kubernetes Dashboard checks Read permissions on each resource, and indicates in the Dashboard and in the pages listing the resources if the current user does not have read access on a resource.
 
+## Annotations
+
+The user interface supports configuration using annotations on resources. The following annotations are supported:
+
+### On Pods
+- `kubernetes-dashboard.podman-desktop.io/logs-colors: "log level colors"`  
+Colorize logs levels (by default)
+- `kubernetes-dashboard.podman-desktop.io/logs-colors: "no colors"`  
+Disable colorization of logs
+
 # Installation
 
 ## Install latest release

--- a/packages/webview/src/annotations/_annotations-module.ts
+++ b/packages/webview/src/annotations/_annotations-module.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { Annotations } from '/@/annotations/annotations';
+
+const annotationsModule = new ContainerModule(options => {
+  options.bind<Annotations>(Annotations).toSelf().inSingletonScope();
+});
+
+export { annotationsModule };

--- a/packages/webview/src/annotations/annotations.spec.ts
+++ b/packages/webview/src/annotations/annotations.spec.ts
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { describe, expect, test } from 'vitest';
+import { Annotations, type AnnotationsMap } from './annotations';
+
+class AnnotationsTest extends Annotations {
+  public filterByDomain(annotations: AnnotationsMap, domain: string): AnnotationsMap {
+    return super.filterByDomain(annotations, domain);
+  }
+  public filterByKey(annotations: AnnotationsMap, key: string): AnnotationsMap {
+    return super.filterByKey(annotations, key);
+  }
+}
+describe('Annotations', () => {
+  test('undefined annotations map gives empty result, not undefined', () => {
+    const annotations = new AnnotationsTest();
+    const annotationsKey1 = annotations.getAnnotations(undefined, { key: 'key1' });
+    expect(annotationsKey1).toEqual({});
+  });
+
+  test('should filter annotations by domain', () => {
+    const annotations = new AnnotationsTest();
+    const annotationsMap = {
+      'kubernetes-dashboard.podman-desktop.io/key1.container1': 'value1',
+      'kubernetes-dashboard.podman-desktop.io/key2': 'value2',
+      'other-domain.example.com/key3': 'value3',
+      key4: 'value4',
+    };
+    const domainAnnotations = annotations.filterByDomain(annotationsMap, 'kubernetes-dashboard.podman-desktop.io');
+    expect(domainAnnotations).toEqual({
+      'key1.container1': 'value1',
+      key2: 'value2',
+    });
+    expect(annotations.filterByKey(domainAnnotations, 'key1')).toEqual({
+      'key1.container1': 'value1',
+    });
+    expect(annotations.filterByKey(domainAnnotations, 'key2')).toEqual({
+      key2: 'value2',
+    });
+
+    const directAnnotationsKey1 = annotations.getAnnotations({ annotations: annotationsMap }, { key: 'key1' });
+    expect(directAnnotationsKey1).toEqual({ 'key1.container1': 'value1' });
+    const directAnnotationsKey2 = annotations.getAnnotations({ annotations: annotationsMap }, { key: 'key2' });
+    expect(directAnnotationsKey2).toEqual({ key2: 'value2' });
+  });
+});

--- a/packages/webview/src/annotations/annotations.ts
+++ b/packages/webview/src/annotations/annotations.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { injectable } from 'inversify';
+import type { V1ObjectMeta } from '@kubernetes/client-node';
+
+export type AnnotationsMap = { [key: string]: string };
+
+export interface GetAnnotationOptions {
+  key: string;
+}
+
+@injectable()
+export class Annotations {
+  #domain = 'kubernetes-dashboard.podman-desktop.io';
+
+  public getAnnotations(metadata: V1ObjectMeta | undefined, options: GetAnnotationOptions): AnnotationsMap {
+    return this.filterByKey(this.filterByDomain(metadata?.annotations ?? {}, this.#domain), options.key);
+  }
+
+  // filter annotations by domain and REMOVE domain prefix
+  protected filterByDomain(annotations: AnnotationsMap, domain: string): AnnotationsMap {
+    return Object.fromEntries(
+      Object.entries(annotations)
+        .filter(([key]) => key.startsWith(`${domain}/`))
+        .map(([key, value]) => [key.replace(`${domain}/`, ''), value]),
+    );
+  }
+
+  // filter annotations by key and KEEP domain prefix
+  protected filterByKey(annotations: AnnotationsMap, key: string): AnnotationsMap {
+    return Object.fromEntries(Object.entries(annotations).filter(([k]) => k.startsWith(`${key}.`) || k === key));
+  }
+}

--- a/packages/webview/src/component/pods/PodLogsCustomizable.spec.ts
+++ b/packages/webview/src/component/pods/PodLogsCustomizable.spec.ts
@@ -26,6 +26,7 @@ import PodLogsCustomizable from '/@/component/pods/PodLogsCustomizable.svelte';
 import PodLogs from '/@/component/pods/PodLogs.svelte';
 import { DependencyMocks } from '/@/tests/dependency-mocks';
 import { PodLogsHelper } from '/@/component/pods/pod-logs-helper';
+import { Annotations } from '/@/annotations/annotations';
 
 vi.mock(import('./PodLogs.svelte'));
 
@@ -63,6 +64,8 @@ beforeEach(() => {
   dependencyMocks.reset();
   dependencyMocks.mock(PodLogsHelper);
   vi.mocked(dependencyMocks.get(PodLogsHelper).getColorizers).mockReturnValue(['colorizer 1', 'colorizer 2']);
+  dependencyMocks.mock(Annotations);
+  vi.mocked(dependencyMocks.get(Annotations).getAnnotations).mockReturnValue({});
 });
 
 test('renders with no container running', () => {
@@ -111,6 +114,19 @@ test('renders with 1 container running', async () => {
   await userEvent.click(colorizerDropdownButton);
   const colorizer2 = within(colorizerDropdown).getByText('colorizer 2');
   await userEvent.click(colorizer2);
+  expect(vi.mocked(PodLogs)).toHaveBeenCalledWith(expect.anything(), {
+    object: fakePod1containerRunning,
+    containerName: '',
+    colorizer: 'colorizer 2',
+  });
+});
+
+test('renders with 1 container running with colors annotation', async () => {
+  vi.mocked(dependencyMocks.get(Annotations).getAnnotations).mockReturnValue({ 'logs-colors': 'colorizer 2' });
+  vi.mocked(dependencyMocks.get(PodLogsHelper).resolveColorizer).mockImplementation(s => s ?? 'colorizer 1');
+
+  render(PodLogsCustomizable, { object: fakePod1containerRunning });
+
   expect(vi.mocked(PodLogs)).toHaveBeenCalledWith(expect.anything(), {
     object: fakePod1containerRunning,
     containerName: '',

--- a/packages/webview/src/component/pods/PodLogsCustomizable.svelte
+++ b/packages/webview/src/component/pods/PodLogsCustomizable.svelte
@@ -6,6 +6,7 @@ import PodLogs from '/@/component/pods/PodLogs.svelte';
 import { getContext } from 'svelte';
 import { DependencyAccessor } from '/@/inject/dependency-accessor';
 import { PodLogsHelper } from '/@/component/pods/pod-logs-helper';
+import { Annotations } from '/@/annotations/annotations';
 
 interface Props {
   object: V1Pod;
@@ -14,8 +15,11 @@ let { object }: Props = $props();
 
 const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
 const podLogsHelper = dependencyAccessor.get<PodLogsHelper>(PodLogsHelper);
+const annotations = dependencyAccessor.get<Annotations>(Annotations);
 
 const runningContainers = $derived(object.status?.containerStatuses?.filter(status => status.state?.running) ?? []);
+
+const colorsAnnotations = $derived(annotations.getAnnotations(object.metadata, { key: 'logs-colors' }));
 
 // If no container is selected, logs for all containers are displayed
 let selectedContainerName = $state<string>('');
@@ -28,7 +32,7 @@ let containerSelection = $derived([
   })),
 ]);
 
-let selectedColorizer = $state<string>(podLogsHelper.getColorizers()[0]);
+let selectedColorizer = $derived<string>(podLogsHelper.resolveColorizer(colorsAnnotations['logs-colors']));
 let colorizerSelection = podLogsHelper.getColorizers().map(colorizer => ({ label: colorizer, value: colorizer }));
 </script>
 

--- a/packages/webview/src/component/pods/pod-logs-helper.spec.ts
+++ b/packages/webview/src/component/pods/pod-logs-helper.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,4 +48,25 @@ test('should colorize container name but no content', () => {
       \u001b[36mcnt1\u001b[0m|[ERROR] some logs
       \u001b[36mcnt1\u001b[0m|line after
 `);
+});
+
+test('should resolve undefined as default colorizer', () => {
+  const multiContainersLogsHelper = new MultiContainersLogsHelper();
+  const helper = new PodLogsHelper(multiContainersLogsHelper);
+  const result = helper.resolveColorizer();
+  expect(result).toEqual('log level colors');
+});
+
+test('should resolve unknown colorizer as default colorizer', () => {
+  const multiContainersLogsHelper = new MultiContainersLogsHelper();
+  const helper = new PodLogsHelper(multiContainersLogsHelper);
+  const result = helper.resolveColorizer('unknown colorizer');
+  expect(result).toEqual('log level colors');
+});
+
+test('should resolve known colorizer as itself', () => {
+  const multiContainersLogsHelper = new MultiContainersLogsHelper();
+  const helper = new PodLogsHelper(multiContainersLogsHelper);
+  const result = helper.resolveColorizer('no colors');
+  expect(result).toEqual('no colors');
 });

--- a/packages/webview/src/component/pods/pod-logs-helper.ts
+++ b/packages/webview/src/component/pods/pod-logs-helper.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,5 +49,13 @@ export class PodLogsHelper {
 
   getColorizers(): string[] {
     return Object.keys(this.#colorizerFunctions);
+  }
+
+  // returns colorizer if found, otherwise returns default colorizer
+  resolveColorizer(colorizer?: string): string {
+    if (!colorizer || !this.#colorizerFunctions[colorizer]) {
+      return this.getColorizers()[0];
+    }
+    return colorizer;
   }
 }

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import { jobsModule } from '/@/component/jobs/_jobs-module';
 import { cronjobsModule } from '/@/component/cronjobs/_cronjobs-module';
 import { podsModule } from '/@/component/pods/_pods-module';
 import { streamsModule } from '/@/stream/stream-module';
+import { annotationsModule } from '/@/annotations/_annotations-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -70,6 +71,7 @@ export class InversifyBinding {
     await this.#container.load(jobsModule);
     await this.#container.load(cronjobsModule);
     await this.#container.load(podsModule);
+    await this.#container.load(annotationsModule);
 
     return this.#container;
   }


### PR DESCRIPTION
Related to #542 (same colorization for all containers) 

Below in the demo (the default is to colorize the logs levels), the user can change to 'no colors' either from kubectl, or from the extension (Patch tab)

https://github.com/user-attachments/assets/5a5fb4da-c844-43bd-8448-fa304e267688

