### PR TITLE
chore: improve agentready score with config, rules, and skills

### DIFF
--- a/.agentready-config.yaml
+++ b/.agentready-config.yaml
@@ -1,0 +1,34 @@
+# AgentReady Configuration
+# https://github.com/ambient-code/agentready
+#
+# AgentReady evaluates repository readiness for AI-assisted development by scoring
+# codebases against evidence-based attributes and assigning a certification tier.
+# Run: uvx --from git+https://github.com/ambient-code/agentready agentready -- assess .
+
+excluded_attributes:
+  # Not a REST API — this is a desktop extension using RPC over postMessage
+  - openapi_specs
+
+  # Not applicable to this project's language/stack
+  - container_setup
+  - dbt_project_config
+  - dbt_model_documentation
+  - dbt_data_tests
+  - dbt_project_structure
+
+  # pnpm monorepo with packages/*/src/ — tool only checks for root src/
+  - standard_layout
+
+  # AGENTS.md/CLAUDE.md and .agents/skills/ already provide AI context
+  - repomix_config
+
+  # Architecture is documented in AGENTS.md/CLAUDE.md under architecture section
+  - architecture_decisions
+
+  # Monorepo false positive — all packages have strict:true in their tsconfig.json already,
+  # but bug does not pick it up
+  # See: https://github.com/ambient-code/agentready/issues/431
+  - type_annotations
+
+  # Design intent is documented inline in AGENTS.md and docs/data-flow.md
+  - design_intent

--- a/.agents/rules/channels.md
+++ b/.agents/rules/channels.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - 'packages/channels/**/*.ts'
+---
+
+Channels package defines RPC channel interfaces, data models, and types shared between extension and webview. Changes here affect both sides.
+
+Channel interfaces are the RPC contract. Keep channel definitions in channels.ts in sync with implementations in the extension package.

--- a/.agents/rules/extension.md
+++ b/.agents/rules/extension.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - 'packages/extension/**/*.ts'
+---
+
+Extension runs in Node.js with Inversify DI. Mock @podman-desktop/api in tests. Uses @kubernetes/client-node for K8s API access.
+
+New RPC methods require: channel interface in packages/channels, backend implementation as @injectable() service, webview proxy via remote.getProxy().

--- a/.agents/rules/rpc.md
+++ b/.agents/rules/rpc.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - 'packages/rpc/**/*.ts'
+---
+
+RPC package provides RpcExtension (backend) and RpcBrowser (webview) for bidirectional communication over webview postMessage.
+
+Default timeout is 5 seconds. Use noTimeoutMethods option for long-running operations. Must stay compatible with channel interfaces.

--- a/.agents/rules/webview.md
+++ b/.agents/rules/webview.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - 'packages/webview/**/*.svelte'
+  - 'packages/webview/**/*.ts'
+---
+
+Use Svelte 5 runes ($state, $derived, $effect). Never use legacy $: reactive syntax or writable() stores. State classes use .svelte.ts extension.
+
+Frontend tests use @testing-library/svelte with vitest. Access backend via remote.getProxy(CHANNEL). Import alias: /@/ -> src/.

--- a/.agents/skills/backend-api/SKILL.md
+++ b/.agents/skills/backend-api/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: backend-api
+description: >-
+  Guides backend development with @podman-desktop/api, @kubernetes/client-node,
+  and the Kubernetes Dashboard extension's RPC and Inversify DI system. Covers
+  Kubernetes resource management, dispatchers, subscribers, port forwarding,
+  and pod streaming. Triggers when working on packages/extension/ code, adding
+  RPC methods, implementing Kubernetes operations, or asking about backend
+  patterns.
+paths:
+  - packages/extension/src/**/*.ts
+  - packages/channels/src/**/*.ts
+---
+
+# Backend API Development Guide
+
+## Extension API: @podman-desktop/api
+
+The extension runs as a Podman Desktop extension in Node.js. Host interactions
+go through `@podman-desktop/api` (external dependency, not bundled).
+
+Discover available APIs by reading type definitions:
+
+```sh
+find node_modules/@podman-desktop/api -name '*.d.ts' | head -5
+```
+
+## Kubernetes Client: @kubernetes/client-node
+
+Key classes:
+- `KubeConfig` — load from file, manage contexts
+- `Watch` — stream Kubernetes object changes
+- `KubernetesObjectApi` — direct object operations (CRUD)
+- `loadAllYaml` — parse YAML documents
+
+Kubeconfig lifecycle in `dashboard-extension.ts`:
+
+```typescript
+const kubeconfig = kubernetes.getKubeconfig();
+const kubeConfig = new KubeConfig();
+kubeConfig.loadFromFile(event.location.path);
+await this.#contextsManager.update(kubeConfig);
+
+// Watch for kubeconfig changes
+kubernetes.onDidUpdateKubeconfig(this.onKubeconfigUpdate.bind(this));
+```
+
+## Inversify DI
+
+All services use `@injectable()` and are bound in module files.
+
+### Creating a New Service
+
+1. Define the interface in `packages/channels/src/interface/`
+2. Create the implementation:
+
+```typescript
+@injectable()
+export class MyServiceImpl implements MyServiceApi {
+  @inject(ContextsManager) private manager: ContextsManager;
+
+  async myMethod(arg: string): Promise<Result> {
+    // implementation
+  }
+}
+```
+
+3. Bind in the appropriate module (`packages/extension/src/manager/_manager-module.ts`):
+
+```typescript
+options.bind<MyServiceImpl>(MyServiceImpl).toSelf().inSingletonScope();
+```
+
+4. If the service needs cleanup, also bind as IDisposable:
+
+```typescript
+options.bind(IDisposable).toService(MyServiceImpl);
+```
+
+### DI Module Organization
+
+- `manager/_manager-module.ts` — Core managers and API implementations
+- `dispatcher/_dispatcher-module.ts` — State dispatchers
+- `port-forward/_port-forward-module.ts` — Port forwarding
+- `subscriber/_subscriber_modules.ts` — Channel subscribers
+
+### Symbols
+
+```typescript
+// packages/extension/src/inject/symbol.ts
+export const ExtensionContextSymbol = Symbol.for('ExtensionContext');
+export const TelemetryLoggerSymbol = Symbol.for('TelemetryLogger');
+```
+
+## Dispatcher Pattern (State Broadcasting)
+
+Dispatchers push state from extension to webview via RPC broadcasts.
+
+Base class: `AbsDispatcherObjectImpl<T, U>` in `dispatcher/util/dispatcher-object.ts`
+
+- Debounce: 100ms — prevents rapid-fire updates
+- Throttle: 200ms — guarantees minimum update interval
+
+### Creating a New Dispatcher
+
+```typescript
+@injectable()
+export class MyDispatcher extends AbsDispatcherObjectImpl<MyOptions, MyInfo> {
+  constructor(@inject(ContextsManager) private manager: ContextsManager) {
+    super(MY_CHANNEL);
+  }
+
+  getData(options: MyOptions): MyInfo {
+    return { items: this.manager.getMyData(options) };
+  }
+}
+```
+
+Bind in `dispatcher/_dispatcher-module.ts`:
+
+```typescript
+options.bind<MyDispatcher>(MyDispatcher).toSelf().inSingletonScope();
+options.bind(DispatcherObject).toService(MyDispatcher);
+```
+
+## Subscriber Pattern
+
+`ChannelSubscriber` (`subscriber/channel-subscriber.ts`) tracks which webview
+subscribers need data for each channel. Used by `ContextsStatesDispatcher` to
+dispatch updates only to active subscribers.
+
+## Resource Factories
+
+Each Kubernetes resource type has a factory in `resources/`:
+- `pods-resource-factory.ts`, `deployments-resource-factory.ts`, etc.
+
+Factories implement `ResourceInformerFactory` and `ResourcePermissionsFactory`:
+
+```typescript
+export interface ResourceInformerFactory {
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<KubernetesObject>;
+}
+```
+
+### Adding a New Kubernetes Resource
+
+1. Create `my-resource-factory.ts` in `packages/extension/src/resources/`
+2. Implement `ResourceInformerFactory` and `ResourcePermissionsFactory`
+3. Register in `ResourceFactoryHandler`
+4. Add channel + dispatcher for the resource data
+5. Add state object in webview
+
+## Checklist for New Backend Features
+
+- [ ] Channel interface defined in `packages/channels/src/interface/`
+- [ ] Data models in `packages/channels/src/model/` if needed
+- [ ] RPC channel created in `packages/channels/src/channels.ts`
+- [ ] `@injectable()` implementation in `packages/extension/src/`
+- [ ] Bound in appropriate DI module
+- [ ] Registered with RPC in `dashboard-extension.ts`
+- [ ] Unit tests with mocked `@podman-desktop/api`

--- a/.agents/skills/extension-development/SKILL.md
+++ b/.agents/skills/extension-development/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: extension-development
+description: >-
+  Guides end-to-end feature development in the Kubernetes Dashboard Podman
+  Desktop extension. Covers the extension lifecycle, 5-package architecture,
+  RPC communication, Inversify DI, build system, and extension points. Triggers
+  when adding features spanning extension and webview, understanding the
+  extension lifecycle, or needing an architectural overview.
+---
+
+# Kubernetes Dashboard Extension Development Guide
+
+## Extension Lifecycle
+
+### Entry Point (`packages/extension/src/main.ts`)
+
+`activate()` creates a `DashboardExtension` and returns a
+`KubernetesDashboardExtensionApi`. `deactivate()` cleans up.
+
+### Activation Sequence (`packages/extension/src/dashboard-extension.ts`)
+
+1. Create webview panel (loads `media/index.html`)
+2. Initialize RPC (`new RpcExtension(panel.webview)` + `rpcExtension.init()`)
+3. Setup Inversify DI container (`InversifyBinding.initBindings()`)
+4. Load all managers, dispatchers, subscribers from container
+5. Register RPC instances for each channel (API_CONTEXTS, API_SUBSCRIBE, etc.)
+6. Start kubeconfig watcher, health checks, port forwarding
+7. Return extension API for external consumers
+
+## 5-Package Architecture
+
+```
+Extension (Node.js) <--RPC--> Channels (shared interfaces) <--RPC--> Webview (Svelte 5)
+                                     |
+                                RPC (transport)
+                                     |
+                                API (external)
+```
+
+- **`packages/extension/`** — Node.js backend. Entry: `src/main.ts`. Uses
+  `@podman-desktop/api`, `@kubernetes/client-node`, Inversify DI.
+- **`packages/webview/`** — Svelte 5 UI. Entry: `src/main.ts`, root: `src/Main.svelte`.
+  Uses `@podman-desktop/ui-svelte`, Inversify DI, RpcBrowser.
+- **`packages/channels/`** — Shared RPC channel definitions, API interfaces, and
+  data models. The contract between extension and webview.
+- **`packages/rpc/`** — Transport layer. `RpcExtension` (backend) and `RpcBrowser`
+  (webview) over webview postMessage.
+- **`packages/api/`** — Public API for other Podman Desktop extensions.
+
+### Build Order
+
+RPC and Channels must build first (they are dependencies):
+
+```sh
+pnpm build:rpc && pnpm build:channels && pnpm build
+```
+
+## Adding a New Feature (End-to-End)
+
+1. **Define the channel interface** in `packages/channels/src/interface/`. Create
+   or extend an API interface (e.g., `MyFeatureApi`).
+2. **Define data models** in `packages/channels/src/model/` if needed.
+3. **Create the RPC channel** in `packages/channels/src/channels.ts`:
+   ```typescript
+   export const API_MY_FEATURE = createRpcChannel<MyFeatureApi>('MyFeatureApi');
+   ```
+4. **Implement the backend** in `packages/extension/src/`:
+   - Create `@injectable()` service implementing the interface
+   - Bind in the appropriate DI module (`_manager-module.ts`)
+   - Register with RPC in `dashboard-extension.ts`:
+     ```typescript
+     rpcExtension.registerInstance(API_MY_FEATURE, container.get(MyFeatureApiImpl));
+     ```
+5. **Build the webview UI** in `packages/webview/src/`:
+   - Access via `remote.getProxy(API_MY_FEATURE)`
+   - For state broadcasting, create a StateObject + DispatcherObject pair
+6. **Write tests** — unit tests for both extension and webview, update E2E if needed.
+
+## RPC Communication
+
+### Request-Response (webview calls extension)
+
+```typescript
+// Webview: get proxy, call methods
+const myApi = remote.getProxy(API_MY_FEATURE);
+const result = await myApi.doSomething(args);
+```
+
+### Broadcasting (extension pushes to webview)
+
+```typescript
+// Extension: fire broadcast
+rpcExtension.fire(MY_CHANNEL, data);
+
+// Webview: listen for broadcasts
+const disposable = rpcBrowser.on(MY_CHANNEL, data => { /* handle */ });
+```
+
+### Timeout
+
+Default 5 seconds. For long-running operations:
+
+```typescript
+const proxy = remote.getProxy(API_MY_FEATURE, {
+  noTimeoutMethods: ['longRunningMethod'],
+});
+```
+
+## Extension Points
+
+Extension points (commands, menus, configuration, icons, views) are defined in
+`packages/extension/package.json` under `contributes`.
+
+## Development Watch Mode
+
+```sh
+cd packages/webview && pnpm watch    # Rebuilds webview on changes
+```
+
+The extension is rebuilt by Podman Desktop when webview output changes.

--- a/.agents/skills/playwright-testing/SKILL.md
+++ b/.agents/skills/playwright-testing/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: playwright-testing
+description: >-
+  Guides writing and maintaining Playwright E2E tests for the Kubernetes
+  Dashboard Podman Desktop extension. Covers the webview-aware test framework,
+  envtest/Kubebuilder setup, extension lifecycle, and spec file patterns.
+  Triggers when creating or modifying E2E spec files, debugging Playwright
+  failures, or asking about the E2E test framework.
+paths:
+  - tests/playwright/**/*.ts
+---
+
+# Playwright E2E Testing for Kubernetes Dashboard Extension
+
+This extension runs inside Podman Desktop as a webview. E2E tests launch Podman
+Desktop via Electron, install the extension from an OCI image, then interact
+with the extension's webview UI.
+
+## Project Structure
+
+```
+tests/playwright/
+├── src/
+│   ├── extension.spec.ts           # Main E2E spec file
+│   └── ...
+├── resources/
+│   └── envtest-kubeconfig          # Test kubeconfig (copied from /tmp/)
+├── playwright.config.ts            # Playwright configuration
+└── package.json
+```
+
+## Prerequisites
+
+E2E tests require a local Kubernetes API server via envtest (Kubebuilder):
+
+1. Install `setup-envtest`:
+   ```sh
+   go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
+   ```
+2. Install `envtest-start`:
+   ```sh
+   go install github.com/feloy/envtest-start@latest
+   ```
+3. Set up assets and start:
+   ```sh
+   export KUBEBUILDER_ASSETS=$(setup-envtest use -p path)
+   envtest-start &
+   ```
+4. Copy kubeconfig:
+   ```sh
+   cp /tmp/envtest-kubeconfig tests/resources/
+   ```
+
+## Running Tests
+
+```sh
+# Set the Podman Desktop binary path
+export PODMAN_DESKTOP_BINARY=/path/to/podman-desktop
+
+# First run (installs extension)
+pnpm test:e2e
+
+# Subsequent runs (skip install)
+EXTENSION_PREINSTALLED=true pnpm test:e2e
+```
+
+## Test Framework
+
+Tests use `@podman-desktop/tests-playwright` which provides:
+
+- `test` — Extended Playwright test with Podman Desktop fixtures
+- `expect` / `playExpect` — Assertions
+- `RunnerOptions` — Test runner configuration
+- `PreferencesPage`, `NavigationBar`, etc. — Page objects
+
+## Spec File Pattern
+
+```typescript
+import {
+  test,
+  expect as playExpect,
+  RunnerOptions,
+} from '@podman-desktop/tests-playwright';
+
+test.beforeAll(async ({ runner, welcomePage }) => {
+  test.setTimeout(80_000);
+  runner.setVideoAndTraceName('kubernetes-dashboard-e2e');
+  await welcomePage.handleWelcomePage(true);
+});
+
+test.describe('Feature group', { tag: ['@integration'] }, () => {
+  test('should do something', async ({ navigationBar }) => {
+    const dashboardPage = await navigationBar.openDashboard();
+    // interact with pages
+  });
+});
+```
+
+## CI Integration
+
+E2E tests are not run by default on PRs. Add the `area/ci/e2e` label to
+trigger them. The CI workflow is in `.github/workflows/e2e-tests.yaml`.
+
+## Test Tags
+
+- `@integration` — Full integration tests (requires auth)
+- `@anonymous` — Tests that run without Kubernetes authentication

--- a/.agents/skills/svelte-ui-design/SKILL.md
+++ b/.agents/skills/svelte-ui-design/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: svelte-ui-design
+description: >-
+  Guides designing and building Svelte 5 UI components in the Kubernetes
+  Dashboard extension. Covers @podman-desktop/ui-svelte components, Tailwind
+  CSS, Svelte 5 runes, state management, routing, tables, and component
+  patterns. Triggers when creating or modifying Svelte components, building UI
+  pages, working with the component library, or asking about frontend patterns.
+paths:
+  - packages/webview/src/**/*.svelte
+  - packages/webview/src/**/*.ts
+  - packages/webview/src/**/*.css
+---
+
+# Svelte UI Design Guide
+
+## Component Library Priority
+
+**Always use `@podman-desktop/ui-svelte` first.** This library provides
+Podman Desktop's design system. Only create custom components when the library
+doesn't offer what you need.
+
+Discover available components:
+
+```sh
+ls node_modules/@podman-desktop/ui-svelte/dist/**/*.svelte
+```
+
+Common components: `Button`, `Dropdown`, `Input`, `FormPage`, `ErrorMessage`,
+`Tab`, `Table`, `EmptyScreen`, `StatusIcon`, `Link`.
+
+Storybook reference: https://podman-desktop.io/storybook
+
+## Svelte 5 Runes
+
+This project uses **Svelte 5 runes**. Never use legacy reactive syntax.
+
+```svelte
+<script lang="ts">
+  // State
+  let count = $state(0);
+  let items = $state<Item[]>([]);
+
+  // Derived
+  let total = $derived(items.length);
+  let filtered = $derived(items.filter(i => i.active));
+
+  // Effects
+  $effect(() => {
+    console.log('count changed:', count);
+  });
+</script>
+```
+
+**Never use:** `$:`, `writable()`, `readable()`, `derived()` from `svelte/store`.
+
+## State Management
+
+State objects use `.svelte.ts` extension and the `StateObject` pattern:
+
+```typescript
+// packages/webview/src/state/my-state.svelte.ts
+@injectable()
+export class StateMyInfo extends AbsStateObjectImpl<MyInfo, void> {
+  constructor(@inject(RpcBrowser) rpcBrowser: RpcBrowser) {
+    super(rpcBrowser);
+  }
+  async init(): Promise<void> {
+    await this.initChannel(MY_CHANNEL);
+  }
+}
+```
+
+Access state in components via `States`:
+
+```svelte
+<script lang="ts">
+  const states = getContext<States>(States);
+  const myState = states.stateMyInfoUI;
+  let data = $derived(myState.data);
+
+  onMount(() => {
+    const unsub = myState.subscribe();
+    return unsub;
+  });
+</script>
+```
+
+All states are collected in `packages/webview/src/state/states.ts`.
+
+## Remote API Access
+
+Call backend methods via RPC proxy:
+
+```svelte
+<script lang="ts">
+  const remote = getContext<Remote>(Remote);
+  const contextsApi = remote.getProxy(API_CONTEXTS);
+
+  async function handleAction(): Promise<void> {
+    await contextsApi.setCurrentContext(contextName);
+  }
+</script>
+```
+
+For broadcast listening:
+
+```svelte
+<script lang="ts">
+  const rpcBrowser = getContext<RpcBrowser>(RpcBrowser);
+
+  onMount(() => {
+    const disposable = rpcBrowser.on(MY_CHANNEL, data => {
+      // handle broadcast
+    });
+    return () => disposable.dispose();
+  });
+</script>
+```
+
+## Routing
+
+The app uses hash-based routing with a custom `Route` component
+(`packages/webview/src/Route.svelte`).
+
+Main routing structure:
+- `Main.svelte` — initializes app, waits for context
+- `App.svelte` — checks for current K8s context
+- `AppWithContext.svelte` — renders navigation + routed content
+
+## Component Patterns
+
+### Page Layout
+
+```svelte
+<FormPage title="My Page" description="Page description">
+  <!-- content -->
+</FormPage>
+```
+
+### Resource Tables
+
+Resource list views follow a standard pattern with table components
+in `packages/webview/src/table/`.
+
+### Props Pattern
+
+```svelte
+<script lang="ts">
+  interface Props {
+    resourceName: string;
+    namespace?: string;
+  }
+  let { resourceName, namespace }: Props = $props();
+</script>
+```
+
+## Styling
+
+Use **Tailwind CSS** classes. The theme comes from `@podman-desktop/ui-svelte`.
+
+```svelte
+<div class="flex flex-col w-full h-full gap-2 p-4">
+  <span class="text-[var(--pd-content-text)]">{label}</span>
+</div>
+```
+
+## DI in Webview
+
+The webview has its own Inversify container (`packages/webview/src/inject/inversify-binding.ts`):
+
+```typescript
+container.bind(RpcBrowser).toConstantValue(rpcBrowser);
+container.bind(Remote).toConstantValue(rpcBrowser);
+await container.load(statesModule);
+await container.load(streamsModule);
+```
+
+Context is provided to Svelte components via Svelte `setContext`/`getContext`.

--- a/.agents/skills/unit-testing/SKILL.md
+++ b/.agents/skills/unit-testing/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: unit-testing
+description: >-
+  Guides writing and maintaining Vitest unit tests for the Kubernetes Dashboard
+  extension's backend, webview, and channels packages. Covers mocking
+  @podman-desktop/api, @kubernetes/client-node, Inversify DI, RPC clients,
+  Svelte components, and state objects. Triggers when creating or modifying
+  .spec.ts files, fixing Vitest failures, or adding test coverage.
+paths:
+  - packages/extension/src/**/*.spec.ts
+  - packages/webview/src/**/*.spec.ts
+  - packages/channels/src/**/*.spec.ts
+argument-hint: '[test-file-or-pattern]'
+---
+
+# Unit Testing for Kubernetes Dashboard Extension
+
+## Framework
+
+- **Vitest 4** with v8 coverage provider
+- **Extension**: Node.js environment, mocked `@podman-desktop/api`
+- **Webview**: jsdom environment, `@testing-library/svelte`
+- **Channels**: Node.js environment
+
+## Running Tests
+
+```sh
+pnpm test                          # all unit tests
+pnpm test:extension                # extension tests only
+pnpm test:webview                  # webview tests only
+pnpm vitest run path/to/file.spec.ts  # single file
+pnpm vitest --watch                # watch mode
+```
+
+## Extension Test Patterns
+
+### Mocking @podman-desktop/api
+
+The mock lives at `__mocks__/@podman-desktop/api.js` and is aliased in
+`packages/extension/vitest.config.ts`:
+
+```typescript
+alias: {
+  '@podman-desktop/api': resolve(WORKSPACE_ROOT, '__mocks__/@podman-desktop/api.js'),
+  '/@/': join(PACKAGE_ROOT, 'src') + '/',
+}
+```
+
+### Mocking @kubernetes/client-node
+
+```typescript
+vi.mock(import('@kubernetes/client-node'));
+
+const kubeConfig = new KubeConfig();
+kubeConfig.loadFromFile = vi.fn();
+```
+
+### Mocking Node.js Modules
+
+```typescript
+import { vol } from 'memfs';
+
+vi.mock(import('node:fs'));
+vi.mock(import('node:fs/promises'));
+
+beforeEach(() => {
+  vol.reset();
+  vol.fromJSON({
+    '/path/to/file': 'content',
+  });
+});
+```
+
+### Testing DI Services
+
+Mock dependencies and test the implementation directly:
+
+```typescript
+beforeEach(() => {
+  vi.restoreAllMocks();
+  ContextsManager.prototype.update = vi.fn();
+  ContextsStatesDispatcher.prototype.init = vi.fn();
+});
+
+test('should activate correctly', async () => {
+  await dashboardExtension.activate();
+  expect(ContextsManager.prototype.update).toHaveBeenCalledOnce();
+});
+```
+
+## Webview Test Patterns
+
+### Rendering Svelte Components
+
+```typescript
+import { render } from '@testing-library/svelte';
+import MyComponent from './MyComponent.svelte';
+
+test('renders correctly', () => {
+  const { getByText } = render(MyComponent, { props: { name: 'test' } });
+  expect(getByText('test')).toBeDefined();
+});
+```
+
+### Mocking State Objects
+
+Use `FakeStateObject` for testing components that depend on state:
+
+```typescript
+import { FakeStateObject } from '/@/state/util/fake-state-object.svelte';
+
+const myStateMock = new FakeStateObject();
+myStateMock.setData({ items: [] });
+
+beforeEach(() => {
+  statesMocks.mock<MyInfo, void>('stateMyInfoUI', myStateMock);
+});
+```
+
+### Using Fake Timers
+
+```typescript
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+test('debounced update', async () => {
+  render(MyComponent);
+  await vi.advanceTimersByTimeAsync(600);
+  expect(/* assertion */);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+```
+
+### Mocking Svelte Components
+
+```typescript
+vi.mock(import('/@/component/MyChild.svelte'));
+```
+
+## Test File Structure
+
+```typescript
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock(/* dependencies */);
+
+let sut: MyClass;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  sut = new MyClass(/* mocked deps */);
+});
+
+describe('myMethod', () => {
+  test('should handle normal case', async () => {
+    const result = await sut.myMethod('input');
+    expect(result).toEqual(expected);
+  });
+
+  test('should handle error case', async () => {
+    await expect(sut.myMethod('bad')).rejects.toThrow('error message');
+  });
+});
+```
+
+## Vitest Configuration
+
+Each package has its own `vitest.config.ts`. Key settings:
+
+- **globals: true** — no need to import `describe`, `test`, `expect`
+- **alias** — `/@/` maps to package `src/`, `@podman-desktop/api` maps to mock
+- **environment** — `node` for extension, `jsdom` for webview

--- a/.claude/rules/channels.md
+++ b/.claude/rules/channels.md
@@ -1,0 +1,1 @@
+../../.agents/rules/channels.md

--- a/.claude/rules/extension.md
+++ b/.claude/rules/extension.md
@@ -1,0 +1,1 @@
+../../.agents/rules/extension.md

--- a/.claude/rules/rpc.md
+++ b/.claude/rules/rpc.md
@@ -1,0 +1,1 @@
+../../.agents/rules/rpc.md

--- a/.claude/rules/webview.md
+++ b/.claude/rules/webview.md
@@ -1,0 +1,1 @@
+../../.agents/rules/webview.md

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm exec prettier --cache --write \"$CLAUDE_FILE_PATH\" 2>/dev/null || true"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm exec eslint --cache --fix \"$CLAUDE_FILE_PATH\" 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"$CLAUDE_TOOL_INPUT\" | grep -qE '(rm -rf|git push --force|git reset --hard|git checkout \\.)' && echo 'BLOCK: Destructive operation detected. Please confirm with the user first.' && exit 1 || exit 0"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/backend-api
+++ b/.claude/skills/backend-api
@@ -1,0 +1,1 @@
+../../.agents/skills/backend-api

--- a/.claude/skills/extension-development
+++ b/.claude/skills/extension-development
@@ -1,0 +1,1 @@
+../../.agents/skills/extension-development

--- a/.claude/skills/playwright-testing
+++ b/.claude/skills/playwright-testing
@@ -1,0 +1,1 @@
+../../.agents/skills/playwright-testing

--- a/.claude/skills/svelte-ui-design
+++ b/.claude/skills/svelte-ui-design
@@ -1,0 +1,1 @@
+../../.agents/skills/svelte-ui-design

--- a/.claude/skills/unit-testing
+++ b/.claude/skills/unit-testing
@@ -1,0 +1,1 @@
+../../.agents/skills/unit-testing

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@commitlint/config-conventional"]
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,1 @@
+dependabot.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,17 @@ dist
 output
 packages/extension/media
 /tests/playwright/tests/
+
+# Vim
+*.swp
+*.swo
+
+# npm
+.npm
+
+# VSCode
+.vscode/*
+!.vscode/settings.json
+
+# agentready
+.agentready/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,189 +1,168 @@
 # AGENTS.md
 
-This file provides guidance for AI agents working on the Kubernetes Dashboard Podman Desktop Extension codebase.
-
 ## Project Overview
 
-This is a **monorepo** for a Podman Desktop extension that provides a Kubernetes Dashboard UI. The extension allows users to monitor and interact with Kubernetes clusters, view resources, access pod logs, open terminals, and manage port forwardings.
+Kubernetes Dashboard extension for Podman Desktop. Monitors Kubernetes clusters,
+views resources (deployments, pods, services, configmaps, secrets, etc.), accesses
+pod logs and terminals, and manages port forwardings. Detects kubeconfig changes
+and connects to the current Kubernetes context automatically.
+
+- **Tech stack**: TypeScript, Svelte 5, Tailwind CSS, Vite, pnpm
+- **Monorepo**: pnpm workspaces with five packages — `extension`, `webview`, `channels`, `rpc`, `api`
+- **Extension API**: `@podman-desktop/api`
+- **Kubernetes client**: `@kubernetes/client-node`
+- **DI framework**: Inversify
+- **Test frameworks**: Vitest (unit), Playwright with `@podman-desktop/tests-playwright` (E2E)
+- **License**: Apache-2.0
+
+## Quick Start
+
+```sh
+pnpm install
+pnpm build
+```
+
+## Essential Commands
+
+```sh
+# Build
+pnpm build                    # build all packages (rpc → channels → extension + webview)
+
+# Test
+pnpm test                     # all unit tests
+pnpm test:extension           # extension unit tests
+pnpm test:webview             # webview unit tests
+pnpm test:e2e:integration     # playwright E2E tests (with auth)
+
+# Lint & Format
+pnpm lint:check               # ESLint check
+pnpm lint:fix                 # ESLint fix
+pnpm format:check             # Prettier check
+pnpm format:fix               # Prettier fix
+pnpm typecheck                # TypeScript type checking across all packages
+pnpm svelte:check             # Svelte component validation
+
+# Pre-PR checklist (run all of these)
+pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm test
+```
+
+## Single-File Verification
+
+Lint, type-check, and test a single file without a full build:
+
+```sh
+# Lint single file
+npx eslint path/to/file.ts
+
+# Type-check single file
+npx tsc --noEmit path/to/file.ts
+
+# Type-check by package (when cross-package imports are involved)
+npx tsc --noEmit -p packages/extension/tsconfig.json
+npx tsc --noEmit -p packages/webview/tsconfig.json
+npx tsc --noEmit -p packages/channels/tsconfig.json
+npx tsc --noEmit -p packages/rpc/tsconfig.json
+
+# Test single file
+pnpm vitest run path/to/file.spec.ts
+```
+
+## Skills
+
+Task-specific guidance lives in `.agents/skills/`:
+
+- `extension-development` — end-to-end feature work across extension/webview
+- `backend-api` — extension backend, K8s client, Inversify DI, RPC channels
+- `svelte-ui-design` — Svelte 5 and Podman Desktop UI patterns
+- `unit-testing` — Vitest patterns for extension/webview/channels
+- `playwright-testing` — E2E structure, envtest setup, and spec patterns
 
 ## Architecture
 
-### Monorepo Structure
+Webview (Svelte 5) ←→ RPC (postMessage) ←→ Extension (Node.js)
 
-The project uses **pnpm workspaces** with the following packages:
+- **Extension**: `main.ts` entry, `DashboardExtension`, `@podman-desktop/api` — see **backend-api** skill
+- **Webview**: `Main.svelte`, state objects, `@podman-desktop/ui-svelte` — see **svelte-ui-design** skill
+- **Channels**: RPC channel definitions, API interfaces, data models (shared contract)
+- **RPC**: `RpcExtension` (backend) and `RpcBrowser` (webview) transport layer
+- **API**: Public extension API for other Podman Desktop extensions
 
-- **`packages/api`**: API to share features with other Podman Desktop extensions
-- **`packages/channels`**: Channel abstractions for communication patterns
-- **`packages/extension`**: The main extension code that runs in Podman Desktop (Node.js/TypeScript)
-- **`packages/rpc`**: RPC communication layer between extension and webview
-- **`packages/webview`**: The Svelte-based UI that runs in a webview (Svelte 5 + TypeScript)
-- **`tests/playwright`**: End-to-end tests using Playwright
+Five packages under `packages/`:
 
-### Communication Flow
+- **`extension/`** — Node.js extension. Entry: `src/main.ts`, lifecycle: `src/dashboard-extension.ts`. Uses Inversify DI, `@kubernetes/client-node`.
+- **`webview/`** — Svelte 5 webview UI. Entry: `src/main.ts`, root: `src/Main.svelte`. Uses Inversify DI, state objects (`.svelte.ts`).
+- **`channels/`** — Shared interfaces and models. Channels: `src/channels.ts`, interfaces: `src/interface/`, models: `src/model/`.
+- **`rpc/`** — RPC transport. `src/rpc.ts` provides `RpcExtension` and `RpcBrowser`.
+- **`api/`** — Public API types: `src/kubernetes-dashboard-extension-api.d.ts`.
 
-- Extension ↔ Webview: Uses RPC channels for bidirectional communication
-- Extension ↔ Kubernetes API: Uses `@kubernetes/client-node`
-- Webview ↔ Extension: All operations go through RPC channels
+### Communication
 
-## Key Technologies
+Extension ↔ Webview via RPC over webview postMessage:
 
-- **TypeScript 5**: Strict type checking enabled
-- **Svelte 5**: Modern reactive framework (runes-based)
-- **Vite 7**: Build tool and dev server
-- **pnpm**: Package manager
-- **Node.js >=24.0.0**: Runtime requirement
-- **Vitest**: Unit testing framework
-- **Playwright**: E2E testing
-- **Inversify**: Dependency injection container
-- **Svelte Components**: via `@podman-desktop/ui-svelte`
-- **Tailwind CSS**: Styling (via `@podman-desktop/ui-svelte`)
+- `RpcExtension` (extension) registers `@injectable()` services for each channel
+- `RpcBrowser` (webview) calls methods via `remote.getProxy(CHANNEL)`
+- Broadcast channels defined in `packages/channels/src/channels.ts`
 
-## Coding Standards
+### Key Patterns
 
-### TypeScript
+- **Inversify DI**: Services use `@injectable()`, bound in module files (`_*-module.ts`), injected via `@inject()`
+- **Dispatcher**: `AbsDispatcherObjectImpl` pushes state to webview with debounce/throttle
+- **StateObject**: `AbsStateObjectImpl` (`.svelte.ts`) manages reactive state in webview
+- **Resource factories**: Each K8s resource type has a factory in `packages/extension/src/resources/`
 
-- Use **strict TypeScript** (`@tsconfig/strictest`)
-- Prefer explicit types over `any`
-- Use interfaces for object shapes
-- Avoid `null` - use `undefined` instead (enforced by `eslint-plugin-no-null`)
-- Avoid redundant `undefined` in optional properties (enforced by `eslint-plugin-redundant-undefined`)
+### Extension Registration
 
-### Svelte
+Extension points (commands, menus, configuration, icons, views) are defined in
+`packages/extension/package.json` under `contributes`.
 
-- Use **Svelte 5 runes** (`$state`, `$derived`, `$effect`, etc.)
-- Prefer runes over legacy reactive statements
-- Keep components focused and composable
-- Use TypeScript for component logic
+## Pattern References
 
-### File Organization
+- New RPC channel: follow `packages/channels/src/channels.ts` (definition), `packages/channels/src/interface/` (interface)
+- New backend service: follow `packages/extension/src/manager/contexts-manager.ts` (implementation), `packages/extension/src/manager/_manager-module.ts` (binding)
+- New dispatcher: follow `packages/extension/src/dispatcher/update-resource-dispatcher.ts`
+- New state object: follow `packages/webview/src/state/available-contexts.svelte.ts`
+- New Svelte page/component: follow `packages/webview/src/component/apply/KubeApplyYAML.svelte`
+- New unit test (extension): follow `packages/extension/src/dashboard-extension.spec.ts`
+- New unit test (webview): follow `packages/webview/src/App.spec.ts`
+- New E2E test: follow `tests/playwright/src/extension.spec.ts`
+- New resource factory: follow `packages/extension/src/resources/pods-resource-factory.ts`
 
-- Source files in `src/` directories
-- Tests co-located
-- Use clear, descriptive file names
-- Group related functionality together
+## Coding Guidelines
 
-### Imports
+### Svelte Patterns
 
-- Use **simple-import-sort** plugin ordering:
-  1. External dependencies
-  2. Internal packages (`@kubernetes-dashboard/*`)
-  3. Podman Desktop packages (`@podman-desktop/*`)
-  4. Relative imports
-- Prefer named exports over default exports
-- Use absolute imports with aliases when configured (e.g., `/@/`)
+This project uses **Svelte 5 runes** (`$state`, `$derived`, `$effect`). Do NOT use legacy reactive syntax (`$:`, `let x = writable()`). For concrete component and state patterns, use `.agents/skills/svelte-ui-design/SKILL.md`.
 
-### Error Handling
+### Testing Patterns
 
-- Always handle errors explicitly
-- Use proper error types
-- Log errors appropriately
-- Provide meaningful error messages
+Use `.agents/skills/unit-testing/SKILL.md` for unit-test patterns and `.agents/skills/playwright-testing/SKILL.md` for E2E patterns. Extension tests mock `@podman-desktop/api` and `@kubernetes/client-node`, webview tests use `@testing-library/svelte` with `FakeStateObject`. Import alias: `/@/` → `src/`.
 
-## Development Workflow
+### Commit Conventions
 
-### Setup
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
 
-```bash
-pnpm i                    # Install dependencies
-cd packages/webview
-pnpm watch               # Watch mode for webview (keep running)
+```text
+feat: add CronJob resource view
+feat(pods): add more information to pod page
+fix: handle missing kubeconfig gracefully
+chore: bump eslint-plugin-unicorn
+docs: update README with E2E instructions
 ```
 
-### Build Commands
+### Import Organization
 
-- `pnpm build`: Build all packages
-- `pnpm watch`: Watch mode for webview and extension
-- `pnpm format:check`: Check code formatting
-- `pnpm format:fix`: Auto-fix formatting
-- `pnpm lint:check`: Check linting
-- `pnpm lint:fix`: Auto-fix linting
-- `pnpm typecheck`: Type check all packages
-- `pnpm test`: Run all unit tests
-- `pnpm test:e2e`: Run E2E tests
+Use **simple-import-sort** plugin ordering:
 
-### Testing
+1. External dependencies
+2. Internal packages (`@kubernetes-dashboard/*`)
+3. Podman Desktop packages (`@podman-desktop/*`)
+4. Relative imports
 
-- **Unit tests**: Use Vitest with `@testing-library/svelte` for Svelte components
-- **E2E tests**: Use Playwright (requires `area/ci/e2e` label on PR to run in CI)
-- Write tests for new features
-- Maintain or improve test coverage
-
-## Important Patterns
-
-### Dependency Injection
-
-The project uses **Inversify** for DI. When adding new services:
-
-1. Define interfaces for services
-2. Create implementations with `@injectable()` decorator
-3. Bind in the appropriate binding file (`inversify-binding.ts`)
-4. Inject dependencies via constructor or via property
-
-### Stream Objects
-
-For streaming data (logs, terminal output), use the `StreamObject` pattern:
-
-```typescript
-export interface StreamObject<T, U> {
-  subscribe(
-    podName: string,
-    namespace: string,
-    containerName: string,
-    options: U,
-    callback: (data: T) => void,
-  ): Promise<IDisposable>;
-}
-```
-
-### RPC Communication
-
-- All webview ↔ extension communication goes through RPC channels
-- Define channel interfaces in `packages/channels`
-- Use typed RPC methods for type safety
-
-### Resource Management
-
-- Implement `IDisposable` for resources that need cleanup
-- Always dispose of subscriptions, timers, and event listeners
-- Use try/finally or cleanup functions in effects
-
-## Common Tasks
-
-### Adding a New Kubernetes Resource View
-
-1. Create component in `packages/webview/src/component/`
-2. Add RPC method in `packages/rpc` if needed
-3. Add route in webview router
-4. Update navigation/menu if needed
-5. Add tests
-
-### Adding a New Feature
-
-1. Determine if it needs extension-side code (Kubernetes API access)
-2. Create RPC methods if needed
-3. Implement webview UI using components from Podman Desktop UI library (`@podman-desktop/ui-svelte`)
-4. Add proper error handling
-5. Write tests
-6. Update documentation if needed
-
-### Debugging
-
-- Extension logs: Check Podman Desktop console
-- Webview logs: Check browser devtools (if webview is debuggable)
-- Use `console.log` sparingly, prefer proper logging
-- Check RPC channel communication for issues
-
-## Code Quality
-
-- **ESLint**: Comprehensive linting with strict rules
-- **Prettier**: Code formatting (check `.prettierrc`)
-- **TypeScript**: Strict type checking
-- **Svelte Check**: Svelte-specific validation
-- All checks must pass before committing
+Import alias: `/@/` → package `src/` directory.
 
 ## License
 
-Apache 2.0 - Include license header in new files:
+Apache 2.0 — include license header in new files:
 
 ```typescript
 /**********************************************************************
@@ -205,17 +184,10 @@ Apache 2.0 - Include license header in new files:
  ***********************************************************************/
 ```
 
-Update headers for modified files, with the current year:
+Update headers for modified files with the current year:
 
 ```typescript
 /**********************************************************************
  * Copyright (C) 2024 - 2026 Red Hat, Inc.
 [...]
 ```
-
-
-## Additional Resources
-
-- See `docs/data-flow.md` for data flow documentation
-- Check existing components for patterns and conventions
-- Review `.github/workflows/` for CI/CD requirements


### PR DESCRIPTION
chore: improve agentready score with config, rules, and skills

Add agent configuration to improve AI-assisted development readiness:

- Restructure AGENTS.md with Quick Start, Essential Commands, Single-File
  Verification, Skills, Pattern References, and concise Architecture
- Add .claude/settings.json with auto-format/lint hooks and destructive
  operation blocking
- Add .agents/rules/ with path-scoped rules for extension, webview,
  channels, and rpc packages (symlinked from .claude/rules/)
- Add .agents/skills/ with 5 task-specific skill guides (backend-api,
  extension-development, svelte-ui-design, unit-testing, playwright-testing)
  symlinked from .claude/skills/
- Add .agentready-config.yaml excluding monorepo false positives
- Add .commitlintrc.json, .pre-commit-config.yaml for deterministic
  enforcement
- Update .gitignore and README.md

Closes: https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/964

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
