### PR TITLE
fix(webview): fix no-useless-assignment rule for eslint/js 10

### DIFF
--- a/packages/webview/src/MainContextAware.svelte
+++ b/packages/webview/src/MainContextAware.svelte
@@ -15,6 +15,7 @@ interface Props {
 
 const { context }: Props = $props();
 
+// eslint-disable-next-line no-useless-assignment
 let initialized = $state(false);
 
 // Sets the value in the global svelte context

--- a/packages/webview/src/component/terminal/TerminalWindow.svelte
+++ b/packages/webview/src/component/terminal/TerminalWindow.svelte
@@ -82,7 +82,7 @@ async function refreshTerminal(): Promise<void> {
 
   //copy behavior
   terminal.attachCustomKeyEventHandler((event: KeyboardEvent): boolean => {
-    let isCopyShortcut = false;
+    let isCopyShortcut: boolean;
 
     if (platformName === 'darwin') {
       // macOS: Cmd+C


### PR DESCRIPTION
Fix/disable some eslint/js errors that appear in major version 10.


Helps for https://github.com/podman-desktop/extension-kubernetes-dashboard/pull/716