### PR TITLE
feat(pods): add more information to pod page

### DIFF
--- a/packages/webview/src/Main.svelte
+++ b/packages/webview/src/Main.svelte
@@ -4,9 +4,13 @@ import './app.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 
 import { onDestroy, onMount } from 'svelte';
+import { tablePersistence } from '@podman-desktop/ui-svelte';
 
 import { Main, type MainContext } from '/@/main';
 import MainContextAware from '/@/MainContextAware.svelte';
+import { LocalStoragePersistence } from '/@/table/local-storage-persistence';
+
+tablePersistence.storage = new LocalStoragePersistence();
 
 let main: Main | undefined;
 let mainContext: MainContext | undefined = $state();

--- a/packages/webview/src/component/objects/KubernetesObjectsList.svelte
+++ b/packages/webview/src/component/objects/KubernetesObjectsList.svelte
@@ -137,6 +137,7 @@ function waitThrottleDelay(): Promise<void> {
         columns={columns}
         row={row}
         defaultSortColumn="Name"
+        enableLayoutConfiguration={true}
         bind:selectedItemsNumber={selectedItemsNumber}></Table>
 
       {#if objects.length === 0}

--- a/packages/webview/src/component/pods/PodUI.ts
+++ b/packages/webview/src/component/pods/PodUI.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,4 +29,7 @@ export interface PodUI extends KubernetesNamespacedObjectUI {
   created?: Date;
   node?: string;
   containers: PodInfoContainerUI[];
+  restarts: number;
+  controlledBy?: string;
+  qosClass?: string;
 }

--- a/packages/webview/src/component/pods/PodsList.svelte
+++ b/packages/webview/src/component/pods/PodsList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { TableColumn, TableDurationColumn, TableRow } from '@podman-desktop/ui-svelte';
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
 import moment from 'moment';
 import NameColumn from '/@/component/objects/columns/Name.svelte';
 import StatusColumn from '/@/component/objects/columns/Status.svelte';
@@ -36,6 +36,31 @@ let containersColumn = new TableColumn<PodUI>('Containers', {
   overflow: true,
 });
 
+let restartsColumn = new TableColumn<PodUI, string>('Restarts', {
+  renderMapping: (pod): string => String(pod.restarts),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.restarts - b.restarts,
+  initialOrder: 'descending',
+});
+
+let controlledByColumn = new TableColumn<PodUI, string>('Controlled By', {
+  renderMapping: (pod): string => pod.controlledBy ?? '',
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => (a.controlledBy ?? '').localeCompare(b.controlledBy ?? ''),
+});
+
+let nodeColumn = new TableColumn<PodUI, string>('Node', {
+  renderMapping: (pod): string => pod.node ?? '',
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => (a.node ?? '').localeCompare(b.node ?? ''),
+});
+
+let qosColumn = new TableColumn<PodUI, string>('QoS', {
+  renderMapping: (pod): string => pod.qosClass ?? '',
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => (a.qosClass ?? '').localeCompare(b.qosClass ?? ''),
+});
+
 let ageColumn = new TableColumn<PodUI, Date | undefined>('Age', {
   renderMapping: (pod): Date | undefined => pod.created,
   renderer: TableDurationColumn,
@@ -46,6 +71,10 @@ const columns = [
   statusColumn,
   nameColumn,
   containersColumn,
+  restartsColumn,
+  controlledByColumn,
+  nodeColumn,
+  qosColumn,
   ageColumn,
   new TableColumn<PodUI>('Actions', { align: 'right', width: '150px', renderer: ActionsColumn, overflow: true }),
 ];

--- a/packages/webview/src/component/pods/columns/Containers.spec.ts
+++ b/packages/webview/src/component/pods/columns/Containers.spec.ts
@@ -38,6 +38,7 @@ const pod: PodUI = {
     },
   ],
   namespace: '',
+  restarts: 0,
 };
 
 const dependencyMocks = new DependencyMocks();

--- a/packages/webview/src/component/pods/columns/OpenLinks.spec.ts
+++ b/packages/webview/src/component/pods/columns/OpenLinks.spec.ts
@@ -70,7 +70,9 @@ test('OpenLinks component', () => {
       },
     ],
   });
-  render(OpenLinks, { object: { name: 'pod1', namespace: 'ns1', containers: [], kind: 'Pod', status: 'Running' } });
+  render(OpenLinks, {
+    object: { name: 'pod1', namespace: 'ns1', containers: [], kind: 'Pod', status: 'Running', restarts: 0 },
+  });
   expect(IconButton).toHaveBeenCalledWith(
     expect.anything(),
     expect.objectContaining({

--- a/packages/webview/src/component/pods/pod-helper.spec.ts
+++ b/packages/webview/src/component/pods/pod-helper.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,12 +33,24 @@ beforeEach(() => {
 const podInfo = {
   apiVersion: 'v1',
   kind: 'Pod',
-  metadata: { name: 'my-pod', namespace: 'test-namespace' },
+  metadata: {
+    name: 'my-pod',
+    namespace: 'test-namespace',
+    ownerReferences: [
+      {
+        apiVersion: 'apps/v1',
+        kind: 'ReplicaSet',
+        name: 'my-replicaset-abc123',
+        controller: true,
+      },
+    ],
+  },
   status: {
     containerStatuses: [
       {
         containerID: 'container-1',
         name: 'container-1-name',
+        restartCount: 2,
         state: {
           running: {},
         },
@@ -46,6 +58,7 @@ const podInfo = {
       {
         containerID: 'container-2',
         name: 'container-2-name',
+        restartCount: 1,
         state: {
           terminated: {},
         },
@@ -53,11 +66,13 @@ const podInfo = {
       {
         containerID: 'container-3',
         name: 'container-3-name',
+        restartCount: 0,
         state: {
           waiting: {},
         },
       },
     ],
+    qosClass: 'Burstable',
   },
   spec: {
     nodeName: 'test-node',
@@ -89,4 +104,72 @@ test('Expect to get container status from pod info', () => {
   expect(pod.containers[2].Id).toBe('container-3');
   expect(pod.containers[2].Names).toBe('container-3-name');
   expect(pod.containers[2].Status).toBe('waiting');
+});
+
+test('Expect to get total restart count from pod info', () => {
+  const pod = podHelper.getPodUI(podInfo);
+
+  expect(pod.restarts).toBe(3);
+});
+
+test('Expect restarts to be 0 when no container statuses', () => {
+  const pod = podHelper.getPodUI({
+    metadata: { name: 'no-containers' },
+    status: {},
+    spec: {},
+  } as unknown as V1Pod);
+
+  expect(pod.restarts).toBe(0);
+});
+
+test('Expect to get controlledBy from owner references', () => {
+  const pod = podHelper.getPodUI(podInfo);
+
+  expect(pod.controlledBy).toBe('ReplicaSet');
+});
+
+test('Expect controlledBy to be undefined when no owner references', () => {
+  const pod = podHelper.getPodUI({
+    metadata: { name: 'no-owner' },
+    status: {},
+    spec: {},
+  } as unknown as V1Pod);
+
+  expect(pod.controlledBy).toBeUndefined();
+});
+
+test('Expect controlledBy to be undefined when no controller owner reference', () => {
+  const pod = podHelper.getPodUI({
+    metadata: {
+      name: 'non-controller-owner',
+      ownerReferences: [
+        {
+          apiVersion: 'v1',
+          kind: 'Service',
+          name: 'my-service',
+          controller: false,
+        },
+      ],
+    },
+    status: {},
+    spec: {},
+  } as unknown as V1Pod);
+
+  expect(pod.controlledBy).toBeUndefined();
+});
+
+test('Expect to get QoS class from pod info', () => {
+  const pod = podHelper.getPodUI(podInfo);
+
+  expect(pod.qosClass).toBe('Burstable');
+});
+
+test('Expect qosClass to be undefined when not set', () => {
+  const pod = podHelper.getPodUI({
+    metadata: { name: 'no-qos' },
+    status: {},
+    spec: {},
+  } as unknown as V1Pod);
+
+  expect(pod.qosClass).toBeUndefined();
 });

--- a/packages/webview/src/component/pods/pod-helper.ts
+++ b/packages/webview/src/component/pods/pod-helper.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,10 @@ export class PodHelper {
         };
       }) ?? [];
 
+    const restarts = pod.status?.containerStatuses?.reduce((sum, status) => sum + (status.restartCount ?? 0), 0) ?? 0;
+
+    const controller = pod.metadata?.ownerReferences?.find(ref => ref.controller);
+
     return {
       kind: 'Pod',
       name: pod.metadata?.name ?? '',
@@ -39,6 +43,9 @@ export class PodHelper {
       selected: false,
       node: pod.spec?.nodeName,
       namespace: pod.metadata?.namespace ?? '',
+      restarts,
+      controlledBy: controller?.kind,
+      qosClass: pod.status?.qosClass,
     };
   }
 

--- a/packages/webview/src/table/local-storage-persistence.spec.ts
+++ b/packages/webview/src/table/local-storage-persistence.spec.ts
@@ -1,0 +1,108 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { LocalStoragePersistence } from './local-storage-persistence';
+
+let persistence: LocalStoragePersistence;
+let storage: Record<string, string>;
+
+beforeEach(() => {
+  storage = {};
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn((key: string) => storage[key]),
+    setItem: vi.fn((key: string, value: string) => {
+      storage[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete storage[key];
+    }),
+  });
+  persistence = new LocalStoragePersistence();
+});
+
+test('load returns default items when no saved config', async () => {
+  const items = await persistence.load('Pod', ['Name', 'Age', 'Status']);
+
+  expect(items).toEqual([
+    { id: 'Name', label: 'Name', enabled: true, originalOrder: 0 },
+    { id: 'Age', label: 'Age', enabled: true, originalOrder: 1 },
+    { id: 'Status', label: 'Status', enabled: true, originalOrder: 2 },
+  ]);
+});
+
+test('load restores saved enabled state', async () => {
+  storage['table-columns.Pod'] = JSON.stringify([
+    { id: 'Name', enabled: true },
+    { id: 'Age', enabled: false },
+    { id: 'Status', enabled: true },
+  ]);
+
+  const items = await persistence.load('Pod', ['Name', 'Age', 'Status']);
+
+  expect(items[0].enabled).toBe(true);
+  expect(items[1].enabled).toBe(false);
+  expect(items[2].enabled).toBe(true);
+});
+
+test('load defaults new columns to enabled', async () => {
+  storage['table-columns.Pod'] = JSON.stringify([
+    { id: 'Name', enabled: true },
+    { id: 'Age', enabled: false },
+  ]);
+
+  const items = await persistence.load('Pod', ['Name', 'Age', 'Node']);
+
+  expect(items).toHaveLength(3);
+  expect(items[2].id).toBe('Node');
+  expect(items[2].enabled).toBe(true);
+});
+
+test('load falls back to defaults on invalid JSON', async () => {
+  storage['table-columns.Pod'] = 'invalid-json';
+
+  const items = await persistence.load('Pod', ['Name', 'Age']);
+
+  expect(items).toHaveLength(2);
+  expect(items.every(i => i.enabled)).toBe(true);
+});
+
+test('save persists column configuration', async () => {
+  await persistence.save('Pod', [
+    { id: 'Name', label: 'Name', enabled: true, originalOrder: 0 },
+    { id: 'Age', label: 'Age', enabled: false, originalOrder: 1 },
+  ]);
+
+  const saved = JSON.parse(storage['table-columns.Pod']);
+  expect(saved).toEqual([
+    { id: 'Name', enabled: true },
+    { id: 'Age', enabled: false },
+  ]);
+});
+
+test('reset clears saved config and returns defaults', async () => {
+  storage['table-columns.Pod'] = JSON.stringify([{ id: 'Name', enabled: false }]);
+
+  const items = await persistence.reset('Pod', ['Name', 'Age']);
+
+  expect(storage['table-columns.Pod']).toBeUndefined();
+  expect(items).toEqual([
+    { id: 'Name', label: 'Name', enabled: true, originalOrder: 0 },
+    { id: 'Age', label: 'Age', enabled: true, originalOrder: 1 },
+  ]);
+});

--- a/packages/webview/src/table/local-storage-persistence.ts
+++ b/packages/webview/src/table/local-storage-persistence.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ListOrganizerItem, TablePersistence } from '@podman-desktop/ui-svelte';
+
+interface SavedColumnConfig {
+  id: string;
+  enabled: boolean;
+}
+
+export class LocalStoragePersistence implements TablePersistence {
+  readonly #prefix = 'table-columns';
+
+  #storageKey(kind: string): string {
+    return `${this.#prefix}.${kind}`;
+  }
+
+  async load(kind: string, columnNames: string[]): Promise<ListOrganizerItem[]> {
+    const raw = localStorage.getItem(this.#storageKey(kind));
+    if (!raw) {
+      return this.#defaultItems(columnNames);
+    }
+
+    try {
+      const saved: SavedColumnConfig[] = JSON.parse(raw);
+      const savedMap = new Map(saved.map(s => [s.id, s.enabled]));
+
+      return columnNames.map((name, index) => ({
+        id: name,
+        label: name,
+        enabled: savedMap.get(name) ?? true,
+        originalOrder: index,
+      }));
+    } catch {
+      return this.#defaultItems(columnNames);
+    }
+  }
+
+  async save(kind: string, items: ListOrganizerItem[]): Promise<void> {
+    const toSave: SavedColumnConfig[] = items.map(item => ({
+      id: item.id,
+      enabled: item.enabled,
+    }));
+    localStorage.setItem(this.#storageKey(kind), JSON.stringify(toSave));
+  }
+
+  async reset(kind: string, columnNames: string[]): Promise<ListOrganizerItem[]> {
+    localStorage.removeItem(this.#storageKey(kind));
+    return this.#defaultItems(columnNames);
+  }
+
+  #defaultItems(columnNames: string[]): ListOrganizerItem[] {
+    return columnNames.map((name, index) => ({
+      id: name,
+      label: name,
+      enabled: true,
+      originalOrder: index,
+    }));
+  }
+}


### PR DESCRIPTION
feat(pods): add more information to pod page

Adds more information to the pod page by adding:

- number of restarts counts
- controlled by
- qos classes
- node

And be able to sort / modify the columns.

Builds upon PR: https://github.com/podman-desktop/extension-kubernetes-dashboard/pull/955


https://github.com/user-attachments/assets/e7d9e37e-48bc-4ae3-a642-02bf5d59c0d7



Closes #953

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
