### PR TITLE
chore(fix): fix namespace dropdown

### DIFF
--- a/packages/webview/src/component/objects/NamespaceDropdown.spec.ts
+++ b/packages/webview/src/component/objects/NamespaceDropdown.spec.ts
@@ -119,7 +119,7 @@ test('Expect basic styling', async () => {
 
   const dropdown = screen.getByLabelText('Kubernetes Namespace');
   expect(dropdown).toBeInTheDocument();
-  expect(dropdown).toHaveClass('w-64 max-w-64 truncate');
+  expect(dropdown).toHaveClass('w-64 max-w-64');
 });
 
 test('Expect namespaces are in the dropdown', async () => {

--- a/packages/webview/src/component/objects/NamespaceDropdown.svelte
+++ b/packages/webview/src/component/objects/NamespaceDropdown.svelte
@@ -58,7 +58,7 @@ onDestroy(() => {
 <Dropdown
   ariaLabel="Kubernetes Namespace"
   name="namespace"
-  class="w-64 max-w-64 truncate"
+  class="w-64 max-w-64"
   value={currentNamespace}
   disabled={!reachable}
   onChange={handleNamespaceChange}


### PR DESCRIPTION
chore(fix): fix namespace dropdown

### What does this PR do?

Remove truncate which wasn't showing the namespace dropdown.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/user-attachments/assets/d251a5e9-f6cc-4f99-b2e9-35fdb690e885



### What issues does this PR fix or reference?

<!-- Include any related issues from the
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/1025

### How to test this PR?

<!-- Please explain steps to reproduce -->

Go to pods, see that you can select via namespace now.
