### PR TITLE
feat(column): add column selection support to all resource tables

### DIFF
--- a/packages/webview/src/Main.svelte
+++ b/packages/webview/src/Main.svelte
@@ -4,9 +4,13 @@ import './app.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 
 import { onDestroy, onMount } from 'svelte';
+import { tablePersistence } from '@podman-desktop/ui-svelte';
 
 import { Main, type MainContext } from '/@/main';
 import MainContextAware from '/@/MainContextAware.svelte';
+import { LocalStoragePersistence } from '/@/table/local-storage-persistence';
+
+tablePersistence.storage = new LocalStoragePersistence();
 
 let main: Main | undefined;
 let mainContext: MainContext | undefined = $state();

--- a/packages/webview/src/component/objects/KubernetesObjectsList.svelte
+++ b/packages/webview/src/component/objects/KubernetesObjectsList.svelte
@@ -137,6 +137,7 @@ function waitThrottleDelay(): Promise<void> {
         columns={columns}
         row={row}
         defaultSortColumn="Name"
+        enableLayoutConfiguration={true}
         bind:selectedItemsNumber={selectedItemsNumber}></Table>
 
       {#if objects.length === 0}

--- a/packages/webview/src/table/local-storage-persistence.spec.ts
+++ b/packages/webview/src/table/local-storage-persistence.spec.ts
@@ -1,0 +1,108 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { LocalStoragePersistence } from './local-storage-persistence';
+
+let persistence: LocalStoragePersistence;
+let storage: Record<string, string>;
+
+beforeEach(() => {
+  storage = {};
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn((key: string) => storage[key]),
+    setItem: vi.fn((key: string, value: string) => {
+      storage[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete storage[key];
+    }),
+  });
+  persistence = new LocalStoragePersistence();
+});
+
+test('load returns default items when no saved config', async () => {
+  const items = await persistence.load('Pod', ['Name', 'Age', 'Status']);
+
+  expect(items).toEqual([
+    { id: 'Name', label: 'Name', enabled: true, originalOrder: 0 },
+    { id: 'Age', label: 'Age', enabled: true, originalOrder: 1 },
+    { id: 'Status', label: 'Status', enabled: true, originalOrder: 2 },
+  ]);
+});
+
+test('load restores saved enabled state', async () => {
+  storage['table-columns.Pod'] = JSON.stringify([
+    { id: 'Name', enabled: true },
+    { id: 'Age', enabled: false },
+    { id: 'Status', enabled: true },
+  ]);
+
+  const items = await persistence.load('Pod', ['Name', 'Age', 'Status']);
+
+  expect(items[0].enabled).toBe(true);
+  expect(items[1].enabled).toBe(false);
+  expect(items[2].enabled).toBe(true);
+});
+
+test('load defaults new columns to enabled', async () => {
+  storage['table-columns.Pod'] = JSON.stringify([
+    { id: 'Name', enabled: true },
+    { id: 'Age', enabled: false },
+  ]);
+
+  const items = await persistence.load('Pod', ['Name', 'Age', 'Node']);
+
+  expect(items).toHaveLength(3);
+  expect(items[2].id).toBe('Node');
+  expect(items[2].enabled).toBe(true);
+});
+
+test('load falls back to defaults on invalid JSON', async () => {
+  storage['table-columns.Pod'] = 'invalid-json';
+
+  const items = await persistence.load('Pod', ['Name', 'Age']);
+
+  expect(items).toHaveLength(2);
+  expect(items.every(i => i.enabled)).toBe(true);
+});
+
+test('save persists column configuration', async () => {
+  await persistence.save('Pod', [
+    { id: 'Name', label: 'Name', enabled: true, originalOrder: 0 },
+    { id: 'Age', label: 'Age', enabled: false, originalOrder: 1 },
+  ]);
+
+  const saved = JSON.parse(storage['table-columns.Pod']);
+  expect(saved).toEqual([
+    { id: 'Name', enabled: true },
+    { id: 'Age', enabled: false },
+  ]);
+});
+
+test('reset clears saved config and returns defaults', async () => {
+  storage['table-columns.Pod'] = JSON.stringify([{ id: 'Name', enabled: false }]);
+
+  const items = await persistence.reset('Pod', ['Name', 'Age']);
+
+  expect(storage['table-columns.Pod']).toBeUndefined();
+  expect(items).toEqual([
+    { id: 'Name', label: 'Name', enabled: true, originalOrder: 0 },
+    { id: 'Age', label: 'Age', enabled: true, originalOrder: 1 },
+  ]);
+});

--- a/packages/webview/src/table/local-storage-persistence.ts
+++ b/packages/webview/src/table/local-storage-persistence.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ListOrganizerItem, TablePersistence } from '@podman-desktop/ui-svelte';
+
+interface SavedColumnConfig {
+  id: string;
+  enabled: boolean;
+}
+
+export class LocalStoragePersistence implements TablePersistence {
+  readonly #prefix = 'table-columns';
+
+  #storageKey(kind: string): string {
+    return `${this.#prefix}.${kind}`;
+  }
+
+  async load(kind: string, columnNames: string[]): Promise<ListOrganizerItem[]> {
+    const raw = localStorage.getItem(this.#storageKey(kind));
+    if (!raw) {
+      return this.#defaultItems(columnNames);
+    }
+
+    try {
+      const saved: SavedColumnConfig[] = JSON.parse(raw);
+      const savedMap = new Map(saved.map(s => [s.id, s.enabled]));
+
+      return columnNames.map((name, index) => ({
+        id: name,
+        label: name,
+        enabled: savedMap.get(name) ?? true,
+        originalOrder: index,
+      }));
+    } catch {
+      return this.#defaultItems(columnNames);
+    }
+  }
+
+  async save(kind: string, items: ListOrganizerItem[]): Promise<void> {
+    const toSave: SavedColumnConfig[] = items.map(item => ({
+      id: item.id,
+      enabled: item.enabled,
+    }));
+    localStorage.setItem(this.#storageKey(kind), JSON.stringify(toSave));
+  }
+
+  async reset(kind: string, columnNames: string[]): Promise<ListOrganizerItem[]> {
+    localStorage.removeItem(this.#storageKey(kind));
+    return this.#defaultItems(columnNames);
+  }
+
+  #defaultItems(columnNames: string[]): ListOrganizerItem[] {
+    return columnNames.map((name, index) => ({
+      id: name,
+      label: name,
+      enabled: true,
+      originalOrder: index,
+    }));
+  }
+}


### PR DESCRIPTION
feat(column): add column selection support to all resource tables

Enable the column visibility dropdown (select/deselect columns, reset
to default) on every resource list table.


https://github.com/user-attachments/assets/268f4f0b-2f82-49cf-b1c7-51e6b990fbfe



Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
