### PR TITLE
fix: resolve GHSA-39q2-94rc-95cp in dompurify

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
       "node-gyp>tar": "^7.5.7",
       "minimatch@<3.1.4": "^3.1.4",
       "minimatch@>=9.0.0 <9.0.7": "^9.0.7",
-      "minimatch@>=10.0.0 <10.2.3": "^10.2.3"
+      "minimatch@>=10.0.0 <10.2.3": "^10.2.3",
+      "dompurify@<=3.3.3": "^3.4.0"
     }
   },
   "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   minimatch@<3.1.4: ^3.1.4
   minimatch@>=9.0.0 <9.0.7: ^9.0.7
   minimatch@>=10.0.0 <10.2.3: ^10.2.3
+  dompurify@<=3.3.3: ^3.4.0
 
 importers:
 
@@ -2205,8 +2206,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+  dompurify@3.4.1:
+    resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -6050,7 +6051,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.2.7:
+  dompurify@3.4.1:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7319,7 +7320,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.2.7
+      dompurify: 3.4.1
       marked: 14.0.0
 
   mri@1.2.0: {}


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability GHSA-39q2-94rc-95cp in `dompurify`.

**Advisory**: DOMPurify's ADD_TAGS function form bypasses FORBID_TAGS due to short-circuit evaluation
**Vulnerable versions**: <=3.3.3
**Patched versions**: >=3.4.0
**Advisory URL**: https://github.com/advisories/GHSA-39q2-94rc-95cp

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-39q2-94rc-95cp: _DOMPurify's ADD_TAGS function form bypasses FORBID_TAGS due to short-circuit evaluation_

### How to test this PR?

Run `pnpm audit` and verify GHSA-39q2-94rc-95cp is no longer reported