### PR TITLE
feat: add DaemonSets, StatefulSets, and ReplicaSets resource views

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -73,6 +73,9 @@ import { ServicesResourceFactory } from '/@/resources/services-resource-factory.
 import { inject, injectable } from 'inversify';
 import { NamespacesResourceFactory } from '/@/resources/namespaces-resource-factory.js';
 import { EndpointSlicesResourceFactory } from '/@/resources/endpoint-slices-resource-factory.js';
+import { DaemonSetsResourceFactory } from '/@/resources/daemonsets-resource-factory.js';
+import { StatefulSetsResourceFactory } from '/@/resources/statefulsets-resource-factory.js';
+import { ReplicaSetsResourceFactory } from '/@/resources/replicasets-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -174,6 +177,9 @@ export class ContextsManager implements ContextsApi {
       new RoutesResourceFactory(this),
       new SecretsResourceFactory(),
       new ServicesResourceFactory(),
+      new DaemonSetsResourceFactory(),
+      new StatefulSetsResourceFactory(),
+      new ReplicaSetsResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/daemonsets-resource-factory.ts
+++ b/packages/extension/src/resources/daemonsets-resource-factory.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1DaemonSet, V1DaemonSetList, V1Status } from '@kubernetes/client-node';
+import { AppsV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class DaemonSetsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'daemonsets',
+      kind: 'DaemonSet',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'apps',
+          resource: 'daemonsets',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setIsActive(this.isDaemonSetActive);
+    this.setDeleteObject(this.deleteDaemonSet);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1DaemonSet> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AppsV1Api);
+    const listFn = (): Promise<V1DaemonSetList> => apiClient.listNamespacedDaemonSet({ namespace });
+    const path = `/apis/apps/v1/namespaces/${namespace}/daemonsets`;
+    return new ResourceInformer<V1DaemonSet>({ kubeconfig, path, listFn, kind: this.kind, plural: 'daemonsets' });
+  }
+
+  isDaemonSetActive(daemonSet: V1DaemonSet): boolean {
+    return (daemonSet.status?.desiredNumberScheduled ?? 0) > 0;
+  }
+
+  deleteDaemonSet(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AppsV1Api);
+    return apiClient.deleteNamespacedDaemonSet({ name, namespace });
+  }
+}

--- a/packages/extension/src/resources/replicasets-resource-factory.ts
+++ b/packages/extension/src/resources/replicasets-resource-factory.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1ReplicaSet, V1ReplicaSetList, V1Status } from '@kubernetes/client-node';
+import { AppsV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class ReplicaSetsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'replicasets',
+      kind: 'ReplicaSet',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'apps',
+          resource: 'replicasets',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setIsActive(this.isReplicaSetActive);
+    this.setDeleteObject(this.deleteReplicaSet);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1ReplicaSet> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AppsV1Api);
+    const listFn = (): Promise<V1ReplicaSetList> => apiClient.listNamespacedReplicaSet({ namespace });
+    const path = `/apis/apps/v1/namespaces/${namespace}/replicasets`;
+    return new ResourceInformer<V1ReplicaSet>({ kubeconfig, path, listFn, kind: this.kind, plural: 'replicasets' });
+  }
+
+  isReplicaSetActive(replicaSet: V1ReplicaSet): boolean {
+    return (replicaSet.spec?.replicas ?? 0) > 0;
+  }
+
+  deleteReplicaSet(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AppsV1Api);
+    return apiClient.deleteNamespacedReplicaSet({ name, namespace });
+  }
+}

--- a/packages/extension/src/resources/statefulsets-resource-factory.ts
+++ b/packages/extension/src/resources/statefulsets-resource-factory.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1StatefulSet, V1StatefulSetList, V1Status } from '@kubernetes/client-node';
+import { AppsV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class StatefulSetsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'statefulsets',
+      kind: 'StatefulSet',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'apps',
+          resource: 'statefulsets',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setIsActive(this.isStatefulSetActive);
+    this.setDeleteObject(this.deleteStatefulSet);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1StatefulSet> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AppsV1Api);
+    const listFn = (): Promise<V1StatefulSetList> => apiClient.listNamespacedStatefulSet({ namespace });
+    const path = `/apis/apps/v1/namespaces/${namespace}/statefulsets`;
+    return new ResourceInformer<V1StatefulSet>({ kubeconfig, path, listFn, kind: this.kind, plural: 'statefulsets' });
+  }
+
+  isStatefulSetActive(statefulSet: V1StatefulSet): boolean {
+    return (statefulSet.spec?.replicas ?? 0) > 0;
+  }
+
+  deleteStatefulSet(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AppsV1Api);
+    return apiClient.deleteNamespacedStatefulSet({ name, namespace });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -26,6 +26,12 @@ import CronJobDetails from './component/cronjobs/CronJobDetails.svelte';
 import PodDetails from './component/pods/PodDetails.svelte';
 import PortForwardingList from './component/port-forward/PortForwardingList.svelte';
 import KubeApplyYAML from './component/apply/KubeApplyYAML.svelte';
+import DaemonSetsList from '/@/component/daemonsets/DaemonSetsList.svelte';
+import DaemonSetDetails from '/@/component/daemonsets/DaemonSetDetails.svelte';
+import StatefulSetsList from '/@/component/statefulsets/StatefulSetsList.svelte';
+import StatefulSetDetails from '/@/component/statefulsets/StatefulSetDetails.svelte';
+import ReplicaSetsList from '/@/component/replicasets/ReplicaSetsList.svelte';
+import ReplicaSetDetails from '/@/component/replicasets/ReplicaSetDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -138,5 +144,29 @@ const { meta }: Props = $props();
 
   <Route path="/applyYaml">
     <KubeApplyYAML />
+  </Route>
+
+  <Route path="/daemonsets">
+    <DaemonSetsList />
+  </Route>
+
+  <Route path="/daemonsets/:name/:namespace/*" let:meta>
+    <DaemonSetDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/statefulsets">
+    <StatefulSetsList />
+  </Route>
+
+  <Route path="/statefulsets/:name/:namespace/*" let:meta>
+    <StatefulSetDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/replicasets">
+    <ReplicaSetsList />
+  </Route>
+
+  <Route path="/replicasets/:name/:namespace/*" let:meta>
+    <ReplicaSetDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
   </Route>
 </div>

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -32,6 +32,9 @@ function isUnderSection(sectionUrls: string[]): boolean {
 
 const workloadUrls = [
   navigator.kubernetesResourcesURL('Deployment'),
+  navigator.kubernetesResourcesURL('DaemonSet'),
+  navigator.kubernetesResourcesURL('StatefulSet'),
+  navigator.kubernetesResourcesURL('ReplicaSet'),
   navigator.kubernetesResourcesURL('Pod'),
   navigator.kubernetesResourcesURL('Job'),
   navigator.kubernetesResourcesURL('CronJob'),
@@ -129,6 +132,21 @@ $effect(() => {
         child={true}
         selected={url === navigator.kubernetesResourcesURL('Deployment')}
         href={navigator.kubernetesResourcesURL('Deployment')} />
+      <SettingsNavItem
+        title="DaemonSets"
+        child={true}
+        selected={url === navigator.kubernetesResourcesURL('DaemonSet')}
+        href={navigator.kubernetesResourcesURL('DaemonSet')} />
+      <SettingsNavItem
+        title="StatefulSets"
+        child={true}
+        selected={url === navigator.kubernetesResourcesURL('StatefulSet')}
+        href={navigator.kubernetesResourcesURL('StatefulSet')} />
+      <SettingsNavItem
+        title="ReplicaSets"
+        child={true}
+        selected={url === navigator.kubernetesResourcesURL('ReplicaSet')}
+        href={navigator.kubernetesResourcesURL('ReplicaSet')} />
       <SettingsNavItem
         title="Pods"
         child={true}

--- a/packages/webview/src/component/daemonsets/DaemonSetDetails.svelte
+++ b/packages/webview/src/component/daemonsets/DaemonSetDetails.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+import type { V1DaemonSet } from '@kubernetes/client-node';
+import { getContext } from 'svelte';
+
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+
+import { DaemonSetHelper } from './daemonset-helper';
+import type { DaemonSetUI } from './DaemonSetUI';
+import DaemonSetDetailsSummary from './DaemonSetDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const daemonSetHelper = dependencyAccessor.get<DaemonSetHelper>(DaemonSetHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1DaemonSet}
+  typedUI={{} as DaemonSetUI}
+  kind="DaemonSet"
+  resourceName="daemonsets"
+  listName="DaemonSets"
+  name={name}
+  namespace={namespace}
+  transformer={daemonSetHelper.getDaemonSetUI.bind(daemonSetHelper)}
+  SummaryComponent={DaemonSetDetailsSummary} />

--- a/packages/webview/src/component/daemonsets/DaemonSetDetailsSummary.svelte
+++ b/packages/webview/src/component/daemonsets/DaemonSetDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1DaemonSet } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1DaemonSet;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/daemonsets/DaemonSetUI.ts
+++ b/packages/webview/src/component/daemonsets/DaemonSetUI.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI.ts';
+
+export interface DaemonSetUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  desired: number;
+  current: number;
+  ready: number;
+  upToDate: number;
+  available: number;
+  nodeSelector: string;
+  created?: Date;
+}

--- a/packages/webview/src/component/daemonsets/DaemonSetsList.svelte
+++ b/packages/webview/src/component/daemonsets/DaemonSetsList.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+import moment from 'moment';
+import { getContext } from 'svelte';
+
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+
+import { icon } from '/@/component/icons/icon';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+
+import type { DaemonSetUI } from './DaemonSetUI';
+import ReadyColumn from './columns/Ready.svelte';
+import { DaemonSetHelper } from './daemonset-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const daemonSetHelper = dependencyAccessor.get<DaemonSetHelper>(DaemonSetHelper);
+
+let statusColumn = new TableColumn<DaemonSetUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<DaemonSetUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let readyColumn = new TableColumn<DaemonSetUI>('Ready', {
+  renderer: ReadyColumn,
+  comparator: (a, b): number => a.ready - b.ready,
+});
+
+let upToDateColumn = new TableColumn<DaemonSetUI, string>('Up-to-date', {
+  renderMapping: (obj): string => String(obj.upToDate),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.upToDate - b.upToDate,
+});
+
+let nodeSelectorColumn = new TableColumn<DaemonSetUI, string>('Node Selector', {
+  renderMapping: (obj): string => obj.nodeSelector,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.nodeSelector.localeCompare(b.nodeSelector),
+});
+
+let ageColumn = new TableColumn<DaemonSetUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [statusColumn, nameColumn, readyColumn, upToDateColumn, nodeSelectorColumn, ageColumn];
+
+const row = new TableRow<DaemonSetUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'daemonsets',
+      transformer: daemonSetHelper.getDaemonSetUI,
+    },
+  ]}
+  singular="daemonset"
+  plural="daemonsets"
+  isNamespaced={true}
+  icon={icon['DaemonSet']}
+  columns={columns}
+  row={row}>
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['DaemonSet']} resources={['daemonsets']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/daemonsets/_daemonsets-module.ts
+++ b/packages/webview/src/component/daemonsets/_daemonsets-module.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { DaemonSetHelper } from './daemonset-helper';
+
+const daemonSetsModule = new ContainerModule(options => {
+  options.bind<DaemonSetHelper>(DaemonSetHelper).toSelf().inSingletonScope();
+});
+
+export { daemonSetsModule };

--- a/packages/webview/src/component/daemonsets/columns/Ready.svelte
+++ b/packages/webview/src/component/daemonsets/columns/Ready.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import type { Props } from './props';
+
+let { object }: Props = $props();
+
+let colorClass = $derived(
+  object.ready === object.desired ? 'text-(--pd-status-running)' : 'text-(--pd-status-degraded)',
+);
+</script>
+
+<div class={colorClass}>
+  {object.ready} / {object.desired}
+</div>

--- a/packages/webview/src/component/daemonsets/columns/props.ts
+++ b/packages/webview/src/component/daemonsets/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { DaemonSetUI } from '/@/component/daemonsets/DaemonSetUI';
+
+export interface Props {
+  object: DaemonSetUI;
+}

--- a/packages/webview/src/component/daemonsets/daemonset-helper.spec.ts
+++ b/packages/webview/src/component/daemonsets/daemonset-helper.spec.ts
@@ -1,0 +1,108 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1DaemonSet } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { DaemonSetHelper } from './daemonset-helper';
+
+let daemonSetHelper: DaemonSetHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  daemonSetHelper = new DaemonSetHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const daemonSet = {
+    metadata: {
+      name: 'my-daemonset',
+      namespace: 'test-namespace',
+      uid: 'test-uid-123',
+    },
+    status: {
+      desiredNumberScheduled: 3,
+      numberReady: 3,
+      currentNumberScheduled: 3,
+      updatedNumberScheduled: 3,
+      numberAvailable: 3,
+    },
+  } as V1DaemonSet;
+  const daemonSetUI = daemonSetHelper.getDaemonSetUI(daemonSet);
+  expect(daemonSetUI.kind).toEqual('DaemonSet');
+  expect(daemonSetUI.name).toEqual('my-daemonset');
+  expect(daemonSetUI.namespace).toEqual('test-namespace');
+  expect(daemonSetUI.uid).toEqual('test-uid-123');
+  expect(daemonSetUI.desired).toEqual(3);
+  expect(daemonSetUI.ready).toEqual(3);
+});
+
+test('expect RUNNING status when desired > 0 and ready equals desired', async () => {
+  const daemonSet = {
+    metadata: { name: 'ds' },
+    status: { desiredNumberScheduled: 2, numberReady: 2 },
+  } as V1DaemonSet;
+  const daemonSetUI = daemonSetHelper.getDaemonSetUI(daemonSet);
+  expect(daemonSetUI.status).toEqual('RUNNING');
+});
+
+test('expect DEGRADED status when desired > 0 and ready < desired', async () => {
+  const daemonSet = {
+    metadata: { name: 'ds' },
+    status: { desiredNumberScheduled: 3, numberReady: 1 },
+  } as V1DaemonSet;
+  const daemonSetUI = daemonSetHelper.getDaemonSetUI(daemonSet);
+  expect(daemonSetUI.status).toEqual('DEGRADED');
+});
+
+test('expect STOPPED status when desired is 0', async () => {
+  const daemonSet = {
+    metadata: { name: 'ds' },
+    status: { desiredNumberScheduled: 0, numberReady: 0 },
+  } as V1DaemonSet;
+  const daemonSetUI = daemonSetHelper.getDaemonSetUI(daemonSet);
+  expect(daemonSetUI.status).toEqual('STOPPED');
+});
+
+test('expect nodeSelector formatted as key=value pairs', async () => {
+  const daemonSet = {
+    metadata: { name: 'ds' },
+    spec: {
+      template: {
+        spec: {
+          nodeSelector: { 'kubernetes.io/os': 'linux', 'node-role': 'worker' },
+        },
+      },
+    },
+    status: { desiredNumberScheduled: 1, numberReady: 1 },
+  } as unknown as V1DaemonSet;
+  const daemonSetUI = daemonSetHelper.getDaemonSetUI(daemonSet);
+  expect(daemonSetUI.nodeSelector).toEqual('kubernetes.io/os=linux, node-role=worker');
+});
+
+test('expect default values when fields are missing', async () => {
+  const daemonSet = { metadata: {} } as V1DaemonSet;
+  const daemonSetUI = daemonSetHelper.getDaemonSetUI(daemonSet);
+  expect(daemonSetUI.name).toEqual('');
+  expect(daemonSetUI.namespace).toEqual('');
+  expect(daemonSetUI.uid).toEqual('');
+  expect(daemonSetUI.desired).toEqual(0);
+  expect(daemonSetUI.ready).toEqual(0);
+  expect(daemonSetUI.nodeSelector).toEqual('');
+  expect(daemonSetUI.status).toEqual('STOPPED');
+});

--- a/packages/webview/src/component/daemonsets/daemonset-helper.ts
+++ b/packages/webview/src/component/daemonsets/daemonset-helper.ts
@@ -1,0 +1,56 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1DaemonSet } from '@kubernetes/client-node';
+import { injectable } from 'inversify';
+
+import type { DaemonSetUI } from './DaemonSetUI';
+
+@injectable()
+export class DaemonSetHelper {
+  getDaemonSetUI(o: KubernetesObject): DaemonSetUI {
+    const obj = o as V1DaemonSet;
+    const desired = obj.status?.desiredNumberScheduled ?? 0;
+    const ready = obj.status?.numberReady ?? 0;
+
+    let status = 'STOPPED';
+    if (desired > 0) {
+      status = ready === desired ? 'RUNNING' : 'DEGRADED';
+    }
+
+    return {
+      kind: 'DaemonSet',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status,
+      namespace: obj.metadata?.namespace ?? '',
+      created: obj.metadata?.creationTimestamp,
+      selected: false,
+      desired,
+      current: obj.status?.currentNumberScheduled ?? 0,
+      ready,
+      upToDate: obj.status?.updatedNumberScheduled ?? 0,
+      available: obj.status?.numberAvailable ?? 0,
+      nodeSelector: obj.spec?.template?.spec?.nodeSelector
+        ? Object.entries(obj.spec.template.spec.nodeSelector)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(', ')
+        : '',
+    };
+  }
+}

--- a/packages/webview/src/component/icons/icon.ts
+++ b/packages/webview/src/component/icons/icon.ts
@@ -46,4 +46,7 @@ export const icon: Record<string, Component | IconDefinition> = {
   PersistentVolumeClaim: PvcIcon,
   Service: ServiceIcon,
   Namespace: NamespaceIcon,
+  DaemonSet: DeploymentIcon,
+  StatefulSet: DeploymentIcon,
+  ReplicaSet: DeploymentIcon,
 };

--- a/packages/webview/src/component/replicasets/ReplicaSetDetails.svelte
+++ b/packages/webview/src/component/replicasets/ReplicaSetDetails.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+import type { V1ReplicaSet } from '@kubernetes/client-node';
+import { getContext } from 'svelte';
+
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+
+import { ReplicaSetHelper } from './replicaset-helper';
+import type { ReplicaSetUI } from './ReplicaSetUI';
+import ReplicaSetDetailsSummary from './ReplicaSetDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const replicaSetHelper = dependencyAccessor.get<ReplicaSetHelper>(ReplicaSetHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1ReplicaSet}
+  typedUI={{} as ReplicaSetUI}
+  kind="ReplicaSet"
+  resourceName="replicasets"
+  listName="ReplicaSets"
+  name={name}
+  namespace={namespace}
+  transformer={replicaSetHelper.getReplicaSetUI.bind(replicaSetHelper)}
+  SummaryComponent={ReplicaSetDetailsSummary} />

--- a/packages/webview/src/component/replicasets/ReplicaSetDetailsSummary.svelte
+++ b/packages/webview/src/component/replicasets/ReplicaSetDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1ReplicaSet } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1ReplicaSet;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/replicasets/ReplicaSetUI.ts
+++ b/packages/webview/src/component/replicasets/ReplicaSetUI.ts
@@ -1,0 +1,28 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI.ts';
+
+export interface ReplicaSetUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  desired: number;
+  current: number;
+  ready: number;
+  owner: string;
+  created?: Date;
+}

--- a/packages/webview/src/component/replicasets/ReplicaSetsList.svelte
+++ b/packages/webview/src/component/replicasets/ReplicaSetsList.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+import moment from 'moment';
+import { getContext } from 'svelte';
+
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+
+import { icon } from '/@/component/icons/icon';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+
+import type { ReplicaSetUI } from './ReplicaSetUI';
+import { ReplicaSetHelper } from './replicaset-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const replicaSetHelper = dependencyAccessor.get<ReplicaSetHelper>(ReplicaSetHelper);
+
+let statusColumn = new TableColumn<ReplicaSetUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<ReplicaSetUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let desiredColumn = new TableColumn<ReplicaSetUI, string>('Desired', {
+  renderMapping: (obj): string => String(obj.desired),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.desired - b.desired,
+});
+
+let currentColumn = new TableColumn<ReplicaSetUI, string>('Current', {
+  renderMapping: (obj): string => String(obj.current),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.current - b.current,
+});
+
+let readyColumn = new TableColumn<ReplicaSetUI, string>('Ready', {
+  renderMapping: (obj): string => String(obj.ready),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.ready - b.ready,
+});
+
+let ownerColumn = new TableColumn<ReplicaSetUI, string>('Owner', {
+  renderMapping: (obj): string => obj.owner,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.owner.localeCompare(b.owner),
+});
+
+let ageColumn = new TableColumn<ReplicaSetUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [statusColumn, nameColumn, desiredColumn, currentColumn, readyColumn, ownerColumn, ageColumn];
+
+const row = new TableRow<ReplicaSetUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'replicasets',
+      transformer: replicaSetHelper.getReplicaSetUI,
+    },
+  ]}
+  singular="replicaset"
+  plural="replicasets"
+  isNamespaced={true}
+  icon={icon['ReplicaSet']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['ReplicaSet']} resources={['replicasets']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/replicasets/_replicasets-module.ts
+++ b/packages/webview/src/component/replicasets/_replicasets-module.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { ReplicaSetHelper } from './replicaset-helper';
+
+const replicaSetsModule = new ContainerModule(options => {
+  options.bind<ReplicaSetHelper>(ReplicaSetHelper).toSelf().inSingletonScope();
+});
+
+export { replicaSetsModule };

--- a/packages/webview/src/component/replicasets/replicaset-helper.spec.ts
+++ b/packages/webview/src/component/replicasets/replicaset-helper.spec.ts
@@ -1,0 +1,94 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ReplicaSet } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { ReplicaSetHelper } from './replicaset-helper';
+
+let replicaSetHelper: ReplicaSetHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  replicaSetHelper = new ReplicaSetHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const replicaSet = {
+    metadata: {
+      name: 'my-replicaset',
+      namespace: 'test-namespace',
+      uid: 'test-uid-789',
+    },
+    spec: { replicas: 4 },
+    status: { readyReplicas: 4, replicas: 4 },
+  } as V1ReplicaSet;
+  const replicaSetUI = replicaSetHelper.getReplicaSetUI(replicaSet);
+  expect(replicaSetUI.kind).toEqual('ReplicaSet');
+  expect(replicaSetUI.name).toEqual('my-replicaset');
+  expect(replicaSetUI.namespace).toEqual('test-namespace');
+  expect(replicaSetUI.uid).toEqual('test-uid-789');
+  expect(replicaSetUI.desired).toEqual(4);
+  expect(replicaSetUI.ready).toEqual(4);
+});
+
+test('expect RUNNING when desired > 0 and ready equals desired, DEGRADED otherwise, STOPPED when 0', async () => {
+  const running = {
+    metadata: { name: 'rs' },
+    spec: { replicas: 2 },
+    status: { readyReplicas: 2 },
+  } as V1ReplicaSet;
+  expect(replicaSetHelper.getReplicaSetUI(running).status).toEqual('RUNNING');
+
+  const degraded = {
+    metadata: { name: 'rs' },
+    spec: { replicas: 3 },
+    status: { readyReplicas: 1 },
+  } as V1ReplicaSet;
+  expect(replicaSetHelper.getReplicaSetUI(degraded).status).toEqual('DEGRADED');
+
+  const stopped = {
+    metadata: { name: 'rs' },
+    spec: { replicas: 0 },
+    status: { readyReplicas: 0 },
+  } as V1ReplicaSet;
+  expect(replicaSetHelper.getReplicaSetUI(stopped).status).toEqual('STOPPED');
+});
+
+test('expect owner from ownerReferences formatted as Kind/Name', async () => {
+  const replicaSet = {
+    metadata: {
+      name: 'rs',
+      ownerReferences: [{ kind: 'Deployment', name: 'my-deployment', uid: '', apiVersion: 'apps/v1' }],
+    },
+    spec: { replicas: 1 },
+    status: { readyReplicas: 1 },
+  } as V1ReplicaSet;
+  const replicaSetUI = replicaSetHelper.getReplicaSetUI(replicaSet);
+  expect(replicaSetUI.owner).toEqual('Deployment/my-deployment');
+});
+
+test('expect empty owner when no ownerReferences', async () => {
+  const replicaSet = {
+    metadata: { name: 'rs' },
+    spec: { replicas: 1 },
+    status: { readyReplicas: 1 },
+  } as V1ReplicaSet;
+  const replicaSetUI = replicaSetHelper.getReplicaSetUI(replicaSet);
+  expect(replicaSetUI.owner).toEqual('');
+});

--- a/packages/webview/src/component/replicasets/replicaset-helper.ts
+++ b/packages/webview/src/component/replicasets/replicaset-helper.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1ReplicaSet } from '@kubernetes/client-node';
+import { injectable } from 'inversify';
+
+import type { ReplicaSetUI } from './ReplicaSetUI';
+
+@injectable()
+export class ReplicaSetHelper {
+  getReplicaSetUI(o: KubernetesObject): ReplicaSetUI {
+    const obj = o as V1ReplicaSet;
+    const desired = obj.spec?.replicas ?? 0;
+    const ready = obj.status?.readyReplicas ?? 0;
+
+    let status = 'STOPPED';
+    if (desired > 0) {
+      status = ready === desired ? 'RUNNING' : 'DEGRADED';
+    }
+
+    return {
+      kind: 'ReplicaSet',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status,
+      namespace: obj.metadata?.namespace ?? '',
+      created: obj.metadata?.creationTimestamp,
+      selected: false,
+      desired,
+      current: obj.status?.replicas ?? 0,
+      ready,
+      owner: obj.metadata?.ownerReferences?.[0]
+        ? `${obj.metadata.ownerReferences[0].kind}/${obj.metadata.ownerReferences[0].name}`
+        : '',
+    };
+  }
+}

--- a/packages/webview/src/component/statefulsets/StatefulSetDetails.svelte
+++ b/packages/webview/src/component/statefulsets/StatefulSetDetails.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+import type { V1StatefulSet } from '@kubernetes/client-node';
+import { getContext } from 'svelte';
+
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+
+import { StatefulSetHelper } from './statefulset-helper';
+import type { StatefulSetUI } from './StatefulSetUI';
+import StatefulSetDetailsSummary from './StatefulSetDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const statefulSetHelper = dependencyAccessor.get<StatefulSetHelper>(StatefulSetHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1StatefulSet}
+  typedUI={{} as StatefulSetUI}
+  kind="StatefulSet"
+  resourceName="statefulsets"
+  listName="StatefulSets"
+  name={name}
+  namespace={namespace}
+  transformer={statefulSetHelper.getStatefulSetUI.bind(statefulSetHelper)}
+  SummaryComponent={StatefulSetDetailsSummary} />

--- a/packages/webview/src/component/statefulsets/StatefulSetDetailsSummary.svelte
+++ b/packages/webview/src/component/statefulsets/StatefulSetDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1StatefulSet } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1StatefulSet;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/statefulsets/StatefulSetUI.ts
+++ b/packages/webview/src/component/statefulsets/StatefulSetUI.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI.ts';
+
+export interface StatefulSetUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  replicas: number;
+  ready: number;
+  upToDate: number;
+  created?: Date;
+}

--- a/packages/webview/src/component/statefulsets/StatefulSetsList.svelte
+++ b/packages/webview/src/component/statefulsets/StatefulSetsList.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+import moment from 'moment';
+import { getContext } from 'svelte';
+
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+
+import { icon } from '/@/component/icons/icon';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+
+import type { StatefulSetUI } from './StatefulSetUI';
+import { StatefulSetHelper } from './statefulset-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const statefulSetHelper = dependencyAccessor.get<StatefulSetHelper>(StatefulSetHelper);
+
+let statusColumn = new TableColumn<StatefulSetUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<StatefulSetUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let readyColumn = new TableColumn<StatefulSetUI, string>('Ready', {
+  renderMapping: (obj): string => `${obj.ready}/${obj.replicas}`,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.ready - b.ready,
+});
+
+let upToDateColumn = new TableColumn<StatefulSetUI, string>('Up-to-date', {
+  renderMapping: (obj): string => String(obj.upToDate),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.upToDate - b.upToDate,
+});
+
+let ageColumn = new TableColumn<StatefulSetUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [statusColumn, nameColumn, readyColumn, upToDateColumn, ageColumn];
+
+const row = new TableRow<StatefulSetUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'statefulsets',
+      transformer: statefulSetHelper.getStatefulSetUI,
+    },
+  ]}
+  singular="statefulset"
+  plural="statefulsets"
+  isNamespaced={true}
+  icon={icon['StatefulSet']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['StatefulSet']} resources={['statefulsets']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/statefulsets/_statefulsets-module.ts
+++ b/packages/webview/src/component/statefulsets/_statefulsets-module.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { StatefulSetHelper } from './statefulset-helper';
+
+const statefulSetsModule = new ContainerModule(options => {
+  options.bind<StatefulSetHelper>(StatefulSetHelper).toSelf().inSingletonScope();
+});
+
+export { statefulSetsModule };

--- a/packages/webview/src/component/statefulsets/statefulset-helper.spec.ts
+++ b/packages/webview/src/component/statefulsets/statefulset-helper.spec.ts
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1StatefulSet } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { StatefulSetHelper } from './statefulset-helper';
+
+let statefulSetHelper: StatefulSetHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  statefulSetHelper = new StatefulSetHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const statefulSet = {
+    metadata: {
+      name: 'my-statefulset',
+      namespace: 'test-namespace',
+      uid: 'test-uid-456',
+    },
+    spec: { replicas: 3 },
+    status: { readyReplicas: 3, updatedReplicas: 3 },
+  } as V1StatefulSet;
+  const statefulSetUI = statefulSetHelper.getStatefulSetUI(statefulSet);
+  expect(statefulSetUI.kind).toEqual('StatefulSet');
+  expect(statefulSetUI.name).toEqual('my-statefulset');
+  expect(statefulSetUI.namespace).toEqual('test-namespace');
+  expect(statefulSetUI.uid).toEqual('test-uid-456');
+  expect(statefulSetUI.replicas).toEqual(3);
+  expect(statefulSetUI.ready).toEqual(3);
+});
+
+test('expect RUNNING status when replicas > 0 and ready equals replicas', async () => {
+  const statefulSet = {
+    metadata: { name: 'sts' },
+    spec: { replicas: 2 },
+    status: { readyReplicas: 2 },
+  } as V1StatefulSet;
+  const statefulSetUI = statefulSetHelper.getStatefulSetUI(statefulSet);
+  expect(statefulSetUI.status).toEqual('RUNNING');
+});
+
+test('expect DEGRADED status when replicas > 0 and ready < replicas', async () => {
+  const statefulSet = {
+    metadata: { name: 'sts' },
+    spec: { replicas: 3 },
+    status: { readyReplicas: 1 },
+  } as V1StatefulSet;
+  const statefulSetUI = statefulSetHelper.getStatefulSetUI(statefulSet);
+  expect(statefulSetUI.status).toEqual('DEGRADED');
+});
+
+test('expect STOPPED status when replicas is 0', async () => {
+  const statefulSet = {
+    metadata: { name: 'sts' },
+    spec: { replicas: 0 },
+    status: { readyReplicas: 0 },
+  } as V1StatefulSet;
+  const statefulSetUI = statefulSetHelper.getStatefulSetUI(statefulSet);
+  expect(statefulSetUI.status).toEqual('STOPPED');
+});
+
+test('expect upToDate from status.updatedReplicas', async () => {
+  const statefulSet = {
+    metadata: { name: 'sts' },
+    spec: { replicas: 5 },
+    status: { readyReplicas: 5, updatedReplicas: 3 },
+  } as V1StatefulSet;
+  const statefulSetUI = statefulSetHelper.getStatefulSetUI(statefulSet);
+  expect(statefulSetUI.upToDate).toEqual(3);
+});

--- a/packages/webview/src/component/statefulsets/statefulset-helper.ts
+++ b/packages/webview/src/component/statefulsets/statefulset-helper.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1StatefulSet } from '@kubernetes/client-node';
+import { injectable } from 'inversify';
+
+import type { StatefulSetUI } from './StatefulSetUI';
+
+@injectable()
+export class StatefulSetHelper {
+  getStatefulSetUI(o: KubernetesObject): StatefulSetUI {
+    const obj = o as V1StatefulSet;
+    const replicas = obj.spec?.replicas ?? 0;
+    const ready = obj.status?.readyReplicas ?? 0;
+
+    let status = 'STOPPED';
+    if (replicas > 0) {
+      status = ready === replicas ? 'RUNNING' : 'DEGRADED';
+    }
+
+    return {
+      kind: 'StatefulSet',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status,
+      namespace: obj.metadata?.namespace ?? '',
+      created: obj.metadata?.creationTimestamp,
+      selected: false,
+      replicas,
+      ready,
+      upToDate: obj.status?.updatedReplicas ?? 0,
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -39,6 +39,9 @@ import { cronjobsModule } from '/@/component/cronjobs/_cronjobs-module';
 import { podsModule } from '/@/component/pods/_pods-module';
 import { streamsModule } from '/@/stream/stream-module';
 import { annotationsModule } from '/@/annotations/_annotations-module';
+import { daemonSetsModule } from '/@/component/daemonsets/_daemonsets-module';
+import { statefulSetsModule } from '/@/component/statefulsets/_statefulsets-module';
+import { replicaSetsModule } from '/@/component/replicasets/_replicasets-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -72,6 +75,9 @@ export class InversifyBinding {
     await this.#container.load(cronjobsModule);
     await this.#container.load(podsModule);
     await this.#container.load(annotationsModule);
+    await this.#container.load(daemonSetsModule);
+    await this.#container.load(statefulSetsModule);
+    await this.#container.load(replicaSetsModule);
 
     return this.#container;
   }


### PR DESCRIPTION
feat: add DaemonSets, StatefulSets, and ReplicaSets resource views

### What does this PR do?

Adds resource views for DaemonSets, StatefulSets, and ReplicaSets under the Compute navigation section. Includes list views, detail pages, summary components, resource factories, Inversify modules, and helper utilities with unit tests.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/user-attachments/assets/2e01fa74-7bcc-4b9f-b11c-1b404cf3bcf8

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/978

### How to test this PR?

1. Connect to a Kubernetes cluster with DaemonSets, StatefulSets, or ReplicaSets
2. Navigate to the Compute section in the sidebar
3. Verify each resource type lists correctly and detail views display expected information
4. Run `pnpm test` to confirm all unit tests pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
