### PR TITLE
feat: add telemetry on delete/no context/set namespace

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 - 2025 Red Hat, Inc.
+ * Copyright (C) 2024 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,7 +133,7 @@ export class ContextsManager implements ContextsApi {
   onEndpointsChange: Event<void> = this.#onEndpointsChange.event;
 
   @inject(TelemetryLoggerSymbol)
-  readonly telemetryLogger: TelemetryLogger;
+  protected telemetryLogger: TelemetryLogger;
 
   constructor() {
     this.#currentKubeConfig = new KubeConfig();
@@ -518,6 +518,7 @@ export class ContextsManager implements ContextsApi {
     try {
       const result = await handler.deleteObject(this.currentContext, name, ns);
       this.handleResult(result, `deletion of ${kind} ${name}`);
+      this.telemetryLogger.logUsage(`delete.${kind.toLowerCase()}`);
     } catch (error: unknown) {
       this.handleApiException(error, `deletion of ${kind} ${name}`);
     }
@@ -662,6 +663,7 @@ export class ContextsManager implements ContextsApi {
       users: this.#currentKubeConfig.users,
       currentContext: this.#currentKubeConfig.currentContext,
     });
+    this.telemetryLogger.logUsage('set.namespace');
     await this.update(newConfig);
   }
 

--- a/packages/webview/src/component/dashboard/KubernetesProviderCard.spec.ts
+++ b/packages/webview/src/component/dashboard/KubernetesProviderCard.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import { render, screen } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 import KubernetesProviderCard from '/@/component/dashboard/KubernetesProviderCard.svelte';
 import { RemoteMocks } from '/@/tests/remote-mocks';
-import { API_NAVIGATION } from '@kubernetes-dashboard/channels';
-import type { NavigationApi } from '@kubernetes-dashboard/channels';
+import { API_NAVIGATION, API_TELEMETRY } from '@kubernetes-dashboard/channels';
+import type { NavigationApi, TelemetryApi } from '@kubernetes-dashboard/channels';
 import userEvent from '@testing-library/user-event';
 
 const remoteMocks = new RemoteMocks();
@@ -35,6 +35,9 @@ beforeEach(() => {
   remoteMocks.mock(API_NAVIGATION, {
     navigateToProviderNewConnection: vi.fn(),
   } as unknown as NavigationApi);
+  remoteMocks.mock(API_TELEMETRY, {
+    track: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TelemetryApi);
 });
 
 test('should render with all values passed', async () => {
@@ -66,4 +69,7 @@ test('should render with minimal values passed', async () => {
   expect(btn).toBeEnabled();
   await userEvent.click(btn);
   expect(remoteMocks.get(API_NAVIGATION).navigateToProviderNewConnection).toHaveBeenCalledWith('k8s-provider');
+  expect(remoteMocks.get(API_TELEMETRY).track).toHaveBeenCalledWith('nocontext.createNew', {
+    provider: 'k8s-provider',
+  });
 });

--- a/packages/webview/src/component/dashboard/KubernetesProviderCard.svelte
+++ b/packages/webview/src/component/dashboard/KubernetesProviderCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faPlusCircle } from '@fortawesome/free-solid-svg-icons';
-import { API_NAVIGATION, type KubernetesProvider } from '@kubernetes-dashboard/channels';
+import { API_NAVIGATION, API_TELEMETRY, type KubernetesProvider } from '@kubernetes-dashboard/channels';
 import { Button } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 import IconImage from '/@/component/icons/IconImage.svelte';
@@ -16,8 +16,10 @@ let { provider }: Props = $props();
 
 const remote = getContext<Remote>(Remote);
 const navigationApi = remote.getProxy(API_NAVIGATION);
+const telemetryApi = remote.getProxy(API_TELEMETRY);
 
 async function createNew(): Promise<void> {
+  telemetryApi.track('nocontext.createNew', { provider: provider.id }).catch(console.warn);
   return navigationApi.navigateToProviderNewConnection(provider.id);
 }
 </script>

--- a/packages/webview/src/component/dashboard/NewProviderCard.spec.ts
+++ b/packages/webview/src/component/dashboard/NewProviderCard.spec.ts
@@ -1,0 +1,54 @@
+/**********************************************************************
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { StatesMocks } from '/@/tests/state-mocks';
+import { API_NAVIGATION, API_TELEMETRY, type NavigationApi, type TelemetryApi } from '@kubernetes-dashboard/channels';
+import { RemoteMocks } from '/@/tests/remote-mocks';
+import NewProviderCard from '/@/component/dashboard/NewProviderCard.svelte';
+import userEvent from '@testing-library/user-event';
+
+vi.mock(import('/@/component/icons/NewProvider.svelte'));
+
+const statesMocks = new StatesMocks();
+const remoteMocks = new RemoteMocks();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  statesMocks.reset();
+  remoteMocks.reset();
+
+  remoteMocks.mock(API_NAVIGATION, {
+    navigateToExtensionsCatalog: vi.fn(),
+  } as unknown as NavigationApi);
+
+  remoteMocks.mock(API_TELEMETRY, {
+    track: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TelemetryApi);
+});
+
+test('should send telemetry when button clicked', async () => {
+  render(NewProviderCard);
+  const btn = screen.getByRole('button', { name: 'See available extensions' });
+  expect(btn).toBeEnabled();
+  await userEvent.click(btn);
+  expect(remoteMocks.get(API_TELEMETRY).track).toHaveBeenCalledWith('nocontext.extensionsCatalog');
+});

--- a/packages/webview/src/component/dashboard/NewProviderCard.svelte
+++ b/packages/webview/src/component/dashboard/NewProviderCard.svelte
@@ -5,11 +5,12 @@ import Fa from 'svelte-fa';
 import NewProvider from '/@/component/icons/NewProvider.svelte';
 import { getContext } from 'svelte';
 import { Remote } from '/@/remote/remote';
-import { API_NAVIGATION } from '@kubernetes-dashboard/channels';
+import { API_NAVIGATION, API_TELEMETRY } from '@kubernetes-dashboard/channels';
 import Markdown from '/@/markdown/Markdown.svelte';
 
 const remote = getContext<Remote>(Remote);
 const navigationApi = remote.getProxy(API_NAVIGATION);
+const telemetryApi = remote.getProxy(API_TELEMETRY);
 
 const markdownText = `
 Install a new Kubernetes provider via extension. Navigate to extensions by pressing the button, install the ones you prefer and they will show up here.
@@ -17,6 +18,7 @@ Install a new Kubernetes provider via extension. Navigate to extensions by press
 More information: [creating a kube cluster](https://podman-desktop.io/docs/kubernetes/creating-a-kube-cluster)`;
 
 async function navigateToExtensionsCatalog(): Promise<void> {
+  telemetryApi.track('nocontext.extensionsCatalog').catch(console.warn);
   return navigationApi.navigateToExtensionsCatalog('category:kubernetes keyword:provider not:installed');
 }
 </script>

--- a/packages/webview/src/component/dashboard/NoContextPage.spec.ts
+++ b/packages/webview/src/component/dashboard/NoContextPage.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,13 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import NoContextPage from './NoContextPage.svelte';
 import { StatesMocks } from '/@/tests/state-mocks';
 import { FakeStateObject } from '/@/state/util/fake-state-object.svelte';
-import { API_NAVIGATION, type KubernetesProvidersInfo, type NavigationApi } from '@kubernetes-dashboard/channels';
+import {
+  API_NAVIGATION,
+  API_TELEMETRY,
+  type KubernetesProvidersInfo,
+  type NavigationApi,
+  type TelemetryApi,
+} from '@kubernetes-dashboard/channels';
 import KubeIcon from '/@/component/icons/KubeIcon.svelte';
 import KubernetesProviderCard from '/@/component/dashboard/KubernetesProviderCard.svelte';
 import type { Unsubscriber } from 'svelte/store';
@@ -47,6 +53,10 @@ beforeEach(() => {
   remoteMocks.mock(API_NAVIGATION, {
     navigateToExtensionsCatalog: vi.fn(),
   } as unknown as NavigationApi);
+
+  remoteMocks.mock(API_TELEMETRY, {
+    track: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TelemetryApi);
 });
 
 test('should render the Kubernetes icon', () => {


### PR DESCRIPTION
Related to #664 

(all events prefixed with `podman-desktop.kubernetes-dashboard`)

- delete.configmap
- delete.cronjob
- delete.deployment
- delete.ingress
- delete.job
- delete.namespace
- delete.pod
- delete.persistentvolumeclaim
- delete.route
- delete.secret
- delete.service

replace:

- kubernetesDeleteConfigMap
- kubernetesDeleteCronJob
- kubernetesDeleteDeployment
- kubernetesDeleteingress
- kubernetesDeleteJob
- kubernetesDeletePod
- kubernetesDeletePersistentVolumeClaim
- kubernetesDeleteRoute
- kubernetesDeleteService
- kubernetesDeleteSecret

Others:

- set.namespace replaces kubernetes.set.namespace
- nocontext.createNew replaces kubernetes.nocontext.createNew
- nocontext.extensionsCatalog replaces kubernetes.nocontext.installExtension and kubernetes.nocontext.showExtensionDetails