### PR TITLE
chore: add more width to namespace selection

### DIFF
--- a/packages/webview/src/component/objects/NamespaceDropdown.spec.ts
+++ b/packages/webview/src/component/objects/NamespaceDropdown.spec.ts
@@ -119,7 +119,7 @@ test('Expect basic styling', async () => {
 
   const dropdown = screen.getByLabelText('Kubernetes Namespace');
   expect(dropdown).toBeInTheDocument();
-  expect(dropdown).toHaveClass('w-56 max-w-56');
+  expect(dropdown).toHaveClass('w-64 max-w-64 truncate');
 });
 
 test('Expect namespaces are in the dropdown', async () => {

--- a/packages/webview/src/component/objects/NamespaceDropdown.svelte
+++ b/packages/webview/src/component/objects/NamespaceDropdown.svelte
@@ -58,7 +58,7 @@ onDestroy(() => {
 <Dropdown
   ariaLabel="Kubernetes Namespace"
   name="namespace"
-  class="w-56 max-w-56"
+  class="w-64 max-w-64 truncate"
   value={currentNamespace}
   disabled={!reachable}
   onChange={handleNamespaceChange}


### PR DESCRIPTION
chore: add more width to namespace selection

adds more width to the namespace selection / it isn't as truncated as
other namespaces.

<img width="1055" height="359" alt="Screenshot 2026-05-15 at 3 15 33 PM" src="https://github.com/user-attachments/assets/aba53e40-6d5a-4fe4-ab31-bd01600b3e8b" />


Signed-off-by: Charlie Drage <charlie@charliedrage.com>
