### PR TITLE
feat: telemetry on restart object/api error/apply resource/dashboard links

### DIFF
--- a/packages/webview/src/component/dashboard/DashboardGuideCard.spec.ts
+++ b/packages/webview/src/component/dashboard/DashboardGuideCard.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, expect, test, vi } from 'vitest';
 import DashboardGuideCard from './DashboardGuideCard.svelte';
 import { RemoteMocks } from '/@/tests/remote-mocks';
-import { API_SYSTEM } from '@kubernetes-dashboard/channels';
-import type { SystemApi } from '@kubernetes-dashboard/channels';
+import { API_SYSTEM, API_TELEMETRY } from '@kubernetes-dashboard/channels';
+import type { SystemApi, TelemetryApi } from '@kubernetes-dashboard/channels';
 
 const remoteMocks = new RemoteMocks();
 
@@ -35,6 +35,9 @@ beforeEach(() => {
   remoteMocks.mock(API_SYSTEM, {
     openExternal: vi.fn(),
   } as unknown as SystemApi);
+  remoteMocks.mock(API_TELEMETRY, {
+    track: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TelemetryApi);
 });
 
 test('Verify basic card format', async () => {
@@ -65,4 +68,8 @@ test('Expect clicking works', async () => {
 
   await userEvent.click(button);
   expect(remoteMocks.get(API_SYSTEM).openExternal).toHaveBeenCalledWith(params.link);
+  expect(remoteMocks.get(API_TELEMETRY).track).toHaveBeenCalledWith('dashboard.guide', {
+    title: params.title,
+    link: params.link,
+  });
 });

--- a/packages/webview/src/component/dashboard/DashboardGuideCard.svelte
+++ b/packages/webview/src/component/dashboard/DashboardGuideCard.svelte
@@ -2,7 +2,7 @@
 import { Button } from '@podman-desktop/ui-svelte';
 import { getContext } from 'svelte';
 import { Remote } from '/@/remote/remote';
-import { API_SYSTEM } from '@kubernetes-dashboard/channels';
+import { API_SYSTEM, API_TELEMETRY } from '@kubernetes-dashboard/channels';
 
 interface Props {
   title: string;
@@ -14,8 +14,10 @@ let { title, link, image }: Props = $props();
 
 const remote = getContext<Remote>(Remote);
 const systemApi = remote.getProxy(API_SYSTEM);
+const telemetryApi = remote.getProxy(API_TELEMETRY);
 
 async function openLink(): Promise<void> {
+  telemetryApi.track('dashboard.guide', { title: title, link: link }).catch(console.warn);
   await systemApi.openExternal(link);
 }
 </script>

--- a/packages/webview/src/component/dashboard/DashboardResourceCard.svelte
+++ b/packages/webview/src/component/dashboard/DashboardResourceCard.svelte
@@ -9,6 +9,8 @@ import { States } from '/@/state/states';
 import { DependencyAccessor } from '/@/inject/dependency-accessor';
 import { Navigator } from '/@/navigation/navigator';
 import type { ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
+import { Remote } from '/@/remote/remote';
+import { API_TELEMETRY } from '@kubernetes-dashboard/channels';
 
 interface Props {
   type: string;
@@ -21,6 +23,8 @@ let { type, resources, kind, iconName = kind }: Props = $props();
 
 const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
 const navigator = dependencyAccessor.get<Navigator>(Navigator);
+const remote = getContext<Remote>(Remote);
+const telemetryApi = remote.getProxy(API_TELEMETRY);
 
 const activeResourcesCount = getContext<States>(States).stateActiveResourcesCountInfoUI;
 const resourcesCount = getContext<States>(States).stateResourcesCountInfoUI;
@@ -86,6 +90,7 @@ const permitted = $derived.by(() => {
 });
 
 async function openLink(): Promise<void> {
+  telemetryApi.track('dashboard.resource', { type: type, kind: kind }).catch(console.warn);
   navigator.navigateTo({ kind });
 }
 </script>


### PR DESCRIPTION
Fixes #664 

- restart.object (internal kubernetesRestartPod)
- api.error (internal various errors)
- apply.resources (internal kubernetesSyncResources)
- dashboard.guide (internal kubernetes.dashboard.guide)
- dashboard.resource (internal kubernetes.dashboard.resource)

All prefixed with `podman-desktop.kubernetes-dashboard.`