### PR TITLE
feat: configure logs timestamps with annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The user interface supports configuration using annotations on resources. The fo
 Colorize logs levels (by default)
 - `kubernetes-dashboard.podman-desktop.io/logs-colors: "no colors"`  
 Disable colorization of logs
+- `kubernetes-dashboard.podman-desktop.io/logs-timestamps: "true"`  
+Prefix the logs of the pod's containers with timestamps.
 
 # Installation
 

--- a/packages/webview/src/component/pods/PodLogsCustomizable.spec.ts
+++ b/packages/webview/src/component/pods/PodLogsCustomizable.spec.ts
@@ -138,3 +138,23 @@ test('renders with 1 container running with colors annotation', async () => {
     timestamps: false,
   });
 });
+
+test('renders with 1 container running with timestamps annotation', async () => {
+  vi.mocked(dependencyMocks.get(Annotations).getAnnotations).mockReturnValue({ 'logs-timestamps': 'true' });
+
+  render(PodLogsCustomizable, { object: fakePod1containerRunning });
+  expect(screen.queryByText('container1')).not.toBeInTheDocument();
+
+  const colorizerDropdown = screen.getByLabelText('Select colorization');
+  const colorizerDropdownButton = within(colorizerDropdown).getByText('colorizer 1');
+
+  await userEvent.click(colorizerDropdownButton);
+  const colorizer2 = within(colorizerDropdown).getByText('colorizer 2');
+  await userEvent.click(colorizer2);
+  expect(vi.mocked(PodLogs)).toHaveBeenCalledWith(expect.anything(), {
+    object: fakePod1containerRunning,
+    containerName: '',
+    colorizer: 'colorizer 2',
+    timestamps: true,
+  });
+});

--- a/packages/webview/src/component/pods/PodLogsCustomizable.svelte
+++ b/packages/webview/src/component/pods/PodLogsCustomizable.svelte
@@ -20,10 +20,11 @@ const annotations = dependencyAccessor.get<Annotations>(Annotations);
 const runningContainers = $derived(object.status?.containerStatuses?.filter(status => status.state?.running) ?? []);
 
 const colorsAnnotations = $derived(annotations.getAnnotations(object.metadata, { key: 'logs-colors' }));
+const timestampsAnnotations = $derived(annotations.getAnnotations(object.metadata, { key: 'logs-timestamps' }));
 
 // If no container is selected, logs for all containers are displayed
 let selectedContainerName = $state<string>('');
-let selectedTimestamps = $state<boolean>(false);
+let selectedTimestamps = $derived<boolean>(timestampsAnnotations['logs-timestamps'] === 'true');
 
 let containerSelection = $derived([
   { label: 'All containers', value: '' },


### PR DESCRIPTION
Fixes #648 

To test:
create a pod (mylog), go to the pod's logs tab, then run the commands:
```
# set timestamps annotation to true
kubectl annotate --overwrite pod/mylog "kubernetes-dashboard.podman-desktop.io/logs-timestamps=true"

# remove timestamps annotation
kubectl annotate --overwrite pod/mylog "kubernetes-dashboard.podman-desktop.io/logs-timestamps-"
```