### PR TITLE
chore: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug 🐞
+description: Report a bug report
+type: bug
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a bug report, please search for the behaviour in the existing issues.
+
+        ---
+
+        Thank you for taking the time to file a bug report. To address this bug as fast as possible, we need some information.
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug description
+      description: What happened?
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: 'Which operating system are you on? Please provide the version as well. If you are on a Mac, please specify Apple silicon or Intel.'
+      placeholder: 'macOS Ventura 13.4 (Arm), Windows 11'
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Extension version
+      description: What version of the Kubernetes Dashboard extension are you running?
+      placeholder: '0.6.0'
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: What steps do we need to take to reproduce this error?
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: If applicable, provide relevant log output.
+      render: shell
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots here.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,42 @@
+name: Feature 💡
+description: A request, idea, or new functionality
+type: feature
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a new feature request, please search for potential existing issues.
+
+        ---
+
+        Thank you for taking the time to file a feature request, we appreciate and value your time to help the project!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature related to a problem? Please describe
+      description: A clear and concise description of what the problem is.
+      placeholder: I'm always frustrated when [...]
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### What does this PR do?
+
+### Screenshot / video of UI
+
+<!-- If this PR is changing UI, please include
+screenshots or screencasts showing the difference -->
+
+### What issues does this PR fix or reference?
+
+<!-- Include any related issues from the
+repository (or from another issue tracker). -->
+
+### How to test this PR?
+
+<!-- Please explain steps to reproduce -->


### PR DESCRIPTION
chore: add GitHub issue and PR templates

Add structured YAML issue templates (bug report and feature request)
and a pull request template to standardize contributions.

Noticed they were missing here

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
