### PR TITLE
feat: logfmt colors

### DIFF
--- a/packages/webview/src/component/pods/pod-logs-helper.ts
+++ b/packages/webview/src/component/pods/pod-logs-helper.ts
@@ -21,6 +21,7 @@ import { colorizeLogLevel } from '/@/component/terminal/terminal-colors';
 import { MultiContainersLogsHelper } from '/@/component/pods/multi-container-logs-helper';
 import { inject, injectable } from 'inversify';
 import { JsonColorizer } from '/@/component/terminal/json-colorizer';
+import { logfmtColorize } from '/@/component/terminal/logfmt-colorizer';
 
 @injectable()
 export class PodLogsHelper {
@@ -31,6 +32,8 @@ export class PodLogsHelper {
     'log level colors': colorizeLogLevel,
     'json colors': (data: string) => this.#jsonColorizer.colorize(data),
     'json colors with indent': (data: string) => this.#jsonColorizer.colorize(data, { indent: 2 }),
+    'logfmt colors': data => logfmtColorize(data),
+    'logfmt colors with indent': data => logfmtColorize(data, 2),
     'no colors': (data: string) => data,
   };
 

--- a/packages/webview/src/component/terminal/logfmt-colorizer.spec.ts
+++ b/packages/webview/src/component/terminal/logfmt-colorizer.spec.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+import { logfmtColorize, KEY_COLOR, NOCOLOR, VALUE_COLOR } from '/@/component/terminal/logfmt-colorizer';
+
+test('should colorize logfmt line with indent', () => {
+  const line = 'true_key null_value= key1=value1 key2="value 2" empty=""';
+  const result = logfmtColorize(line, 2);
+  expect(result).toEqual(
+    `${KEY_COLOR}true_key${NOCOLOR}
+  ${KEY_COLOR}null_value${NOCOLOR}=
+  ${KEY_COLOR}key1${NOCOLOR}=${VALUE_COLOR}value1${NOCOLOR}
+  ${KEY_COLOR}key2${NOCOLOR}="${VALUE_COLOR}value 2${NOCOLOR}"
+  ${KEY_COLOR}empty${NOCOLOR}=""`,
+  );
+});
+
+test('should colorize logfmt line without indent', () => {
+  const line = 'true_key null_value= key1=value1 key2="value 2" empty=""';
+  const result = logfmtColorize(line);
+  expect(result).toEqual(
+    `${KEY_COLOR}true_key${NOCOLOR} ${KEY_COLOR}null_value${NOCOLOR}= ${KEY_COLOR}key1${NOCOLOR}=${VALUE_COLOR}value1${NOCOLOR} ${KEY_COLOR}key2${NOCOLOR}="${VALUE_COLOR}value 2${NOCOLOR}" ${KEY_COLOR}empty${NOCOLOR}=""`,
+  );
+});

--- a/packages/webview/src/component/terminal/logfmt-colorizer.ts
+++ b/packages/webview/src/component/terminal/logfmt-colorizer.ts
@@ -1,0 +1,91 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable sonarjs/cognitive-complexity */
+
+export const KEY_COLOR = '\u001b[34;1m';
+export const VALUE_COLOR = '\u001b[32m';
+export const NOCOLOR = '\u001b[0m';
+
+// Code inspired from https://github.com/csquared/node-logfmt/blob/6c3c61fcf5b8fdea1bca2ddac60367f616979dfd/lib/logfmt_parser.js
+// MIT License: https://opensource.org/license/mit
+
+export function logfmtColorize(line: string, indent: number = 0): string {
+  let key: string | boolean = '';
+  let value: string | boolean | undefined = '';
+  let in_key = false;
+  let in_value = false;
+  let in_quote = false;
+  let had_quote = false;
+
+  if (line[line.length - 1] === '\n') {
+    line = line.slice(0, line.length - 1);
+  }
+
+  let result = '';
+
+  for (let i = 0; i <= line.length; i++) {
+    if ((line[i] === ' ' && !in_quote) || i === line.length) {
+      if (in_key && key.length > 0) {
+        result += KEY_COLOR + key + NOCOLOR + (indent > 0 ? '\n' + ' '.repeat(indent) : ' ');
+      } else if (in_value) {
+        if (had_quote) {
+          result +=
+            '="' +
+            (value !== '' ? VALUE_COLOR + value + NOCOLOR : '') +
+            '"' +
+            (indent > 0 ? '\n' + ' '.repeat(indent) : ' ');
+        } else {
+          result +=
+            '=' + (value !== '' ? VALUE_COLOR + value + NOCOLOR : '') + (indent > 0 ? '\n' + ' '.repeat(indent) : ' ');
+        }
+        value = '';
+      }
+
+      if (i === line.length) break;
+      else {
+        in_key = false;
+        in_value = false;
+        in_quote = false;
+        had_quote = false;
+      }
+    }
+
+    if (line[i] === '=' && !in_quote) {
+      //split
+      in_key = false;
+      in_value = true;
+      result += KEY_COLOR + key + NOCOLOR;
+    } else if (line[i] === '\\') {
+      // eslint-disable-next-line sonarjs/updated-loop-counter
+      i++;
+      value += line[i];
+    } else if (line[i] === '"') {
+      had_quote = true;
+      in_quote = !in_quote;
+    } else if (line[i] !== ' ' && !in_value && !in_key) {
+      in_key = true;
+      key = line[i];
+    } else if (in_key) {
+      key += line[i];
+    } else if (in_value) {
+      value += line[i];
+    }
+  }
+  return result.trimEnd();
+}


### PR DESCRIPTION
Part of #524

Add a choice to colorize pods logs formatted with logfmt, with or without indentation.

Without indent:

<img width="1151" height="898" alt="logfmt-colors" src="https://github.com/user-attachments/assets/fec0256f-47d8-49d4-a41c-a7b92bf044b5" />

With indent:

<img width="1151" height="898" alt="logfmt-colors-indent" src="https://github.com/user-attachments/assets/b318d696-6fc6-40e7-ae96-f12534313a12" />
