### PR TITLE
fix(accessibility): colors contrast on terminal/logs page

### DIFF
--- a/packages/webview/src/component/pods/PodTerminal.svelte
+++ b/packages/webview/src/component/pods/PodTerminal.svelte
@@ -54,6 +54,7 @@ async function initializeNewTerminal(
     lineHeight: 1,
     screenReaderMode: true,
     theme: getTerminalTheme(),
+    minimumContrastRatio: 4.5,
   });
 
   disposables.push(

--- a/packages/webview/src/component/terminal/TerminalWindow.svelte
+++ b/packages/webview/src/component/terminal/TerminalWindow.svelte
@@ -69,6 +69,7 @@ async function refreshTerminal(): Promise<void> {
     convertEol: convertEol,
     screenReaderMode: screenReaderMode,
     rightClickSelectsWord: true,
+    minimumContrastRatio: 4.5,
   });
   const fitAddon = new FitAddon();
   terminal.loadAddon(fitAddon);


### PR DESCRIPTION
Related to #489 

This PR hardcodes a minimum contrast ratio for WCGA AA compliance, for the xtermjs component (terminal and logs of pods)

