### PR TITLE
test(e2e): fix failing/outdated e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -78,7 +78,7 @@ jobs:
       # Install Node.js
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       # Install npm packages for extension

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -16,6 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+export enum NavSection {
+  Compute = 'Compute',
+  Config = 'Config',
+  Network = 'Network',
+  Storage = 'Storage',
+}
+
 export enum KubernetesResources {
   Namespaces = 'Namespaces',
   Nodes = 'Nodes',

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -17,22 +17,22 @@
  ***********************************************************************/
 
 import type { Locator, Page } from '@playwright/test';
-import type { KubernetesResources } from '/@/model/core/types';
+import { KubernetesResources, NavSection } from '/@/model/core/types';
 import { KubernetesResourcePage } from './kubernetes-resource-page';
 import { KubernetesDashboardPage } from './kubernetes-dashboard-page';
 import { PortForwardingPage } from './port-forwarding-page';
 
 // Maps each nav item to the collapsible section it lives in (undefined = top-level).
-const RESOURCE_SECTION: Partial<Record<string, string>> = {
-  Deployments: 'Compute',
-  Pods: 'Compute',
-  Jobs: 'Compute',
-  CronJobs: 'Compute',
-  'ConfigMaps & Secrets': 'Config',
-  Services: 'Network',
-  'Ingresses & Routes': 'Network',
-  'Port Forwarding': 'Network',
-  'Persistent Volume Claims': 'Storage',
+const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
+  [KubernetesResources.Deployments]: NavSection.Compute,
+  [KubernetesResources.Pods]: NavSection.Compute,
+  [KubernetesResources.Jobs]: NavSection.Compute,
+  [KubernetesResources.Cronjobs]: NavSection.Compute,
+  [KubernetesResources.ConfigMapsSecrets]: NavSection.Config,
+  [KubernetesResources.Services]: NavSection.Network,
+  [KubernetesResources.IngressesRoutes]: NavSection.Network,
+  [KubernetesResources.PortForwarding]: NavSection.Network,
+  [KubernetesResources.PVCs]: NavSection.Storage,
 };
 
 export class KubernetesBar {

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -84,7 +84,7 @@ export class KubernetesBar {
 
   public async openPortForwardingPage(): Promise<PortForwardingPage> {
     const portForwardingLink = this.kubernetesNavBar.getByRole('link', { name: 'Port Forwarding', exact: true });
-    await this.expandSectionIfNeeded('Network', portForwardingLink);
+    await this.expandSectionIfNeeded(NavSection.Network, portForwardingLink);
     await portForwardingLink.click();
     return new PortForwardingPage(this.page);
   }

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -22,6 +22,19 @@ import { KubernetesResourcePage } from './kubernetes-resource-page';
 import { KubernetesDashboardPage } from './kubernetes-dashboard-page';
 import { PortForwardingPage } from './port-forwarding-page';
 
+// Maps each nav item to the collapsible section it lives in (undefined = top-level).
+const RESOURCE_SECTION: Partial<Record<string, string>> = {
+  Deployments: 'Compute',
+  Pods: 'Compute',
+  Jobs: 'Compute',
+  CronJobs: 'Compute',
+  'ConfigMaps & Secrets': 'Config',
+  Services: 'Network',
+  'Ingresses & Routes': 'Network',
+  'Port Forwarding': 'Network',
+  'Persistent Volume Claims': 'Storage',
+};
+
 export class KubernetesBar {
   readonly page: Page;
   readonly kubernetesNavBar: Locator;
@@ -29,12 +42,26 @@ export class KubernetesBar {
 
   constructor(page: Page) {
     this.page = page;
-    this.kubernetesNavBar = page.getByRole('navigation', { name: 'PreferencesNavigation' });
+    this.kubernetesNavBar = page.getByRole('navigation', { name: 'Kubernetes resources' });
     this.title = this.kubernetesNavBar.getByText('Kubernetes');
   }
 
+  // Clicks the section header to expand it, only when the resource link is not already visible.
+  private async expandSectionIfNeeded(sectionName: string, resourceLink: Locator): Promise<void> {
+    if (!(await resourceLink.isVisible())) {
+      const sectionLink = this.kubernetesNavBar.getByRole('link', { name: sectionName, exact: true });
+      await sectionLink.click();
+    }
+  }
+
   public async openTabPage(kubernetesResource: KubernetesResources): Promise<KubernetesResourcePage> {
+    const section = RESOURCE_SECTION[kubernetesResource];
     const resource = this.kubernetesNavBar.getByRole('link', { name: kubernetesResource, exact: true });
+
+    if (section) {
+      await this.expandSectionIfNeeded(section, resource);
+    }
+
     await resource.click();
 
     switch (kubernetesResource) {
@@ -57,6 +84,7 @@ export class KubernetesBar {
 
   public async openPortForwardingPage(): Promise<PortForwardingPage> {
     const portForwardingLink = this.kubernetesNavBar.getByRole('link', { name: 'Port Forwarding', exact: true });
+    await this.expandSectionIfNeeded('Network', portForwardingLink);
     await portForwardingLink.click();
     return new PortForwardingPage(this.page);
   }


### PR DESCRIPTION
### What does this PR do?

Fix failing e2e tests:
- update navigation during e2e to support collapsible navigation
- fix node version to not use buggy v24.16.0, with which chromium install fails during CI

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fixes #1042

### How to test this PR?

<!-- Please explain steps to reproduce -->
