### PR TITLE
docs(AGENTS): injection via constructor or property

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ The project uses **Inversify** for DI. When adding new services:
 1. Define interfaces for services
 2. Create implementations with `@injectable()` decorator
 3. Bind in the appropriate binding file (`inversify-binding.ts`)
-4. Inject dependencies via constructor
+4. Inject dependencies via constructor or via property
 
 ### Stream Objects
 


### PR DESCRIPTION
The code is using both solutions for injecting dependencies in classes, either via constructor or via property.

Let's change the AGENTS.md to avoid agents promoting the injection via constructor, as it is not clear at the moment which one should be the best the choose.

Example of agent feedback: https://github.com/podman-desktop/extension-kubernetes-dashboard/pull/665#pullrequestreview-3722424161