### PR TITLE
chore: build rpc and channels deps before extension and webview build/watch

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -16,14 +16,15 @@
     ]
   },
   "scripts": {
-    "build": "vite build",
+    "build:deps": "pnpm --filter @kubernetes-dashboard/rpc run build && pnpm --filter @kubernetes-dashboard/channels run build",
+    "build": "pnpm run build:deps && vite build",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch --coverage",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "format:fix": "prettier --write \"src/**/*.ts\"",
     "lint:check": "eslint . --ext js,ts,tsx",
     "lint:fix": "eslint . --fix --ext js,ts,tsx",
-    "watch": "vite --mode development build -w"
+    "watch": "pnpm run build:deps && vite --mode development build -w"
   },
   "devDependencies": {
     "@kubernetes-dashboard/rpc": "workspace:*",

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -6,14 +6,15 @@
   "type": "module",
   "scripts": {
     "preview": "vite preview",
-    "build": "vite build",
+    "build:deps": "pnpm --filter @kubernetes-dashboard/rpc run build && pnpm --filter @kubernetes-dashboard/channels run build",
+    "build": "pnpm run build:deps && vite build",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch --coverage",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "format:fix": "prettier --write \"src/**/*.{ts,svelte}\"",
     "lint:check": "eslint . --ext js,ts,tsx",
     "lint:fix": "eslint . --fix --ext js,ts,tsx",
-    "watch": "vite --mode development build -w",
+    "watch": "pnpm run build:deps && vite --mode development build -w",
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {


### PR DESCRIPTION
### What does this PR do?

The root watch script launches extension and webview watches concurrently without pre-building rpc and channels, causing resolution failures when those packages haven't been compiled yet. Add a build:deps script to both packages that compiles rpc and channels first, and prepend it to their build and watch scripts.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #1030 

### How to test this PR?

See #1030 