### PR TITLE
test: integration tag for e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -44,8 +44,8 @@ jobs:
           name: extension-plugin
           path: output/plugins/
 
-  e2e-pr-check:
-    name: e2e tests smoke / ${{ matrix.os }}
+  integration-tests-pr-check:
+    name: integration tests / ${{ matrix.os }}
     needs: build-container
     runs-on: ${{ matrix.os }}
     strategy:
@@ -183,11 +183,11 @@ jobs:
           kubectl version --client
 
       # Run tests
-      - name: Run E2E Smoke tests
+      - name: Run Integration tests
         shell: bash
         run: |
           cp "${KUBECONFIG}" ./tests/resources/envtest-kubeconfig
-          pnpm test:e2e:smoke
+          pnpm test:e2e:integration
         env:
           NODE_OPTIONS: --no-experimental-strip-types
           KUBEBUILDER_ASSETS: ${{ steps.setup-envtest.outputs.KUBEBUILDER_ASSETS }}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:channels": "vitest run --project channels --passWithNoTests",
     "test": "pnpm run test:extension && pnpm run test:webview && pnpm run test:channels",
     "test:e2e": "cd tests/playwright && npm run test:e2e",
-    "test:e2e:smoke": "cd tests/playwright && npm run test:e2e:smoke",
+    "test:e2e:integration": "cd tests/playwright && npm run test:e2e:integration",
     "typecheck:rpc": "tsc --noEmit --project packages/rpc",
     "typecheck:channels": "tsc --noEmit --project packages/channels",
     "typecheck:webview": "tsc --noEmit --project packages/webview",

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test:e2e:setup": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' --",
     "test:e2e": "npm run test:e2e:setup playwright test src/",
-    "test:e2e:smoke": "npm run test:e2e:setup playwright test src/ --grep @smoke"
+    "test:e2e:integration": "npm run test:e2e:setup playwright test src/ --grep @integration"
   },
   "publisher": "podman-desktop",
   "license": "Apache-2.0",

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -76,7 +76,7 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe.serial(`Extension installation and verification`, { tag: '@smoke' }, () => {
+test.describe.serial(`Extension installation and verification`, { tag: '@integration' }, () => {
   test.skip(EXTENSION_PREINSTALLED, 'Extension is preinstalled');
   test.describe.serial(`Extension installation`, () => {
     let extensionsPage: ExtensionsPage;
@@ -122,7 +122,7 @@ test.describe.serial(`Extension installation and verification`, { tag: '@smoke' 
   });
 });
 
-test.describe.serial(`Extension usage`, () => {
+test.describe.serial(`Extension usage`, { tag: '@integration' }, () => {
   let navigation: KubernetesBar;
 
   test('Load kubeconfig file in Preferences for an empty envtest cluster', async ({ page, navigationBar }) => {
@@ -212,7 +212,7 @@ test.describe.serial(`Extension usage`, () => {
   });
 });
 
-test.describe.serial('With resources', () => {
+test.describe.serial('With resources', { tag: '@integration' }, () => {
   let navigation: KubernetesBar;
 
   test('deploy resources to cluster', async () => {


### PR DESCRIPTION
Adds `@integration` label to e2e tests based on envtest and change the `pnpm test:e2e:smoke` to `pnpm test:e2e:integration` 

Fixes #725 