### PR TITLE
feat(informers): lazily load resources

### DIFF
--- a/packages/extension/src/manager/contexts-manager.spec.ts
+++ b/packages/extension/src/manager/contexts-manager.spec.ts
@@ -89,6 +89,7 @@ class TestContextsManager extends ContextsManager {
       new ResourceFactoryBase({
         kind: 'Resource1',
         resource: 'resource1',
+        eagerStart: true,
       })
         .setPermissions({
           isNamespaced: true,
@@ -111,6 +112,7 @@ class TestContextsManager extends ContextsManager {
       new ResourceFactoryBase({
         kind: 'Resource1b',
         resource: 'resource1b',
+        eagerStart: true,
       })
         .setPermissions({
           isNamespaced: true,
@@ -217,6 +219,7 @@ class TestContextsManager extends ContextsManager {
       new ResourceFactoryBase({
         kind: 'Event',
         resource: 'events',
+        eagerStart: true,
       })
         .setPermissions({
           isNamespaced: true,
@@ -1867,5 +1870,169 @@ test('applyResources sends telemetry', async () => {
   expect(telemetryLoggerMock.logUsage).toHaveBeenCalledWith('apply.resources', {
     manifestsSize: 1,
     kinds: 'Namespace',
+  });
+});
+
+describe('lazy informer lifecycle', () => {
+  const createdLazyInformerMock = {
+    onCacheUpdated: vi.fn(),
+    onOffline: vi.fn(),
+    onObjectDeleted: vi.fn(),
+    start: vi.fn(),
+    dispose: vi.fn(),
+    isOffline: vi.fn().mockReturnValue(false),
+  } as unknown as ResourceInformer<KubernetesObject>;
+
+  const createdEagerInformerMock = {
+    onCacheUpdated: vi.fn(),
+    onOffline: vi.fn(),
+    onObjectDeleted: vi.fn(),
+    start: vi.fn(),
+    dispose: vi.fn(),
+    isOffline: vi.fn().mockReturnValue(false),
+  } as unknown as ResourceInformer<KubernetesObject>;
+
+  class LazyTestContextsManager extends ContextsManager {
+    constructor() {
+      super();
+      this.telemetryLogger = telemetryLoggerMock;
+    }
+    override getResourceFactories(): ResourceFactory[] {
+      return [
+        new ResourceFactoryBase({
+          kind: 'EagerResource',
+          resource: 'eager-resource',
+          eagerStart: true,
+        })
+          .setPermissions({
+            isNamespaced: true,
+            permissionsRequests: [{ group: '*', resource: '*', verb: 'watch' }],
+          })
+          .setInformer({
+            createInformer: (): ResourceInformer<KubernetesObject> => createdEagerInformerMock,
+          }),
+        new ResourceFactoryBase({
+          kind: 'LazyResource',
+          resource: 'lazy-resource',
+        })
+          .setPermissions({
+            isNamespaced: true,
+            permissionsRequests: [{ group: '*', resource: '*', verb: 'watch' }],
+          })
+          .setInformer({
+            createInformer: (): ResourceInformer<KubernetesObject> => createdLazyInformerMock,
+          }),
+      ];
+    }
+
+    public override async startMonitoring(
+      config: KubeConfigSingleContext,
+      contextName: string,
+      options?: ConnectOptions,
+    ): Promise<void> {
+      return super.startMonitoring(config, contextName, options);
+    }
+
+    public override stopMonitoring(contextName: string): void {
+      return super.stopMonitoring(contextName);
+    }
+  }
+
+  let manager: LazyTestContextsManager;
+  let kc: KubeConfig;
+  let kcSingle: KubeConfigSingleContext;
+
+  function grantPermissions(): void {
+    const healthCheckCallback = vi.mocked(ContextHealthChecker.prototype.onReachable).mock.calls[0][0];
+    healthCheckCallback!({
+      kubeConfig: kcSingle,
+      contextName: 'context1',
+      checking: false,
+      reachable: true,
+    });
+    const permissionCallback = vi.mocked(ContextPermissionsChecker.prototype.onPermissionResult).mock.calls[1][0];
+    permissionCallback!({
+      kubeConfig: kcSingle,
+      resources: ['eager-resource', 'lazy-resource'],
+      permitted: true,
+      attrs: {},
+    });
+  }
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    ContextHealthChecker.prototype.onStateChange = vi.fn();
+    ContextHealthChecker.prototype.onReachable = vi.fn();
+    ContextPermissionsChecker.prototype.onPermissionResult = vi.fn();
+    kc = new KubeConfig();
+    kc.loadFromOptions(kcWithContext1asDefault);
+    kcSingle = new KubeConfigSingleContext(kc, context1);
+    manager = new LazyTestContextsManager();
+    vi.spyOn(manager, 'stopMonitoring').mockImplementation((): void => {});
+    const cacheMock = { list: vi.fn().mockReturnValue([]), get: vi.fn() } as ObjectCache<KubernetesObject>;
+    vi.mocked(createdEagerInformerMock.start).mockReturnValue(cacheMock);
+    vi.mocked(createdLazyInformerMock.start).mockReturnValue(cacheMock);
+    await manager.startMonitoring(kcSingle, 'context1');
+    grantPermissions();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('eager informer starts immediately on permission grant', () => {
+    expect(createdEagerInformerMock.start).toHaveBeenCalledOnce();
+  });
+
+  test('lazy informer does not start on permission grant', () => {
+    expect(createdLazyInformerMock.start).not.toHaveBeenCalled();
+  });
+
+  test('subscribeToResource starts lazy informer', () => {
+    manager.subscribeToResource('context1', 'lazy-resource', 'sub1');
+    expect(createdLazyInformerMock.start).toHaveBeenCalledOnce();
+  });
+
+  test('subscribeToResource does not duplicate informer on repeated calls', () => {
+    manager.subscribeToResource('context1', 'lazy-resource', 'sub1');
+    manager.subscribeToResource('context1', 'lazy-resource', 'sub2');
+    expect(createdLazyInformerMock.start).toHaveBeenCalledOnce();
+  });
+
+  test('unsubscribeFromResource with remaining subscribers does not schedule stop', () => {
+    manager.subscribeToResource('context1', 'lazy-resource', 'sub1');
+    manager.subscribeToResource('context1', 'lazy-resource', 'sub2');
+    manager.unsubscribeFromResource('context1', 'lazy-resource', 'sub1');
+    vi.advanceTimersByTime(30_000);
+    expect(createdLazyInformerMock.dispose).not.toHaveBeenCalled();
+  });
+
+  test('unsubscribeFromResource with no remaining subscribers schedules grace-period stop', () => {
+    manager.subscribeToResource('context1', 'lazy-resource', 'sub1');
+    manager.unsubscribeFromResource('context1', 'lazy-resource', 'sub1');
+    expect(createdLazyInformerMock.dispose).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(30_000);
+    expect(createdLazyInformerMock.dispose).toHaveBeenCalledOnce();
+  });
+
+  test('re-subscribing before grace period cancels the stop', () => {
+    manager.subscribeToResource('context1', 'lazy-resource', 'sub1');
+    manager.unsubscribeFromResource('context1', 'lazy-resource', 'sub1');
+    vi.advanceTimersByTime(15_000);
+    manager.subscribeToResource('context1', 'lazy-resource', 'sub2');
+    vi.advanceTimersByTime(30_000);
+    expect(createdLazyInformerMock.dispose).not.toHaveBeenCalled();
+  });
+
+  test('subscribeToResource without granted permission does not start informer', () => {
+    manager.subscribeToResource('context1', 'nonexistent-resource', 'sub1');
+    expect(createdLazyInformerMock.start).not.toHaveBeenCalled();
+  });
+
+  test('unsubscribeFromResource does not schedule stop for eager resources', () => {
+    manager.subscribeToResource('context1', 'eager-resource', 'sub1');
+    manager.unsubscribeFromResource('context1', 'eager-resource', 'sub1');
+    vi.advanceTimersByTime(30_000);
+    expect(createdEagerInformerMock.dispose).not.toHaveBeenCalled();
   });
 });

--- a/packages/extension/src/manager/contexts-manager.spec.ts
+++ b/packages/extension/src/manager/contexts-manager.spec.ts
@@ -89,8 +89,8 @@ class TestContextsManager extends ContextsManager {
       new ResourceFactoryBase({
         kind: 'Resource1',
         resource: 'resource1',
-        eagerStart: true,
       })
+        .setEagerStart()
         .setPermissions({
           isNamespaced: true,
           permissionsRequests: [
@@ -112,8 +112,8 @@ class TestContextsManager extends ContextsManager {
       new ResourceFactoryBase({
         kind: 'Resource1b',
         resource: 'resource1b',
-        eagerStart: true,
       })
+        .setEagerStart()
         .setPermissions({
           isNamespaced: true,
           permissionsRequests: [
@@ -219,8 +219,8 @@ class TestContextsManager extends ContextsManager {
       new ResourceFactoryBase({
         kind: 'Event',
         resource: 'events',
-        eagerStart: true,
       })
+        .setEagerStart()
         .setPermissions({
           isNamespaced: true,
           permissionsRequests: [
@@ -1902,8 +1902,8 @@ describe('lazy informer lifecycle', () => {
         new ResourceFactoryBase({
           kind: 'EagerResource',
           resource: 'eager-resource',
-          eagerStart: true,
         })
+          .setEagerStart()
           .setPermissions({
             isNamespaced: true,
             permissionsRequests: [{ group: '*', resource: '*', verb: 'watch' }],

--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -420,6 +420,7 @@ export class ContextsManager implements ContextsApi {
 
         newPermissionChecker.onPermissionResult((event: ContextPermissionResult) => {
           if (!event.permitted) {
+            // if the user does not have watch permission, do not try to start informers on these resources
             return;
           }
           for (const resource of event.resources) {
@@ -434,6 +435,8 @@ export class ContextsManager implements ContextsApi {
               );
             }
             if (!factory.informer) {
+              // no informer for this factory, skipping
+              // (we may want to check permissions on some resource, without having to start an informer)
               continue;
             }
 

--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -84,6 +84,7 @@ import { TelemetryLoggerSymbol } from '/@/inject/symbol.js';
 const HEALTH_CHECK_TIMEOUT_MS = 5_000;
 const DEFAULT_NAMESPACE = 'default';
 const FIELD_MANAGER = 'kubernetes-dashboard';
+const LAZY_INFORMER_GRACE_PERIOD_MS = 30_000;
 
 /**
  * ContextsManager receives new KubeConfig updates
@@ -101,6 +102,9 @@ export class ContextsManager implements ContextsApi {
   #permissionsCheckers: ContextPermissionsChecker[];
   #informers: ContextResourceRegistry<ResourceInformer<KubernetesObject>>;
   #objectCaches: ContextResourceRegistry<ObjectCache<KubernetesObject>>;
+  #grantedPermissions: ContextResourceRegistry<KubeConfigSingleContext>;
+  #graceTimers: Map<string, NodeJS.Timeout>;
+  #resourceSubscriptions: Map<string, Set<string>>;
   #currentContext?: KubeConfigSingleContext;
   #currentKubeConfig: KubeConfig;
 
@@ -149,6 +153,9 @@ export class ContextsManager implements ContextsApi {
     this.#permissionsCheckers = [];
     this.#informers = new ContextResourceRegistry<ResourceInformer<KubernetesObject>>();
     this.#objectCaches = new ContextResourceRegistry<ObjectCache<KubernetesObject>>();
+    this.#grantedPermissions = new ContextResourceRegistry<KubeConfigSingleContext>();
+    this.#graceTimers = new Map<string, NodeJS.Timeout>();
+    this.#resourceSubscriptions = new Map<string, Set<string>>();
     this.#dispatcher = new ContextsDispatcher();
     this.#dispatcher.onUpdate(this.onUpdate.bind(this));
     this.#dispatcher.onDelete(this.onDelete.bind(this));
@@ -310,6 +317,11 @@ export class ContextsManager implements ContextsApi {
     this.disposeAllHealthChecks();
     this.disposeAllPermissionsCheckers();
     this.disposeAllInformers();
+    for (const timer of this.#graceTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.#graceTimers.clear();
+    this.#resourceSubscriptions.clear();
     this.#onContextHealthStateChange.dispose();
     this.#onContextDelete.dispose();
   }
@@ -408,7 +420,6 @@ export class ContextsManager implements ContextsApi {
 
         newPermissionChecker.onPermissionResult((event: ContextPermissionResult) => {
           if (!event.permitted) {
-            // if the user does not have watch permission, do not try to start informers on these resources
             return;
           }
           for (const resource of event.resources) {
@@ -423,41 +434,17 @@ export class ContextsManager implements ContextsApi {
               );
             }
             if (!factory.informer) {
-              // no informer for this factory, skipping
-              // (we may want to check permissions on some resource, without having to start an informer)
               continue;
             }
-            const informer = factory.informer.createInformer(event.kubeConfig);
-            this.#informers.set(contextName, resource, informer);
-            informer.onCacheUpdated((e: CacheUpdatedEvent) => {
-              this.#onResourceUpdated.fire({
-                contextName: e.kubeconfig.getKubeConfig().currentContext,
-                resourceName: e.resourceName,
-              });
-              if (e.countChanged) {
-                this.#onResourceCountUpdated.fire({
-                  contextName: e.kubeconfig.getKubeConfig().currentContext,
-                  resourceName: e.resourceName,
-                });
-              }
-              if (['endpointslices', 'routes', 'ingresses', 'pods'].includes(e.resourceName)) {
-                this.#onEndpointsChange.fire();
-              }
-            });
-            informer.onOffline((e: OfflineEvent) => {
-              this.#onOfflineChange.fire();
-              this.#objectCaches.removeForContext(e.kubeconfig.getKubeConfig().currentContext);
-            });
-            informer.onObjectDeleted((e: ObjectDeletedEvent) => {
-              this.#onObjectDeleted.fire({
-                contextName: e.kubeconfig.getKubeConfig().currentContext,
-                resourceName: e.resourceName,
-                name: e.name,
-                namespace: e.namespace,
-              });
-            });
-            const cache = informer.start();
-            this.#objectCaches.set(contextName, resource, cache);
+
+            this.#grantedPermissions.set(contextName, resource, event.kubeConfig);
+
+            if (factory.eagerStart) {
+              console.log(`[informer] starting eager informer: ${resource} on ${contextName}`);
+              this.createAndStartInformer(contextName, resource, event.kubeConfig);
+            } else {
+              console.log(`[informer] permission granted for lazy resource: ${resource} on ${contextName} (deferred)`);
+            }
           }
         });
         await newPermissionChecker.start();
@@ -486,6 +473,145 @@ export class ContextsManager implements ContextsApi {
     }
     this.#informers.removeForContext(contextName);
     this.#objectCaches.removeForContext(contextName);
+    this.#grantedPermissions.removeForContext(contextName);
+    this.clearGraceTimersForContext(contextName);
+    this.clearResourceSubscriptionsForContext(contextName);
+  }
+
+  protected createAndStartInformer(contextName: string, resource: string, kubeConfig: KubeConfigSingleContext): void {
+    if (this.#informers.get(contextName, resource)) {
+      return;
+    }
+    const factory = this.#resourceFactoryHandler.getResourceFactoryByResourceName(resource);
+    if (!factory?.informer) {
+      return;
+    }
+    const informer = factory.informer.createInformer(kubeConfig);
+    this.#informers.set(contextName, resource, informer);
+    informer.onCacheUpdated((e: CacheUpdatedEvent) => {
+      this.#onResourceUpdated.fire({
+        contextName: e.kubeconfig.getKubeConfig().currentContext,
+        resourceName: e.resourceName,
+      });
+      if (e.countChanged) {
+        this.#onResourceCountUpdated.fire({
+          contextName: e.kubeconfig.getKubeConfig().currentContext,
+          resourceName: e.resourceName,
+        });
+      }
+      if (['endpointslices', 'routes', 'ingresses', 'pods'].includes(e.resourceName)) {
+        this.#onEndpointsChange.fire();
+      }
+    });
+    informer.onOffline((e: OfflineEvent) => {
+      this.#onOfflineChange.fire();
+      this.#objectCaches.removeForContext(e.kubeconfig.getKubeConfig().currentContext);
+    });
+    informer.onObjectDeleted((e: ObjectDeletedEvent) => {
+      this.#onObjectDeleted.fire({
+        contextName: e.kubeconfig.getKubeConfig().currentContext,
+        resourceName: e.resourceName,
+        name: e.name,
+        namespace: e.namespace,
+      });
+    });
+    const cache = informer.start();
+    this.#objectCaches.set(contextName, resource, cache);
+  }
+
+  stopResourceInformer(contextName: string, resource: string): void {
+    const informer = this.#informers.get(contextName, resource);
+    if (informer) {
+      console.log(`[informer] stopping lazy informer: ${resource} on ${contextName}`);
+      informer.dispose();
+      this.#informers.remove(contextName, resource);
+      this.#objectCaches.remove(contextName, resource);
+      this.#onResourceCountUpdated.fire({ contextName, resourceName: resource });
+    }
+  }
+
+  subscribeToResource(contextName: string, resourceName: string, subscriptionId: string): void {
+    const key = `${contextName}/${resourceName}`;
+    this.cancelGraceTimer(key);
+
+    let subs = this.#resourceSubscriptions.get(key);
+    if (!subs) {
+      subs = new Set<string>();
+      this.#resourceSubscriptions.set(key, subs);
+    }
+    subs.add(subscriptionId);
+
+    if (this.#informers.get(contextName, resourceName)) {
+      console.log(
+        `[informer] resource subscription added: ${resourceName} on ${contextName} (already running, ${subs.size} subscribers)`,
+      );
+      return;
+    }
+    const kubeConfig = this.#grantedPermissions.get(contextName, resourceName);
+    if (kubeConfig) {
+      console.log(
+        `[informer] starting lazy informer on demand: ${resourceName} on ${contextName} (${subs.size} subscribers)`,
+      );
+      this.createAndStartInformer(contextName, resourceName, kubeConfig);
+    }
+  }
+
+  unsubscribeFromResource(contextName: string, resourceName: string, subscriptionId: string): void {
+    const key = `${contextName}/${resourceName}`;
+    const subs = this.#resourceSubscriptions.get(key);
+    if (subs) {
+      subs.delete(subscriptionId);
+      if (subs.size === 0) {
+        this.#resourceSubscriptions.delete(key);
+        const factory = this.#resourceFactoryHandler.getResourceFactoryByResourceName(resourceName);
+        if (factory && !factory.eagerStart && this.#informers.get(contextName, resourceName)) {
+          console.log(
+            `[informer] no subscribers left for ${resourceName} on ${contextName}, scheduling grace period (${LAZY_INFORMER_GRACE_PERIOD_MS}ms)`,
+          );
+          this.scheduleGraceTimer(contextName, resourceName);
+        }
+      } else {
+        console.log(
+          `[informer] resource subscription removed: ${resourceName} on ${contextName} (${subs.size} remaining)`,
+        );
+      }
+    }
+  }
+
+  private scheduleGraceTimer(contextName: string, resourceName: string): void {
+    const key = `${contextName}/${resourceName}`;
+    this.cancelGraceTimer(key);
+    const timer = setTimeout(() => {
+      this.#graceTimers.delete(key);
+      console.log(`[informer] grace period expired for ${resourceName} on ${contextName}, stopping informer`);
+      this.stopResourceInformer(contextName, resourceName);
+    }, LAZY_INFORMER_GRACE_PERIOD_MS);
+    this.#graceTimers.set(key, timer);
+  }
+
+  private cancelGraceTimer(key: string): void {
+    const timer = this.#graceTimers.get(key);
+    if (timer) {
+      clearTimeout(timer);
+      this.#graceTimers.delete(key);
+    }
+  }
+
+  private clearGraceTimersForContext(contextName: string): void {
+    for (const [key, timer] of this.#graceTimers.entries()) {
+      if (key.startsWith(`${contextName}/`)) {
+        clearTimeout(timer);
+        this.#graceTimers.delete(key);
+      }
+    }
+  }
+
+  private clearResourceSubscriptionsForContext(contextName: string): void {
+    for (const key of this.#resourceSubscriptions.keys()) {
+      if (key.startsWith(`${contextName}/`)) {
+        this.#resourceSubscriptions.delete(key);
+      }
+    }
   }
 
   // returns true if at least one informer for the context is 'offline'

--- a/packages/extension/src/manager/contexts-states-dispatcher.spec.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.spec.ts
@@ -89,6 +89,7 @@ const kubernetesProvidersManagerMock = {
 } as unknown as KubernetesProvidersManager;
 const webviewSubscriberMock = {
   onSubscribe: vi.fn(),
+  onUnsubscribe: vi.fn(),
   hasSubscribers: vi.fn(),
   getSubscriptions: vi.fn(),
 } as unknown as ChannelSubscriber;

--- a/packages/extension/src/manager/contexts-states-dispatcher.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import {
   RESOURCES_COUNT,
   UPDATE_RESOURCE,
   KUBERNETES_PROVIDERS,
+  type UpdateResourceOptions,
 } from '@kubernetes-dashboard/channels';
 
 import type { ContextHealthState } from './context-health-checker.js';
@@ -114,13 +115,23 @@ export class ContextsStatesDispatcher {
     });
 
     this.#subscribers.forEach(subscriber => {
-      subscriber.onSubscribe(channelName => this.dispatchByChannelName(subscriber, channelName));
+      this.wireSubscriber(subscriber);
+    });
+  }
+
+  private wireSubscriber(subscriber: StateSubscriber): void {
+    subscriber.onSubscribe(channelName => {
+      this.dispatchByChannelName(subscriber, channelName).catch(console.error);
+      this.handleResourceSubscription(subscriber, channelName);
+    });
+    subscriber.onUnsubscribe(channelName => {
+      this.handleResourceUnsubscription(subscriber, channelName);
     });
   }
 
   addSubscriber(subscriber: StateSubscriber): void {
     this.#subscribers.push(subscriber);
-    subscriber.onSubscribe(channelName => this.dispatchByChannelName(subscriber, channelName));
+    this.wireSubscriber(subscriber);
   }
 
   /**
@@ -162,5 +173,61 @@ export class ContextsStatesDispatcher {
       return;
     }
     await dispatcher.dispatch(subscriber, subscriptions);
+  }
+
+  #subscriberResourceTracker: Map<StateSubscriber, Map<string, Set<string>>> = new Map();
+
+  private handleResourceSubscription(subscriber: StateSubscriber, channelName: string): void {
+    if (channelName !== UPDATE_RESOURCE.name) {
+      return;
+    }
+    const subscriptions = subscriber.getSubscriptions(channelName) as UpdateResourceOptions[];
+    const currentContextName = this.manager.currentContext?.getKubeConfig().currentContext;
+
+    for (const options of subscriptions) {
+      const contextName = options.contextName ?? currentContextName;
+      if (!contextName) continue;
+      const subscriptionId = `${subscriber.constructor.name}:${channelName}:${contextName}:${options.resourceName}`;
+
+      let tracked = this.#subscriberResourceTracker.get(subscriber);
+      if (!tracked) {
+        tracked = new Map();
+        this.#subscriberResourceTracker.set(subscriber, tracked);
+      }
+      const key = `${contextName}/${options.resourceName}`;
+      if (!tracked.has(key)) {
+        tracked.set(key, new Set());
+      }
+      tracked.get(key)!.add(subscriptionId);
+
+      this.manager.subscribeToResource(contextName, options.resourceName, subscriptionId);
+    }
+  }
+
+  private handleResourceUnsubscription(subscriber: StateSubscriber, channelName: string): void {
+    if (channelName !== UPDATE_RESOURCE.name) {
+      return;
+    }
+    const tracked = this.#subscriberResourceTracker.get(subscriber);
+    if (!tracked) return;
+
+    const currentSubscriptions = new Set(
+      (subscriber.getSubscriptions(channelName) as UpdateResourceOptions[])
+        .map(options => {
+          const contextName = options.contextName ?? this.manager.currentContext?.getKubeConfig().currentContext;
+          return contextName ? `${contextName}/${options.resourceName}` : undefined;
+        })
+        .filter((key): key is string => key !== undefined),
+    );
+
+    for (const [key, subscriptionIds] of tracked.entries()) {
+      if (!currentSubscriptions.has(key)) {
+        const [contextName, resourceName] = key.split('/');
+        for (const subscriptionId of subscriptionIds) {
+          this.manager.unsubscribeFromResource(contextName, resourceName, subscriptionId);
+        }
+        tracked.delete(key);
+      }
+    }
   }
 }

--- a/packages/extension/src/registry/context-resource-registry.ts
+++ b/packages/extension/src/registry/context-resource-registry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,10 @@ export class ContextResourceRegistry<T> {
 
   get(context: string, resource: string): T | undefined {
     return this.#registry.get(context)?.get(resource);
+  }
+
+  remove(context: string, resource: string): boolean {
+    return this.#registry.get(context)?.delete(resource) ?? false;
   }
 
   getAll(): Details<T>[] {

--- a/packages/extension/src/resources/configmaps-resource-factory.ts
+++ b/packages/extension/src/resources/configmaps-resource-factory.ts
@@ -29,9 +29,9 @@ export class ConfigmapsResourceFactory extends ResourceFactoryBase implements Re
     super({
       resource: 'configmaps',
       kind: 'ConfigMap',
-      eagerStart: true,
     });
 
+    this.setEagerStart();
     this.setPermissions({
       isNamespaced: true,
       permissionsRequests: [

--- a/packages/extension/src/resources/configmaps-resource-factory.ts
+++ b/packages/extension/src/resources/configmaps-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ export class ConfigmapsResourceFactory extends ResourceFactoryBase implements Re
     super({
       resource: 'configmaps',
       kind: 'ConfigMap',
+      eagerStart: true,
     });
 
     this.setPermissions({

--- a/packages/extension/src/resources/cronjobs-resource-factory.ts
+++ b/packages/extension/src/resources/cronjobs-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ export class CronjobsResourceFactory extends ResourceFactoryBase implements Reso
     super({
       resource: 'cronjobs',
       kind: 'CronJob',
+      eagerStart: true,
     });
 
     this.setPermissions({

--- a/packages/extension/src/resources/cronjobs-resource-factory.ts
+++ b/packages/extension/src/resources/cronjobs-resource-factory.ts
@@ -29,9 +29,9 @@ export class CronjobsResourceFactory extends ResourceFactoryBase implements Reso
     super({
       resource: 'cronjobs',
       kind: 'CronJob',
-      eagerStart: true,
     });
 
+    this.setEagerStart();
     this.setPermissions({
       isNamespaced: true,
       permissionsRequests: [

--- a/packages/extension/src/resources/deployments-resource-factory.ts
+++ b/packages/extension/src/resources/deployments-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024, 2025 Red Hat, Inc.
+ * Copyright (C) 2024 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ export class DeploymentsResourceFactory extends ResourceFactoryBase implements R
     super({
       resource: 'deployments',
       kind: 'Deployment',
+      eagerStart: true,
     });
 
     this.setPermissions({

--- a/packages/extension/src/resources/deployments-resource-factory.ts
+++ b/packages/extension/src/resources/deployments-resource-factory.ts
@@ -29,9 +29,9 @@ export class DeploymentsResourceFactory extends ResourceFactoryBase implements R
     super({
       resource: 'deployments',
       kind: 'Deployment',
-      eagerStart: true,
     });
 
+    this.setEagerStart();
     this.setPermissions({
       isNamespaced: true,
       permissionsRequests: [

--- a/packages/extension/src/resources/endpoint-slices-resource-factory.ts
+++ b/packages/extension/src/resources/endpoint-slices-resource-factory.ts
@@ -34,9 +34,9 @@ export class EndpointSlicesResourceFactory extends ResourceFactoryBase implement
     super({
       resource: 'endpointslices',
       kind: 'EndpointSlice',
-      eagerStart: true,
     });
 
+    this.setEagerStart();
     this.setPermissions({
       isNamespaced: true,
       permissionsRequests: [

--- a/packages/extension/src/resources/endpoint-slices-resource-factory.ts
+++ b/packages/extension/src/resources/endpoint-slices-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ export class EndpointSlicesResourceFactory extends ResourceFactoryBase implement
     super({
       resource: 'endpointslices',
       kind: 'EndpointSlice',
+      eagerStart: true,
     });
 
     this.setPermissions({

--- a/packages/extension/src/resources/ingresses-resource-factory.ts
+++ b/packages/extension/src/resources/ingresses-resource-factory.ts
@@ -31,9 +31,9 @@ export class IngressesResourceFactory extends ResourceFactoryBase implements Res
     super({
       resource: 'ingresses',
       kind: 'Ingress',
-      eagerStart: true,
     });
 
+    this.setEagerStart();
     this.setPermissions({
       isNamespaced: true,
       permissionsRequests: [

--- a/packages/extension/src/resources/ingresses-resource-factory.ts
+++ b/packages/extension/src/resources/ingresses-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ export class IngressesResourceFactory extends ResourceFactoryBase implements Res
     super({
       resource: 'ingresses',
       kind: 'Ingress',
+      eagerStart: true,
     });
 
     this.setPermissions({

--- a/packages/extension/src/resources/jobs-resource-factory.ts
+++ b/packages/extension/src/resources/jobs-resource-factory.ts
@@ -30,9 +30,9 @@ export class JobsResourceFactory extends ResourceFactoryBase implements Resource
     super({
       resource: 'jobs',
       kind: 'Job',
-      eagerStart: true,
     });
 
+    this.setEagerStart();
     this.setPermissions({
       isNamespaced: true,
       permissionsRequests: [

--- a/packages/extension/src/resources/jobs-resource-factory.ts
+++ b/packages/extension/src/resources/jobs-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ export class JobsResourceFactory extends ResourceFactoryBase implements Resource
     super({
       resource: 'jobs',
       kind: 'Job',
+      eagerStart: true,
     });
 
     this.setPermissions({

--- a/packages/extension/src/resources/namespaces-resource-factory.ts
+++ b/packages/extension/src/resources/namespaces-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ export class NamespacesResourceFactory extends ResourceFactoryBase implements Re
     super({
       resource: 'namespaces',
       kind: 'Namespace',
+      eagerStart: true,
     });
 
     this.setPermissions({

--- a/packages/extension/src/resources/namespaces-resource-factory.ts
+++ b/packages/extension/src/resources/namespaces-resource-factory.ts
@@ -34,9 +34,9 @@ export class NamespacesResourceFactory extends ResourceFactoryBase implements Re
     super({
       resource: 'namespaces',
       kind: 'Namespace',
-      eagerStart: true,
     });
 
+    this.setEagerStart();
     this.setPermissions({
       isNamespaced: false,
       permissionsRequests: [

--- a/packages/extension/src/resources/nodes-resource-factory.ts
+++ b/packages/extension/src/resources/nodes-resource-factory.ts
@@ -29,9 +29,9 @@ export class NodesResourceFactory extends ResourceFactoryBase implements Resourc
     super({
       resource: 'nodes',
       kind: 'Node',
-      eagerStart: true,
     });
 
+    this.setEagerStart();
     this.setPermissions({
       isNamespaced: false,
       permissionsRequests: [

--- a/packages/extension/src/resources/nodes-resource-factory.ts
+++ b/packages/extension/src/resources/nodes-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ export class NodesResourceFactory extends ResourceFactoryBase implements Resourc
     super({
       resource: 'nodes',
       kind: 'Node',
+      eagerStart: true,
     });
 
     this.setPermissions({

--- a/packages/extension/src/resources/pods-resource-factory.ts
+++ b/packages/extension/src/resources/pods-resource-factory.ts
@@ -31,9 +31,9 @@ export class PodsResourceFactory extends ResourceFactoryBase implements Resource
     super({
       resource: 'pods',
       kind: 'Pod',
-      eagerStart: true,
     });
 
+    this.setEagerStart();
     this.setPermissions({
       isNamespaced: true,
       permissionsRequests: [

--- a/packages/extension/src/resources/pods-resource-factory.ts
+++ b/packages/extension/src/resources/pods-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024, 2025 Red Hat, Inc.
+ * Copyright (C) 2024 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ export class PodsResourceFactory extends ResourceFactoryBase implements Resource
     super({
       resource: 'pods',
       kind: 'Pod',
+      eagerStart: true,
     });
 
     this.setPermissions({

--- a/packages/extension/src/resources/pvcs-resource-factory.ts
+++ b/packages/extension/src/resources/pvcs-resource-factory.ts
@@ -34,9 +34,9 @@ export class PVCsResourceFactory extends ResourceFactoryBase implements Resource
     super({
       resource: 'persistentvolumeclaims',
       kind: 'PersistentVolumeClaim',
-      eagerStart: true,
     });
 
+    this.setEagerStart();
     this.setPermissions({
       isNamespaced: true,
       permissionsRequests: [

--- a/packages/extension/src/resources/pvcs-resource-factory.ts
+++ b/packages/extension/src/resources/pvcs-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ export class PVCsResourceFactory extends ResourceFactoryBase implements Resource
     super({
       resource: 'persistentvolumeclaims',
       kind: 'PersistentVolumeClaim',
+      eagerStart: true,
     });
 
     this.setPermissions({

--- a/packages/extension/src/resources/resource-factory.ts
+++ b/packages/extension/src/resources/resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 - 2025 Red Hat, Inc.
+ * Copyright (C) 2024 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,6 +76,7 @@ type SearchByTargetRefNamespacedObject = (
 export class ResourceFactoryBase {
   #resource: string;
   #kind: string;
+  #eagerStart: boolean;
   #permissions: ResourcePermissionsFactory | undefined;
   #informer: ResourceInformerFactory | undefined;
   #isActive: undefined | ((resource: KubernetesObject) => boolean);
@@ -85,9 +86,10 @@ export class ResourceFactoryBase {
   #readObject: ReadNamespacedObject | ReadNonNamespacedObject;
   #restartObject: RestartNamespacedObject | RestartNonNamespacedObject;
 
-  constructor(options: { resource: string; kind: string }) {
+  constructor(options: { resource: string; kind: string; eagerStart?: boolean }) {
     this.#resource = options.resource;
     this.#kind = options.kind;
+    this.#eagerStart = options.eagerStart ?? false;
   }
 
   setPermissions(options: { permissionsRequests: V1ResourceAttributes[]; isNamespaced: boolean }): ResourceFactoryBase {
@@ -147,6 +149,10 @@ export class ResourceFactoryBase {
     return this.#kind;
   }
 
+  get eagerStart(): boolean {
+    return this.#eagerStart;
+  }
+
   get permissions(): ResourcePermissionsFactory | undefined {
     return this.#permissions;
   }
@@ -200,6 +206,7 @@ export class ResourceFactoryBase {
 export interface ResourceFactory {
   get resource(): string;
   get kind(): string;
+  get eagerStart(): boolean;
   permissions?: ResourcePermissionsFactory;
   informer?: ResourceInformerFactory;
   // isActive returns true if `resource` is considered active

--- a/packages/extension/src/resources/resource-factory.ts
+++ b/packages/extension/src/resources/resource-factory.ts
@@ -86,10 +86,15 @@ export class ResourceFactoryBase {
   #readObject: ReadNamespacedObject | ReadNonNamespacedObject;
   #restartObject: RestartNamespacedObject | RestartNonNamespacedObject;
 
-  constructor(options: { resource: string; kind: string; eagerStart?: boolean }) {
+  constructor(options: { resource: string; kind: string }) {
     this.#resource = options.resource;
     this.#kind = options.kind;
-    this.#eagerStart = options.eagerStart ?? false;
+    this.#eagerStart = false;
+  }
+
+  setEagerStart(): ResourceFactoryBase {
+    this.#eagerStart = true;
+    return this;
   }
 
   setPermissions(options: { permissionsRequests: V1ResourceAttributes[]; isNamespaced: boolean }): ResourceFactoryBase {

--- a/packages/extension/src/resources/routes-resource-factory.ts
+++ b/packages/extension/src/resources/routes-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ export class RoutesResourceFactory extends ResourceFactoryBase implements Resour
     super({
       resource: 'routes',
       kind: 'Route',
+      eagerStart: true,
     });
 
     this.setPermissions({

--- a/packages/extension/src/resources/routes-resource-factory.ts
+++ b/packages/extension/src/resources/routes-resource-factory.ts
@@ -32,9 +32,9 @@ export class RoutesResourceFactory extends ResourceFactoryBase implements Resour
     super({
       resource: 'routes',
       kind: 'Route',
-      eagerStart: true,
     });
 
+    this.setEagerStart();
     this.setPermissions({
       isNamespaced: true,
       permissionsRequests: [

--- a/packages/extension/src/resources/secrets-resource-factory.ts
+++ b/packages/extension/src/resources/secrets-resource-factory.ts
@@ -29,9 +29,9 @@ export class SecretsResourceFactory extends ResourceFactoryBase implements Resou
     super({
       resource: 'secrets',
       kind: 'Secret',
-      eagerStart: true,
     });
 
+    this.setEagerStart();
     this.setPermissions({
       isNamespaced: true,
       permissionsRequests: [

--- a/packages/extension/src/resources/secrets-resource-factory.ts
+++ b/packages/extension/src/resources/secrets-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ export class SecretsResourceFactory extends ResourceFactoryBase implements Resou
     super({
       resource: 'secrets',
       kind: 'Secret',
+      eagerStart: true,
     });
 
     this.setPermissions({

--- a/packages/extension/src/resources/services-resource-factory.ts
+++ b/packages/extension/src/resources/services-resource-factory.ts
@@ -29,9 +29,9 @@ export class ServicesResourceFactory extends ResourceFactoryBase implements Reso
     super({
       resource: 'services',
       kind: 'Service',
-      eagerStart: true,
     });
 
+    this.setEagerStart();
     this.setPermissions({
       isNamespaced: true,
       permissionsRequests: [

--- a/packages/extension/src/resources/services-resource-factory.ts
+++ b/packages/extension/src/resources/services-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ export class ServicesResourceFactory extends ResourceFactoryBase implements Reso
     super({
       resource: 'services',
       kind: 'Service',
+      eagerStart: true,
     });
 
     this.setPermissions({

--- a/packages/extension/src/subscriber/api-subscriber.ts
+++ b/packages/extension/src/subscriber/api-subscriber.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,9 @@ export class ApiSubscriber implements StateSubscriber, IDisposable {
 
   #onSubscribe = new Emitter<string>();
   onSubscribe: Event<string> = this.#onSubscribe.event;
+
+  #onUnsubscribe = new Emitter<string>();
+  onUnsubscribe: Event<string> = this.#onUnsubscribe.event;
 
   async resetApiSubscribers(channelName: string): Promise<void> {
     this.#subscribers[channelName] = [];

--- a/packages/extension/src/subscriber/channel-subscriber.spec.ts
+++ b/packages/extension/src/subscriber/channel-subscriber.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,17 @@ test('subscribe makes onSubscribe emit an event', async () => {
   subscriber.onSubscribe(listener);
   await subscriber.resetChannelSubscribers(channel);
   await subscriber.subscribeToChannel(channel, {}, uid);
+  expect(listener).toHaveBeenCalledWith(channel);
+});
+
+test('unsubscribe makes onUnsubscribe emit an event', async () => {
+  const channel = 'channel1';
+  const uid = 1;
+  const subscriber = new ChannelSubscriber();
+  const listener = vi.fn();
+  subscriber.onUnsubscribe(listener);
+  await subscriber.subscribeToChannel(channel, {}, uid);
+  await subscriber.unsubscribeFromChannel(channel, uid);
   expect(listener).toHaveBeenCalledWith(channel);
 });
 

--- a/packages/extension/src/subscriber/channel-subscriber.ts
+++ b/packages/extension/src/subscriber/channel-subscriber.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,10 @@ export class ChannelSubscriber implements StateSubscriber {
   #subscribers: { [channelName: string]: ChannelSubscriberInfo[] } = {};
 
   #onSubscribe = new Emitter<string>();
-
   onSubscribe: Event<string> = this.#onSubscribe.event;
+
+  #onUnsubscribe = new Emitter<string>();
+  onUnsubscribe: Event<string> = this.#onUnsubscribe.event;
 
   async resetChannelSubscribers(channelName: string): Promise<void> {
     this.#subscribers[channelName] = [];
@@ -61,6 +63,7 @@ export class ChannelSubscriber implements StateSubscriber {
     this.#subscribers[channelName] = (this.#subscribers[channelName] ?? []).filter(
       subscriber => subscriber.uid !== subscription,
     );
+    this.#onUnsubscribe.fire(channelName);
   }
 
   hasSubscribers(channelName: string): boolean {

--- a/packages/extension/src/subscriber/state-subscriber.ts
+++ b/packages/extension/src/subscriber/state-subscriber.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,5 +23,6 @@ export interface StateSubscriber {
   hasSubscribers(channelName: string): boolean;
   getSubscriptions(channelName: string): unknown[];
   onSubscribe: (listener: (e: string) => unknown) => IDisposable;
+  onUnsubscribe: (listener: (e: string) => unknown) => IDisposable;
   dispatch<T>(channel: RpcChannel<T>, data: T): Promise<void>;
 }


### PR DESCRIPTION
feat(informers): lazily load resources

### What does this PR do?

We will now lazily load informers (on demand) with a 30 second timeout.

The ones which are always on / eager, will be the ones located on the
dashboard (pods, services, ingresses & routes, namespaces nodes,
cronjobs and jobs).

When navigating to a new section, it will "lazily" load the informer.

We also have debugging output that will inform what is lazily loaded /
unloaded.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/user-attachments/assets/c53b43d4-e86c-426b-9893-8fe26a0640fb




No UI change, but below is a demo of it still working.

### What issues does this PR fix or reference?

<!-- Include any related issues from the
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/1024

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Load the extension
2. See the dashboard is accurate and loading everything fine
3. Go to a "non-eager" / lazy loading informer such as ReplicaSets and
   see it loads fine.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
