### PR TITLE
feat: display previous logs

### DIFF
--- a/packages/webview/src/component/pods/PodLogs.svelte
+++ b/packages/webview/src/component/pods/PodLogs.svelte
@@ -16,8 +16,9 @@ interface Props {
   containerName?: string;
   colorizer: string;
   timestamps: boolean;
+  previous: boolean;
 }
-let { object, containerName, colorizer, timestamps }: Props = $props();
+let { object, containerName, colorizer, timestamps, previous }: Props = $props();
 
 // Logs has been initialized
 let noLogs = $state<boolean>();
@@ -45,7 +46,7 @@ onMount(async () => {
         object.metadata?.name ?? '',
         object.metadata?.namespace ?? '',
         name,
-        { timestamps },
+        { timestamps, previous },
         chunk => {
           const data = podLogsHelper.transformPodLogs(name, chunk.data);
           if (noLogs !== false) {

--- a/packages/webview/src/component/pods/PodLogsCustomizable.spec.ts
+++ b/packages/webview/src/component/pods/PodLogsCustomizable.spec.ts
@@ -84,6 +84,7 @@ test('renders with 2 containers running', async () => {
     containerName: '',
     colorizer: 'colorizer 1',
     timestamps: false,
+    previous: false,
   });
 
   await userEvent.click(containerDropdownButton);
@@ -94,6 +95,7 @@ test('renders with 2 containers running', async () => {
     containerName: 'container2',
     colorizer: 'colorizer 1',
     timestamps: false,
+    previous: false,
   });
 
   await userEvent.click(colorizerDropdownButton);
@@ -104,6 +106,17 @@ test('renders with 2 containers running', async () => {
     containerName: 'container2',
     colorizer: 'colorizer 2',
     timestamps: false,
+    previous: false,
+  });
+
+  const previousCheckbox = screen.getByLabelText('Previous logs');
+  await userEvent.click(previousCheckbox);
+  expect(vi.mocked(PodLogs)).toHaveBeenCalledWith(expect.anything(), {
+    object: fakePod2containersRunning,
+    containerName: 'container2',
+    colorizer: 'colorizer 2',
+    timestamps: false,
+    previous: true,
   });
 });
 
@@ -122,6 +135,7 @@ test('renders with 1 container running', async () => {
     containerName: '',
     colorizer: 'colorizer 2',
     timestamps: false,
+    previous: false,
   });
 });
 
@@ -136,6 +150,7 @@ test('renders with 1 container running with colors annotation', async () => {
     containerName: '',
     colorizer: 'colorizer 2',
     timestamps: false,
+    previous: false,
   });
 });
 
@@ -156,5 +171,6 @@ test('renders with 1 container running with timestamps annotation', async () => 
     containerName: '',
     colorizer: 'colorizer 2',
     timestamps: true,
+    previous: false,
   });
 });

--- a/packages/webview/src/component/pods/PodLogsCustomizable.svelte
+++ b/packages/webview/src/component/pods/PodLogsCustomizable.svelte
@@ -25,6 +25,7 @@ const timestampsAnnotations = $derived(annotations.getAnnotations(object.metadat
 // If no container is selected, logs for all containers are displayed
 let selectedContainerName = $state<string>('');
 let selectedTimestamps = $derived<boolean>(timestampsAnnotations['logs-timestamps'] === 'true');
+let selectedPrevious = $state<boolean>(false);
 
 let containerSelection = $derived([
   { label: 'All containers', value: '' },
@@ -40,7 +41,7 @@ let colorizerSelection = podLogsHelper.getColorizers().map(colorizer => ({ label
 
 {#if runningContainers.length > 0}
   <div class="flex grow flex-col h-full w-full">
-    <div class="flex flex-row p-2 h-[40px] gap-2">
+    <div class="flex flex-wrap flex-row p-2 h-min-[40px] gap-x-4">
       {#if runningContainers.length > 1}
         <div class="w-48">
           <Dropdown
@@ -59,20 +60,25 @@ let colorizerSelection = podLogsHelper.getColorizers().map(colorizer => ({ label
           options={colorizerSelection}>
         </Dropdown>
       </div>
-      <div class="w-48">
+      <div>
         <Checkbox class="pt-2" name="timestamps" title="Show timestamps" bind:checked={selectedTimestamps}
           >Show timestamps</Checkbox>
+      </div>
+      <div>
+        <Checkbox class="pt-2" name="previous" title="Previous logs" bind:checked={selectedPrevious}
+          >Previous logs</Checkbox>
       </div>
     </div>
 
     <div class="flex w-full h-full min-h-0">
-      {#key [selectedContainerName, selectedColorizer, selectedTimestamps]}
+      {#key [selectedContainerName, selectedColorizer, selectedTimestamps, selectedPrevious]}
         {#if selectedContainerName !== undefined}
           <PodLogs
             object={object}
             containerName={selectedContainerName}
             colorizer={selectedColorizer}
-            timestamps={selectedTimestamps} />
+            timestamps={selectedTimestamps}
+            previous={selectedPrevious} />
         {/if}
       {/key}
     </div>


### PR DESCRIPTION
- Adds a 'Previous logs' option in the Pod Logs page, to allow the user to see the logs of the previous container.
- Update the logs toolbar, to allow the options wrap
