### PR TITLE
chore(ui): add more width to roles

### DIFF
--- a/packages/webview/src/component/nodes/NodesList.svelte
+++ b/packages/webview/src/component/nodes/NodesList.svelte
@@ -29,6 +29,7 @@ let nameColumn = new TableColumn<NodeUI>('Name', {
 });
 
 let rolesColumn = new TableColumn<NodeUI>('Roles', {
+  width: '180px',
   renderer: RolesColumn,
   overflow: true,
   comparator: (a, b): number => a.role.localeCompare(b.role),


### PR DESCRIPTION
chore(ui): add more width to roles

### What does this PR do?

Nitpick, adds more width to roles since they were looking odd with
multiple labels.

### Screenshot / video of UI

Before:
<img width="1359" height="896" alt="598172917-977e4a72-cd25-4b5e-aca5-d44090279117" src="https://github.com/user-attachments/assets/19b62f78-6116-49c6-8ce7-cc89cafff83c" />




After:
<img width="1317" height="991" alt="Screenshot 2026-05-26 at 8 28 41 AM" src="https://github.com/user-attachments/assets/0d16706f-944b-4a9e-bb98-a0fb20e2f0a9" />



### What issues does this PR fix or reference?

N/A

### How to test this PR?

Look at nodes page and see width is better.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
