### PR TITLE
fix(navigation): navigate back to previous section

### DIFF
--- a/packages/webview/src/App.spec.ts
+++ b/packages/webview/src/App.spec.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import { render } from '@testing-library/svelte';
+import { router } from 'tinro';
 import { StatesMocks } from '/@/tests/state-mocks';
 import { FakeStateObject } from '/@/state/util/fake-state-object.svelte';
 import type { AvailableContextsInfo, CurrentContextInfo } from '@kubernetes-dashboard/channels';
@@ -28,6 +29,7 @@ import type { WebviewApi } from '@podman-desktop/webview-api';
 import AppWithContext from '/@/AppWithContext.svelte';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
+vi.mock(import('tinro'));
 vi.mock(import('/@/component/dashboard/NoContextPage.svelte'));
 vi.mock(import('/@/component/dashboard/NoSelectedContextPage.svelte'));
 vi.mock(import('/@/AppWithContext.svelte'));
@@ -106,4 +108,31 @@ test('dashboard with two contexts, one current context', async () => {
   expect(NoContextPage).not.toHaveBeenCalled();
   expect(NoSelectedContextPage).not.toHaveBeenCalled();
   expect(AppWithContext).toHaveBeenCalled();
+});
+
+test('restores saved router state on mount', async () => {
+  vi.mocked(webviewApiMock.getState).mockReturnValue({ url: '/pods' });
+  currentContextMock.setData({
+    contextName: 'context1',
+  });
+  availableContextsMock.setData({
+    contextNames: ['context1'],
+  });
+  render(App);
+  await vi.advanceTimersByTimeAsync(600);
+  expect(webviewApiMock.getState).toHaveBeenCalled();
+  expect(router.goto).toHaveBeenCalledWith('/pods');
+});
+
+test('navigates to root when no saved state exists', async () => {
+  vi.mocked(webviewApiMock.getState).mockReturnValue(undefined);
+  currentContextMock.setData({
+    contextName: 'context1',
+  });
+  availableContextsMock.setData({
+    contextNames: ['context1'],
+  });
+  render(App);
+  await vi.advanceTimersByTimeAsync(600);
+  expect(router.goto).toHaveBeenCalledWith('/');
 });

--- a/packages/webview/src/App.svelte
+++ b/packages/webview/src/App.svelte
@@ -8,16 +8,32 @@ import NoSelectedContextPage from './component/dashboard/NoSelectedContextPage.s
 import NoContextPage from './component/dashboard/NoContextPage.svelte';
 import type { Unsubscriber } from 'svelte/store';
 import AppWithContext from './AppWithContext.svelte';
+import { router } from 'tinro';
+import type { RouterState } from '/@/models/router-state';
+import type { WebviewApi } from '@podman-desktop/webview-api';
 
-let isMounted = false;
+let isMounted = $state(false);
 
+const webviewApi = getContext<WebviewApi>('WebviewApi');
 const states = getContext<States>(States);
 const currentContext = states.stateCurrentContextInfoUI;
 const availableContexts = states.stateAvailableContextsInfoUI;
 const currentContextName = $derived(currentContext.data?.contextName);
 
+function getRouterState(): RouterState {
+  const state = webviewApi.getState() as RouterState | undefined;
+  if (state?.url) {
+    return state;
+  }
+  return { url: '/' };
+}
+
 let unsubscribers: Unsubscriber[] = [];
 onMount(() => {
+  const state = getRouterState();
+  router.goto(state.url);
+  isMounted = true;
+
   unsubscribers.push(currentContext.subscribe());
 });
 

--- a/packages/webview/src/MainContextAware.svelte
+++ b/packages/webview/src/MainContextAware.svelte
@@ -24,6 +24,7 @@ setContext(Streams, context.streams);
 setContext(Remote, context.remote);
 setContext(DependencyAccessor, context.dependencyAccessor);
 setContext(RpcBrowser, context.rpcBrowser);
+setContext('WebviewApi', context.webviewApi);
 
 initialized = true;
 </script>


### PR DESCRIPTION
fix(navigation): navigate back to previous section

### What does this PR do?

When you navigate away from a page, it will save and bring you back to
that route / page when you navigate back to the dashboard.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/user-attachments/assets/03a50703-abb5-4e67-89e4-94da0cf4abda



### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/1044

### How to test this PR?

1. Open extension
2. Navigate away
3. Go back to extension, spot is saved / back to the original location.
