### PR TITLE
feat(config): add config section resources

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -76,6 +76,15 @@ import { EndpointSlicesResourceFactory } from '/@/resources/endpoint-slices-reso
 import { DaemonSetsResourceFactory } from '/@/resources/daemonsets-resource-factory.js';
 import { StatefulSetsResourceFactory } from '/@/resources/statefulsets-resource-factory.js';
 import { ReplicaSetsResourceFactory } from '/@/resources/replicasets-resource-factory.js';
+import { ResourceQuotasResourceFactory } from '/@/resources/resource-quotas-resource-factory.js';
+import { LimitRangesResourceFactory } from '/@/resources/limit-ranges-resource-factory.js';
+import { HpasResourceFactory } from '/@/resources/hpas-resource-factory.js';
+import { PdbsResourceFactory } from '/@/resources/pdbs-resource-factory.js';
+import { PriorityClassesResourceFactory } from '/@/resources/priority-classes-resource-factory.js';
+import { RuntimeClassesResourceFactory } from '/@/resources/runtime-classes-resource-factory.js';
+import { LeasesResourceFactory } from '/@/resources/leases-resource-factory.js';
+import { MutatingWebhooksResourceFactory } from '/@/resources/mutating-webhooks-resource-factory.js';
+import { ValidatingWebhooksResourceFactory } from '/@/resources/validating-webhooks-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -187,6 +196,15 @@ export class ContextsManager implements ContextsApi {
       new DaemonSetsResourceFactory(),
       new StatefulSetsResourceFactory(),
       new ReplicaSetsResourceFactory(),
+      new ResourceQuotasResourceFactory(),
+      new LimitRangesResourceFactory(),
+      new HpasResourceFactory(),
+      new PdbsResourceFactory(),
+      new PriorityClassesResourceFactory(),
+      new RuntimeClassesResourceFactory(),
+      new LeasesResourceFactory(),
+      new MutatingWebhooksResourceFactory(),
+      new ValidatingWebhooksResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/hpas-resource-factory.ts
+++ b/packages/extension/src/resources/hpas-resource-factory.ts
@@ -1,0 +1,83 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  KubernetesObject,
+  V1Status,
+  V2HorizontalPodAutoscaler,
+  V2HorizontalPodAutoscalerList,
+} from '@kubernetes/client-node';
+import { AutoscalingV2Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class HpasResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'horizontalpodautoscalers',
+      kind: 'HorizontalPodAutoscaler',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          group: 'autoscaling',
+          verb: 'watch',
+          resource: 'horizontalpodautoscalers',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteHorizontalPodAutoscaler);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V2HorizontalPodAutoscaler> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AutoscalingV2Api);
+    const listFn = (): Promise<V2HorizontalPodAutoscalerList> =>
+      apiClient.listNamespacedHorizontalPodAutoscaler({ namespace });
+    const path = `/apis/autoscaling/v2/namespaces/${namespace}/horizontalpodautoscalers`;
+    return new ResourceInformer<V2HorizontalPodAutoscaler>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'horizontalpodautoscalers',
+    });
+  }
+
+  deleteHorizontalPodAutoscaler(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AutoscalingV2Api);
+    return apiClient.deleteNamespacedHorizontalPodAutoscaler({ name, namespace });
+  }
+}

--- a/packages/extension/src/resources/leases-resource-factory.ts
+++ b/packages/extension/src/resources/leases-resource-factory.ts
@@ -1,0 +1,71 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1Lease, V1LeaseList, V1Status } from '@kubernetes/client-node';
+import { CoordinationV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class LeasesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'leases',
+      kind: 'Lease',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          group: 'coordination.k8s.io',
+          verb: 'watch',
+          resource: 'leases',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteLease);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Lease> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoordinationV1Api);
+    const listFn = (): Promise<V1LeaseList> => apiClient.listNamespacedLease({ namespace });
+    const path = `/apis/coordination.k8s.io/v1/namespaces/${namespace}/leases`;
+    return new ResourceInformer<V1Lease>({ kubeconfig, path, listFn, kind: this.kind, plural: 'leases' });
+  }
+
+  deleteLease(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoordinationV1Api);
+    return apiClient.deleteNamespacedLease({ name, namespace });
+  }
+}

--- a/packages/extension/src/resources/limit-ranges-resource-factory.ts
+++ b/packages/extension/src/resources/limit-ranges-resource-factory.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1LimitRange, V1LimitRangeList, V1Status } from '@kubernetes/client-node';
+import { CoreV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class LimitRangesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'limitranges',
+      kind: 'LimitRange',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'limitranges',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteLimitRange);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1LimitRange> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    const listFn = (): Promise<V1LimitRangeList> => apiClient.listNamespacedLimitRange({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/limitranges`;
+    return new ResourceInformer<V1LimitRange>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'limitranges',
+    });
+  }
+
+  deleteLimitRange(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    return apiClient.deleteNamespacedLimitRange({ name, namespace });
+  }
+}

--- a/packages/extension/src/resources/mutating-webhooks-resource-factory.ts
+++ b/packages/extension/src/resources/mutating-webhooks-resource-factory.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  KubernetesObject,
+  V1MutatingWebhookConfiguration,
+  V1MutatingWebhookConfigurationList,
+  V1Status,
+} from '@kubernetes/client-node';
+import { AdmissionregistrationV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class MutatingWebhooksResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'mutatingwebhookconfigurations',
+      kind: 'MutatingWebhookConfiguration',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          group: 'admissionregistration.k8s.io',
+          verb: 'watch',
+          resource: 'mutatingwebhookconfigurations',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteMutatingWebhookConfiguration);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1MutatingWebhookConfiguration> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AdmissionregistrationV1Api);
+    const listFn = (): Promise<V1MutatingWebhookConfigurationList> => apiClient.listMutatingWebhookConfiguration();
+    const path = `/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations`;
+    return new ResourceInformer<V1MutatingWebhookConfiguration>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'mutatingwebhookconfigurations',
+    });
+  }
+
+  deleteMutatingWebhookConfiguration(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AdmissionregistrationV1Api);
+    return apiClient.deleteMutatingWebhookConfiguration({ name });
+  }
+}

--- a/packages/extension/src/resources/pdbs-resource-factory.ts
+++ b/packages/extension/src/resources/pdbs-resource-factory.ts
@@ -1,0 +1,82 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  KubernetesObject,
+  V1PodDisruptionBudget,
+  V1PodDisruptionBudgetList,
+  V1Status,
+} from '@kubernetes/client-node';
+import { PolicyV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class PdbsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'poddisruptionbudgets',
+      kind: 'PodDisruptionBudget',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          group: 'policy',
+          verb: 'watch',
+          resource: 'poddisruptionbudgets',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deletePodDisruptionBudget);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1PodDisruptionBudget> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(PolicyV1Api);
+    const listFn = (): Promise<V1PodDisruptionBudgetList> => apiClient.listNamespacedPodDisruptionBudget({ namespace });
+    const path = `/apis/policy/v1/namespaces/${namespace}/poddisruptionbudgets`;
+    return new ResourceInformer<V1PodDisruptionBudget>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'poddisruptionbudgets',
+    });
+  }
+
+  deletePodDisruptionBudget(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(PolicyV1Api);
+    return apiClient.deleteNamespacedPodDisruptionBudget({ name, namespace });
+  }
+}

--- a/packages/extension/src/resources/priority-classes-resource-factory.ts
+++ b/packages/extension/src/resources/priority-classes-resource-factory.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1PriorityClass, V1PriorityClassList, V1Status } from '@kubernetes/client-node';
+import { SchedulingV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class PriorityClassesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'priorityclasses',
+      kind: 'PriorityClass',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          group: 'scheduling.k8s.io',
+          verb: 'watch',
+          resource: 'priorityclasses',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deletePriorityClass);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1PriorityClass> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(SchedulingV1Api);
+    const listFn = (): Promise<V1PriorityClassList> => apiClient.listPriorityClass();
+    const path = `/apis/scheduling.k8s.io/v1/priorityclasses`;
+    return new ResourceInformer<V1PriorityClass>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'priorityclasses',
+    });
+  }
+
+  deletePriorityClass(kubeconfig: KubeConfigSingleContext, name: string): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(SchedulingV1Api);
+    return apiClient.deletePriorityClass({ name });
+  }
+}

--- a/packages/extension/src/resources/resource-quotas-resource-factory.ts
+++ b/packages/extension/src/resources/resource-quotas-resource-factory.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1ResourceQuota, V1ResourceQuotaList, V1Status } from '@kubernetes/client-node';
+import { CoreV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class ResourceQuotasResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'resourcequotas',
+      kind: 'ResourceQuota',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'resourcequotas',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteResourceQuota);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1ResourceQuota> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    const listFn = (): Promise<V1ResourceQuotaList> => apiClient.listNamespacedResourceQuota({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/resourcequotas`;
+    return new ResourceInformer<V1ResourceQuota>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'resourcequotas',
+    });
+  }
+
+  deleteResourceQuota(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    return apiClient.deleteNamespacedResourceQuota({ name, namespace });
+  }
+}

--- a/packages/extension/src/resources/runtime-classes-resource-factory.ts
+++ b/packages/extension/src/resources/runtime-classes-resource-factory.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1RuntimeClass, V1RuntimeClassList, V1Status } from '@kubernetes/client-node';
+import { NodeV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class RuntimeClassesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'runtimeclasses',
+      kind: 'RuntimeClass',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          group: 'node.k8s.io',
+          verb: 'watch',
+          resource: 'runtimeclasses',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteRuntimeClass);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1RuntimeClass> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(NodeV1Api);
+    const listFn = (): Promise<V1RuntimeClassList> => apiClient.listRuntimeClass();
+    const path = `/apis/node.k8s.io/v1/runtimeclasses`;
+    return new ResourceInformer<V1RuntimeClass>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'runtimeclasses',
+    });
+  }
+
+  deleteRuntimeClass(kubeconfig: KubeConfigSingleContext, name: string): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(NodeV1Api);
+    return apiClient.deleteRuntimeClass({ name });
+  }
+}

--- a/packages/extension/src/resources/validating-webhooks-resource-factory.ts
+++ b/packages/extension/src/resources/validating-webhooks-resource-factory.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  KubernetesObject,
+  V1Status,
+  V1ValidatingWebhookConfiguration,
+  V1ValidatingWebhookConfigurationList,
+} from '@kubernetes/client-node';
+import { AdmissionregistrationV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class ValidatingWebhooksResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'validatingwebhookconfigurations',
+      kind: 'ValidatingWebhookConfiguration',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          group: 'admissionregistration.k8s.io',
+          verb: 'watch',
+          resource: 'validatingwebhookconfigurations',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteValidatingWebhookConfiguration);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1ValidatingWebhookConfiguration> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AdmissionregistrationV1Api);
+    const listFn = (): Promise<V1ValidatingWebhookConfigurationList> => apiClient.listValidatingWebhookConfiguration();
+    const path = `/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations`;
+    return new ResourceInformer<V1ValidatingWebhookConfiguration>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'validatingwebhookconfigurations',
+    });
+  }
+
+  deleteValidatingWebhookConfiguration(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AdmissionregistrationV1Api);
+    return apiClient.deleteValidatingWebhookConfiguration({ name });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -32,6 +32,24 @@ import StatefulSetsList from '/@/component/statefulsets/StatefulSetsList.svelte'
 import StatefulSetDetails from '/@/component/statefulsets/StatefulSetDetails.svelte';
 import ReplicaSetsList from '/@/component/replicasets/ReplicaSetsList.svelte';
 import ReplicaSetDetails from '/@/component/replicasets/ReplicaSetDetails.svelte';
+import ResourceQuotasList from './component/resource-quotas/ResourceQuotasList.svelte';
+import ResourceQuotaDetails from './component/resource-quotas/ResourceQuotaDetails.svelte';
+import LimitRangesList from './component/limit-ranges/LimitRangesList.svelte';
+import LimitRangeDetails from './component/limit-ranges/LimitRangeDetails.svelte';
+import HpasList from './component/hpas/HpasList.svelte';
+import HpaDetails from './component/hpas/HpaDetails.svelte';
+import PdbsList from './component/pdbs/PdbsList.svelte';
+import PdbDetails from './component/pdbs/PdbDetails.svelte';
+import PriorityClassesList from './component/priority-classes/PriorityClassesList.svelte';
+import PriorityClassDetails from './component/priority-classes/PriorityClassDetails.svelte';
+import RuntimeClassesList from './component/runtime-classes/RuntimeClassesList.svelte';
+import RuntimeClassDetails from './component/runtime-classes/RuntimeClassDetails.svelte';
+import LeasesList from './component/leases/LeasesList.svelte';
+import LeaseDetails from './component/leases/LeaseDetails.svelte';
+import MutatingWebhooksList from './component/mutating-webhooks/MutatingWebhooksList.svelte';
+import MutatingWebhookDetails from './component/mutating-webhooks/MutatingWebhookDetails.svelte';
+import ValidatingWebhooksList from './component/validating-webhooks/ValidatingWebhooksList.svelte';
+import ValidatingWebhookDetails from './component/validating-webhooks/ValidatingWebhookDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -168,5 +186,77 @@ const { meta }: Props = $props();
 
   <Route path="/replicasets/:name/:namespace/*" let:meta>
     <ReplicaSetDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/resourcequotas">
+    <ResourceQuotasList />
+  </Route>
+
+  <Route path="/resourcequotas/:name/:namespace/*" let:meta>
+    <ResourceQuotaDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/limitranges">
+    <LimitRangesList />
+  </Route>
+
+  <Route path="/limitranges/:name/:namespace/*" let:meta>
+    <LimitRangeDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/horizontalpodautoscalers">
+    <HpasList />
+  </Route>
+
+  <Route path="/horizontalpodautoscalers/:name/:namespace/*" let:meta>
+    <HpaDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/poddisruptionbudgets">
+    <PdbsList />
+  </Route>
+
+  <Route path="/poddisruptionbudgets/:name/:namespace/*" let:meta>
+    <PdbDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/priorityclasses">
+    <PriorityClassesList />
+  </Route>
+
+  <Route path="/priorityclasses/:name/*" let:meta>
+    <PriorityClassDetails name={decodeURI(meta.params.name)} />
+  </Route>
+
+  <Route path="/runtimeclasses">
+    <RuntimeClassesList />
+  </Route>
+
+  <Route path="/runtimeclasses/:name/*" let:meta>
+    <RuntimeClassDetails name={decodeURI(meta.params.name)} />
+  </Route>
+
+  <Route path="/leases">
+    <LeasesList />
+  </Route>
+
+  <Route path="/leases/:name/:namespace/*" let:meta>
+    <LeaseDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/mutatingwebhookconfigurations">
+    <MutatingWebhooksList />
+  </Route>
+
+  <Route path="/mutatingwebhookconfigurations/:name/*" let:meta>
+    <MutatingWebhookDetails name={decodeURI(meta.params.name)} />
+  </Route>
+
+  <Route path="/validatingwebhookconfigurations">
+    <ValidatingWebhooksList />
+  </Route>
+
+  <Route path="/validatingwebhookconfigurations/:name/*" let:meta>
+    <ValidatingWebhookDetails name={decodeURI(meta.params.name)} />
   </Route>
 </div>

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -42,7 +42,18 @@ const workloadUrls = [
   navigator.kubernetesResourcesURL('CronJob'),
 ];
 
-const configUrls = [navigator.kubernetesResourcesURL('ConfigMap')];
+const configUrls = [
+  navigator.kubernetesResourcesURL('ConfigMap'),
+  navigator.kubernetesResourcesURL('ResourceQuota'),
+  navigator.kubernetesResourcesURL('LimitRange'),
+  navigator.kubernetesResourcesURL('HorizontalPodAutoscaler'),
+  navigator.kubernetesResourcesURL('PodDisruptionBudget'),
+  navigator.kubernetesResourcesURL('PriorityClass'),
+  navigator.kubernetesResourcesURL('RuntimeClass'),
+  navigator.kubernetesResourcesURL('Lease'),
+  navigator.kubernetesResourcesURL('MutatingWebhookConfiguration'),
+  navigator.kubernetesResourcesURL('ValidatingWebhookConfiguration'),
+];
 
 const networkUrls = [
   navigator.kubernetesResourcesURL('Service'),
@@ -132,6 +143,27 @@ $effect(() => {
     <NavItem title="Config" icon={faGear} section={true} bind:expanded={configExpanded} href="" />
     {#if configExpanded}
       <NavItem title="ConfigMaps &amp; Secrets" child={true} href={navigator.kubernetesResourcesURL('ConfigMap')} />
+      <NavItem title="Resource Quotas" child={true} href={navigator.kubernetesResourcesURL('ResourceQuota')} />
+      <NavItem title="Limit Ranges" child={true} href={navigator.kubernetesResourcesURL('LimitRange')} />
+      <NavItem
+        title="Horizontal Pod Autoscalers"
+        child={true}
+        href={navigator.kubernetesResourcesURL('HorizontalPodAutoscaler')} />
+      <NavItem
+        title="Pod Disruption Budgets"
+        child={true}
+        href={navigator.kubernetesResourcesURL('PodDisruptionBudget')} />
+      <NavItem title="Priority Classes" child={true} href={navigator.kubernetesResourcesURL('PriorityClass')} />
+      <NavItem title="Runtime Classes" child={true} href={navigator.kubernetesResourcesURL('RuntimeClass')} />
+      <NavItem title="Leases" child={true} href={navigator.kubernetesResourcesURL('Lease')} />
+      <NavItem
+        title="Mutating Webhook Configs"
+        child={true}
+        href={navigator.kubernetesResourcesURL('MutatingWebhookConfiguration')} />
+      <NavItem
+        title="Validating Webhook Configs"
+        child={true}
+        href={navigator.kubernetesResourcesURL('ValidatingWebhookConfiguration')} />
     {/if}
 
     <!-- Network section -->

--- a/packages/webview/src/component/hpas/HpaDetails.svelte
+++ b/packages/webview/src/component/hpas/HpaDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { HpaHelper } from './hpa-helper';
+import type { HpaUI } from './HpaUI';
+import type { V2HorizontalPodAutoscaler } from '@kubernetes/client-node';
+import HpaDetailsSummary from './HpaDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const hpaHelper = dependencyAccessor.get<HpaHelper>(HpaHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V2HorizontalPodAutoscaler}
+  typedUI={{} as HpaUI}
+  kind="HorizontalPodAutoscaler"
+  resourceName="horizontalpodautoscalers"
+  listName="Horizontal Pod Autoscalers"
+  name={name}
+  namespace={namespace}
+  transformer={hpaHelper.getHpaUI.bind(hpaHelper)}
+  SummaryComponent={HpaDetailsSummary} />

--- a/packages/webview/src/component/hpas/HpaDetailsSummary.svelte
+++ b/packages/webview/src/component/hpas/HpaDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V2HorizontalPodAutoscaler } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V2HorizontalPodAutoscaler;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/hpas/HpaUI.ts
+++ b/packages/webview/src/component/hpas/HpaUI.ts
@@ -1,0 +1,29 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface HpaUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  metrics: string;
+  minReplicas: number;
+  maxReplicas: number;
+  currentReplicas: number;
+  desiredReplicas: number;
+}

--- a/packages/webview/src/component/hpas/HpasList.svelte
+++ b/packages/webview/src/component/hpas/HpasList.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import ActionsColumn from './columns/Actions.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { HpaUI } from './HpaUI';
+import { HpaHelper } from './hpa-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const hpaHelper = dependencyAccessor.get<HpaHelper>(HpaHelper);
+
+let statusColumn = new TableColumn<HpaUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<HpaUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let metricsColumn = new TableColumn<HpaUI, string>('Metrics', {
+  renderMapping: (obj): string => obj.metrics,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.metrics.localeCompare(b.metrics),
+});
+
+let minPodsColumn = new TableColumn<HpaUI, string>('Min Pods', {
+  renderMapping: (obj): string => String(obj.minReplicas),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.minReplicas - b.minReplicas,
+});
+
+let maxPodsColumn = new TableColumn<HpaUI, string>('Max Pods', {
+  renderMapping: (obj): string => String(obj.maxReplicas),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.maxReplicas - b.maxReplicas,
+});
+
+let replicasColumn = new TableColumn<HpaUI, string>('Replicas', {
+  renderMapping: (obj): string => String(obj.currentReplicas),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.currentReplicas - b.currentReplicas,
+});
+
+let desiredReplicasColumn = new TableColumn<HpaUI, string>('Desired', {
+  renderMapping: (obj): string => String(obj.desiredReplicas),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.desiredReplicas - b.desiredReplicas,
+});
+
+let ageColumn = new TableColumn<HpaUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  metricsColumn,
+  minPodsColumn,
+  maxPodsColumn,
+  replicasColumn,
+  desiredReplicasColumn,
+  ageColumn,
+  new TableColumn<HpaUI>('Actions', { align: 'right', width: '150px', renderer: ActionsColumn, overflow: true }),
+];
+
+const row = new TableRow<HpaUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'horizontalpodautoscalers',
+      transformer: hpaHelper.getHpaUI,
+    },
+  ]}
+  singular="horizontal pod autoscaler"
+  plural="horizontal pod autoscalers"
+  isNamespaced={true}
+  icon={icon['HorizontalPodAutoscaler']}
+  columns={columns}
+  row={row}>
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['HorizontalPodAutoscaler']} resources={['horizontalpodautoscalers']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/hpas/_hpas-module.ts
+++ b/packages/webview/src/component/hpas/_hpas-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { HpaHelper } from './hpa-helper';
+
+const hpasModule = new ContainerModule(options => {
+  options.bind<HpaHelper>(HpaHelper).toSelf().inSingletonScope();
+});
+
+export { hpasModule };

--- a/packages/webview/src/component/hpas/columns/Actions.svelte
+++ b/packages/webview/src/component/hpas/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/hpas/columns/props.ts
+++ b/packages/webview/src/component/hpas/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { HpaUI } from '/@/component/hpas/HpaUI';
+
+export interface Props {
+  object: HpaUI;
+}

--- a/packages/webview/src/component/hpas/hpa-helper.spec.ts
+++ b/packages/webview/src/component/hpas/hpa-helper.spec.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V2HorizontalPodAutoscaler } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { HpaHelper } from './hpa-helper';
+
+let helper: HpaHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new HpaHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const hpa = {
+    metadata: {
+      name: 'my-hpa',
+      namespace: 'default',
+      uid: 'uid-789',
+    },
+    spec: { maxReplicas: 10 },
+    status: {},
+  } as V2HorizontalPodAutoscaler;
+  const ui = helper.getHpaUI(hpa);
+  expect(ui.kind).toEqual('HorizontalPodAutoscaler');
+  expect(ui.name).toEqual('my-hpa');
+  expect(ui.namespace).toEqual('default');
+});
+
+test('expect Resource metrics formatting "name: current%/target%"', async () => {
+  const hpa = {
+    metadata: { name: 'hpa1' },
+    spec: {
+      maxReplicas: 5,
+      metrics: [
+        {
+          type: 'Resource',
+          resource: { name: 'cpu', target: { averageUtilization: 80 } },
+        },
+      ],
+    },
+    status: {
+      currentMetrics: [
+        {
+          type: 'Resource',
+          resource: { name: 'cpu', current: { averageUtilization: 45 } },
+        },
+      ],
+    },
+  } as V2HorizontalPodAutoscaler;
+  const ui = helper.getHpaUI(hpa);
+  expect(ui.metrics).toEqual('cpu: 45%/80%');
+});
+
+test('expect minReplicas and maxReplicas defaults', async () => {
+  const hpa = {
+    metadata: { name: 'hpa2' },
+    spec: { maxReplicas: 10, minReplicas: 2 },
+    status: {},
+  } as V2HorizontalPodAutoscaler;
+  const ui = helper.getHpaUI(hpa);
+  expect(ui.minReplicas).toEqual(2);
+  expect(ui.maxReplicas).toEqual(10);
+});

--- a/packages/webview/src/component/hpas/hpa-helper.ts
+++ b/packages/webview/src/component/hpas/hpa-helper.ts
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V2HorizontalPodAutoscaler } from '@kubernetes/client-node';
+
+import type { HpaUI } from './HpaUI';
+
+export class HpaHelper {
+  getHpaUI(hpa: V2HorizontalPodAutoscaler): HpaUI {
+    const specMetrics = hpa.spec?.metrics ?? [];
+    const currentMetrics = hpa.status?.currentMetrics ?? [];
+
+    const metrics = specMetrics
+      .map(metric => {
+        if (metric.type === 'Resource') {
+          const name = metric.resource?.name ?? '';
+          const targetUtil = metric.resource?.target?.averageUtilization;
+          const currentMetric = currentMetrics.find(cm => cm.type === 'Resource' && cm.resource?.name === name);
+          const currentUtil = currentMetric?.resource?.current?.averageUtilization;
+          const currentStr = currentUtil !== undefined ? `${String(currentUtil)}%` : '<unknown>';
+          const targetStr = targetUtil !== undefined ? `${String(targetUtil)}%` : '<unknown>';
+          return `${name}: ${currentStr}/${targetStr}`;
+        }
+        if (metric.type === 'Pods') {
+          return metric.pods?.metric?.name ?? 'Pods';
+        }
+        if (metric.type === 'Object') {
+          return metric.object?.metric?.name ?? 'Object';
+        }
+        if (metric.type === 'External') {
+          return metric.external?.metric?.name ?? 'External';
+        }
+        return '';
+      })
+      .filter(name => name !== '')
+      .join(', ');
+
+    return {
+      kind: 'HorizontalPodAutoscaler',
+      uid: hpa.metadata?.uid ?? '',
+      name: hpa.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: hpa.metadata?.namespace ?? '',
+      created: hpa.metadata?.creationTimestamp,
+      selected: false,
+      metrics: metrics || 'N/A',
+      minReplicas: hpa.spec?.minReplicas ?? 1,
+      maxReplicas: hpa.spec?.maxReplicas ?? 0,
+      currentReplicas: hpa.status?.currentReplicas ?? 0,
+      desiredReplicas: hpa.status?.desiredReplicas ?? 0,
+    };
+  }
+}

--- a/packages/webview/src/component/leases/LeaseDetails.svelte
+++ b/packages/webview/src/component/leases/LeaseDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { LeaseHelper } from './lease-helper';
+import type { LeaseUI } from './LeaseUI';
+import type { V1Lease } from '@kubernetes/client-node';
+import LeaseDetailsSummary from './LeaseDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const leaseHelper = dependencyAccessor.get<LeaseHelper>(LeaseHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1Lease}
+  typedUI={{} as LeaseUI}
+  kind="Lease"
+  resourceName="leases"
+  listName="Leases"
+  name={name}
+  namespace={namespace}
+  transformer={leaseHelper.getLeaseUI.bind(leaseHelper)}
+  SummaryComponent={LeaseDetailsSummary} />

--- a/packages/webview/src/component/leases/LeaseDetailsSummary.svelte
+++ b/packages/webview/src/component/leases/LeaseDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1Lease } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1Lease;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/leases/LeaseUI.ts
+++ b/packages/webview/src/component/leases/LeaseUI.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface LeaseUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  holder: string;
+  leaseDuration: string;
+  renewTime: string;
+}

--- a/packages/webview/src/component/leases/LeasesList.svelte
+++ b/packages/webview/src/component/leases/LeasesList.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import ActionsColumn from './columns/Actions.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { LeaseUI } from './LeaseUI';
+import { LeaseHelper } from './lease-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const leaseHelper = dependencyAccessor.get<LeaseHelper>(LeaseHelper);
+
+let statusColumn = new TableColumn<LeaseUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<LeaseUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let holderColumn = new TableColumn<LeaseUI, string>('Holder', {
+  renderMapping: (obj): string => obj.holder,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.holder.localeCompare(b.holder),
+});
+
+let leaseDurationColumn = new TableColumn<LeaseUI, string>('Lease Duration', {
+  renderMapping: (obj): string => obj.leaseDuration,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.leaseDuration.localeCompare(b.leaseDuration),
+});
+
+let renewTimeColumn = new TableColumn<LeaseUI, string>('Renew Time', {
+  renderMapping: (obj): string => obj.renewTime,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.renewTime.localeCompare(b.renewTime),
+});
+
+let ageColumn = new TableColumn<LeaseUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  holderColumn,
+  leaseDurationColumn,
+  renewTimeColumn,
+  ageColumn,
+  new TableColumn<LeaseUI>('Actions', { align: 'right', width: '150px', renderer: ActionsColumn, overflow: true }),
+];
+
+const row = new TableRow<LeaseUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'leases',
+      transformer: leaseHelper.getLeaseUI,
+    },
+  ]}
+  singular="lease"
+  plural="leases"
+  isNamespaced={true}
+  icon={icon['Lease']}
+  columns={columns}
+  row={row}>
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['Lease']} resources={['leases']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/leases/_leases-module.ts
+++ b/packages/webview/src/component/leases/_leases-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { LeaseHelper } from './lease-helper';
+
+const leasesModule = new ContainerModule(options => {
+  options.bind<LeaseHelper>(LeaseHelper).toSelf().inSingletonScope();
+});
+
+export { leasesModule };

--- a/packages/webview/src/component/leases/columns/Actions.svelte
+++ b/packages/webview/src/component/leases/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/leases/columns/props.ts
+++ b/packages/webview/src/component/leases/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { LeaseUI } from '/@/component/leases/LeaseUI';
+
+export interface Props {
+  object: LeaseUI;
+}

--- a/packages/webview/src/component/leases/lease-helper.spec.ts
+++ b/packages/webview/src/component/leases/lease-helper.spec.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Lease } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { LeaseHelper } from './lease-helper';
+
+let helper: LeaseHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new LeaseHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const lease = {
+    metadata: {
+      name: 'my-lease',
+      namespace: 'kube-system',
+      uid: 'uid-lease',
+    },
+    spec: {},
+  } as V1Lease;
+  const ui = helper.getLeaseUI(lease);
+  expect(ui.kind).toEqual('Lease');
+  expect(ui.name).toEqual('my-lease');
+  expect(ui.namespace).toEqual('kube-system');
+});
+
+test('expect holder and leaseDuration fields', async () => {
+  const lease = {
+    metadata: { name: 'lease1' },
+    spec: {
+      holderIdentity: 'node-1',
+      leaseDurationSeconds: 40,
+    },
+  } as V1Lease;
+  const ui = helper.getLeaseUI(lease);
+  expect(ui.holder).toEqual('node-1');
+  expect(ui.leaseDuration).toEqual('40s');
+});
+
+test('expect renewTime as ISO string', async () => {
+  const lease = {
+    metadata: { name: 'lease2' },
+    spec: {
+      renewTime: new Date('2026-01-15T10:30:00Z'),
+    },
+  } as V1Lease;
+  const ui = helper.getLeaseUI(lease);
+  expect(ui.renewTime).toEqual('2026-01-15T10:30:00.000Z');
+});
+
+test('expect empty strings when spec fields are missing', async () => {
+  const lease = {
+    metadata: { name: 'lease3' },
+  } as V1Lease;
+  const ui = helper.getLeaseUI(lease);
+  expect(ui.holder).toEqual('');
+  expect(ui.leaseDuration).toEqual('');
+  expect(ui.renewTime).toEqual('');
+});

--- a/packages/webview/src/component/leases/lease-helper.ts
+++ b/packages/webview/src/component/leases/lease-helper.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Lease } from '@kubernetes/client-node';
+
+import type { LeaseUI } from './LeaseUI';
+
+export class LeaseHelper {
+  getLeaseUI(lease: V1Lease): LeaseUI {
+    return {
+      kind: 'Lease',
+      uid: lease.metadata?.uid ?? '',
+      name: lease.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: lease.metadata?.namespace ?? '',
+      created: lease.metadata?.creationTimestamp,
+      selected: false,
+      holder: lease.spec?.holderIdentity ?? '',
+      leaseDuration:
+        lease.spec?.leaseDurationSeconds !== undefined ? `${String(lease.spec.leaseDurationSeconds)}s` : '',
+      renewTime: lease.spec?.renewTime ? new Date(lease.spec.renewTime).toISOString() : '',
+    };
+  }
+}

--- a/packages/webview/src/component/limit-ranges/LimitRangeDetails.svelte
+++ b/packages/webview/src/component/limit-ranges/LimitRangeDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { LimitRangeHelper } from './limit-range-helper';
+import type { LimitRangeUI } from './LimitRangeUI';
+import type { V1LimitRange } from '@kubernetes/client-node';
+import LimitRangeDetailsSummary from './LimitRangeDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const limitRangeHelper = dependencyAccessor.get<LimitRangeHelper>(LimitRangeHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1LimitRange}
+  typedUI={{} as LimitRangeUI}
+  kind="LimitRange"
+  resourceName="limitranges"
+  listName="Limit Ranges"
+  name={name}
+  namespace={namespace}
+  transformer={limitRangeHelper.getLimitRangeUI.bind(limitRangeHelper)}
+  SummaryComponent={LimitRangeDetailsSummary} />

--- a/packages/webview/src/component/limit-ranges/LimitRangeDetailsSummary.svelte
+++ b/packages/webview/src/component/limit-ranges/LimitRangeDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1LimitRange } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1LimitRange;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/limit-ranges/LimitRangeUI.ts
+++ b/packages/webview/src/component/limit-ranges/LimitRangeUI.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface LimitRangeUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  limitTypes: string;
+  limitCount: number;
+}

--- a/packages/webview/src/component/limit-ranges/LimitRangesList.svelte
+++ b/packages/webview/src/component/limit-ranges/LimitRangesList.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import ActionsColumn from './columns/Actions.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { LimitRangeUI } from './LimitRangeUI';
+import { LimitRangeHelper } from './limit-range-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const limitRangeHelper = dependencyAccessor.get<LimitRangeHelper>(LimitRangeHelper);
+
+let statusColumn = new TableColumn<LimitRangeUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<LimitRangeUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let typeColumn = new TableColumn<LimitRangeUI, string>('Type', {
+  renderMapping: (obj): string => obj.limitTypes,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.limitTypes.localeCompare(b.limitTypes),
+});
+
+let countColumn = new TableColumn<LimitRangeUI, string>('Count', {
+  renderMapping: (obj): string => String(obj.limitCount),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.limitCount - b.limitCount,
+});
+
+let ageColumn = new TableColumn<LimitRangeUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  typeColumn,
+  countColumn,
+  ageColumn,
+  new TableColumn<LimitRangeUI>('Actions', { align: 'right', width: '150px', renderer: ActionsColumn, overflow: true }),
+];
+
+const row = new TableRow<LimitRangeUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'limitranges',
+      transformer: limitRangeHelper.getLimitRangeUI,
+    },
+  ]}
+  singular="limit range"
+  plural="limit ranges"
+  isNamespaced={true}
+  icon={icon['LimitRange']}
+  columns={columns}
+  row={row}>
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['LimitRange']} resources={['limitranges']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/limit-ranges/_limit-ranges-module.ts
+++ b/packages/webview/src/component/limit-ranges/_limit-ranges-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { LimitRangeHelper } from './limit-range-helper';
+
+const limitRangesModule = new ContainerModule(options => {
+  options.bind<LimitRangeHelper>(LimitRangeHelper).toSelf().inSingletonScope();
+});
+
+export { limitRangesModule };

--- a/packages/webview/src/component/limit-ranges/columns/Actions.svelte
+++ b/packages/webview/src/component/limit-ranges/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/limit-ranges/columns/props.ts
+++ b/packages/webview/src/component/limit-ranges/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { LimitRangeUI } from '/@/component/limit-ranges/LimitRangeUI';
+
+export interface Props {
+  object: LimitRangeUI;
+}

--- a/packages/webview/src/component/limit-ranges/limit-range-helper.spec.ts
+++ b/packages/webview/src/component/limit-ranges/limit-range-helper.spec.ts
@@ -1,0 +1,84 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1LimitRange } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { LimitRangeHelper } from './limit-range-helper';
+
+let helper: LimitRangeHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new LimitRangeHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const lr = {
+    metadata: {
+      name: 'my-limit',
+      namespace: 'default',
+      uid: 'uid-456',
+    },
+    spec: { limits: [] },
+  } as V1LimitRange;
+  const ui = helper.getLimitRangeUI(lr);
+  expect(ui.kind).toEqual('LimitRange');
+  expect(ui.name).toEqual('my-limit');
+  expect(ui.namespace).toEqual('default');
+  expect(ui.uid).toEqual('uid-456');
+});
+
+test('expect limitTypes and limitCount with type', async () => {
+  const lr = {
+    metadata: { name: 'lr1' },
+    spec: {
+      limits: [
+        {
+          type: 'Container',
+          _default: { cpu: '500m', memory: '128Mi' },
+          defaultRequest: { cpu: '250m' },
+        },
+      ],
+    },
+  } as V1LimitRange;
+  const ui = helper.getLimitRangeUI(lr);
+  expect(ui.limitTypes).toEqual('Container');
+  expect(ui.limitCount).toEqual(1);
+});
+
+test('expect multiple limit types', async () => {
+  const lr = {
+    metadata: { name: 'lr2' },
+    spec: {
+      limits: [{ type: 'Container', _default: { cpu: '500m' } }, { type: 'Pod' }],
+    },
+  } as V1LimitRange;
+  const ui = helper.getLimitRangeUI(lr);
+  expect(ui.limitTypes).toEqual('Container, Pod');
+  expect(ui.limitCount).toEqual(2);
+});
+
+test('expect empty limitTypes when no spec', async () => {
+  const lr = {
+    metadata: { name: 'empty' },
+  } as V1LimitRange;
+  const ui = helper.getLimitRangeUI(lr);
+  expect(ui.limitTypes).toEqual('');
+  expect(ui.limitCount).toEqual(0);
+});

--- a/packages/webview/src/component/limit-ranges/limit-range-helper.ts
+++ b/packages/webview/src/component/limit-ranges/limit-range-helper.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1LimitRange } from '@kubernetes/client-node';
+
+import type { LimitRangeUI } from './LimitRangeUI';
+
+export class LimitRangeHelper {
+  getLimitRangeUI(o: KubernetesObject): LimitRangeUI {
+    const obj = o as V1LimitRange;
+    const items = obj.spec?.limits ?? [];
+    const types = items.map(item => item.type).filter((t): t is string => !!t);
+    const limitCount = items.length;
+
+    return {
+      kind: 'LimitRange',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: obj.metadata?.namespace ?? '',
+      created: obj.metadata?.creationTimestamp,
+      selected: false,
+      limitTypes: types.join(', '),
+      limitCount,
+    };
+  }
+}

--- a/packages/webview/src/component/mutating-webhooks/MutatingWebhookDetails.svelte
+++ b/packages/webview/src/component/mutating-webhooks/MutatingWebhookDetails.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { MutatingWebhookHelper } from './mutating-webhook-helper';
+import type { MutatingWebhookUI } from './MutatingWebhookUI';
+import type { V1MutatingWebhookConfiguration } from '@kubernetes/client-node';
+import MutatingWebhookDetailsSummary from './MutatingWebhookDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+}
+let { name }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const mutatingWebhookHelper = dependencyAccessor.get<MutatingWebhookHelper>(MutatingWebhookHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1MutatingWebhookConfiguration}
+  typedUI={{} as MutatingWebhookUI}
+  kind="MutatingWebhookConfiguration"
+  resourceName="mutatingwebhookconfigurations"
+  listName="Mutating Webhook Configurations"
+  name={name}
+  transformer={mutatingWebhookHelper.getMutatingWebhookUI.bind(mutatingWebhookHelper)}
+  SummaryComponent={MutatingWebhookDetailsSummary} />

--- a/packages/webview/src/component/mutating-webhooks/MutatingWebhookDetailsSummary.svelte
+++ b/packages/webview/src/component/mutating-webhooks/MutatingWebhookDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1MutatingWebhookConfiguration } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1MutatingWebhookConfiguration;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/mutating-webhooks/MutatingWebhookUI.ts
+++ b/packages/webview/src/component/mutating-webhooks/MutatingWebhookUI.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface MutatingWebhookUI extends KubernetesObjectUI {
+  uid: string;
+  created?: Date;
+  webhooks: number;
+  failurePolicy: string;
+}

--- a/packages/webview/src/component/mutating-webhooks/MutatingWebhooksList.svelte
+++ b/packages/webview/src/component/mutating-webhooks/MutatingWebhooksList.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import ActionsColumn from './columns/Actions.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { MutatingWebhookUI } from './MutatingWebhookUI';
+import { MutatingWebhookHelper } from './mutating-webhook-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const mutatingWebhookHelper = dependencyAccessor.get<MutatingWebhookHelper>(MutatingWebhookHelper);
+
+let statusColumn = new TableColumn<MutatingWebhookUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<MutatingWebhookUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let webhooksColumn = new TableColumn<MutatingWebhookUI, string>('Webhooks', {
+  renderMapping: (obj): string => String(obj.webhooks),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.webhooks - b.webhooks,
+});
+
+let failurePolicyColumn = new TableColumn<MutatingWebhookUI, string>('Failure Policy', {
+  renderMapping: (obj): string => obj.failurePolicy,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.failurePolicy.localeCompare(b.failurePolicy),
+});
+
+let ageColumn = new TableColumn<MutatingWebhookUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  webhooksColumn,
+  failurePolicyColumn,
+  ageColumn,
+  new TableColumn<MutatingWebhookUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<MutatingWebhookUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'mutatingwebhookconfigurations',
+      transformer: mutatingWebhookHelper.getMutatingWebhookUI.bind(mutatingWebhookHelper),
+    },
+  ]}
+  singular="mutating webhook configuration"
+  plural="mutating webhook configurations"
+  isNamespaced={false}
+  icon={icon['MutatingWebhookConfiguration']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['MutatingWebhookConfiguration']} resources={['mutatingwebhookconfigurations']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/mutating-webhooks/_mutating-webhooks-module.ts
+++ b/packages/webview/src/component/mutating-webhooks/_mutating-webhooks-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { MutatingWebhookHelper } from './mutating-webhook-helper';
+
+const mutatingWebhooksModule = new ContainerModule(options => {
+  options.bind<MutatingWebhookHelper>(MutatingWebhookHelper).toSelf().inSingletonScope();
+});
+
+export { mutatingWebhooksModule };

--- a/packages/webview/src/component/mutating-webhooks/columns/Actions.svelte
+++ b/packages/webview/src/component/mutating-webhooks/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/mutating-webhooks/columns/props.ts
+++ b/packages/webview/src/component/mutating-webhooks/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { MutatingWebhookUI } from '/@/component/mutating-webhooks/MutatingWebhookUI';
+
+export interface Props {
+  object: MutatingWebhookUI;
+}

--- a/packages/webview/src/component/mutating-webhooks/mutating-webhook-helper.spec.ts
+++ b/packages/webview/src/component/mutating-webhooks/mutating-webhook-helper.spec.ts
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1MutatingWebhookConfiguration } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { MutatingWebhookHelper } from './mutating-webhook-helper';
+
+let helper: MutatingWebhookHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new MutatingWebhookHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const obj = {
+    metadata: {
+      name: 'my-mutating-webhook',
+      uid: 'uid-mw',
+    },
+    webhooks: [],
+  } as V1MutatingWebhookConfiguration;
+  const ui = helper.getMutatingWebhookUI(obj);
+  expect(ui.kind).toEqual('MutatingWebhookConfiguration');
+  expect(ui.name).toEqual('my-mutating-webhook');
+  expect(ui.uid).toEqual('uid-mw');
+});
+
+test('expect webhooks count', async () => {
+  const obj = {
+    metadata: { name: 'mw1' },
+    webhooks: [
+      { name: 'hook1', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+      { name: 'hook2', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+      { name: 'hook3', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+    ],
+  } as V1MutatingWebhookConfiguration;
+  const ui = helper.getMutatingWebhookUI(obj);
+  expect(ui.webhooks).toEqual(3);
+});
+
+test('expect failurePolicy deduplication', async () => {
+  const obj = {
+    metadata: { name: 'mw2' },
+    webhooks: [
+      { name: 'h1', failurePolicy: 'Ignore', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+      { name: 'h2', failurePolicy: 'Ignore', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+      { name: 'h3', failurePolicy: 'Fail', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+    ],
+  } as V1MutatingWebhookConfiguration;
+  const ui = helper.getMutatingWebhookUI(obj);
+  expect(ui.failurePolicy).toEqual('Ignore, Fail');
+});

--- a/packages/webview/src/component/mutating-webhooks/mutating-webhook-helper.ts
+++ b/packages/webview/src/component/mutating-webhooks/mutating-webhook-helper.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1MutatingWebhookConfiguration } from '@kubernetes/client-node';
+
+import type { MutatingWebhookUI } from './MutatingWebhookUI';
+
+export class MutatingWebhookHelper {
+  getMutatingWebhookUI(obj: V1MutatingWebhookConfiguration): MutatingWebhookUI {
+    return {
+      kind: 'MutatingWebhookConfiguration',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      created: obj.metadata?.creationTimestamp,
+      webhooks: obj.webhooks?.length ?? 0,
+      failurePolicy: [...new Set((obj.webhooks ?? []).map(w => w.failurePolicy ?? 'Fail'))].join(', '),
+    };
+  }
+}

--- a/packages/webview/src/component/pdbs/PdbDetails.svelte
+++ b/packages/webview/src/component/pdbs/PdbDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { PdbHelper } from './pdb-helper';
+import type { PdbUI } from './PdbUI';
+import type { V1PodDisruptionBudget } from '@kubernetes/client-node';
+import PdbDetailsSummary from './PdbDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const pdbHelper = dependencyAccessor.get<PdbHelper>(PdbHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1PodDisruptionBudget}
+  typedUI={{} as PdbUI}
+  kind="PodDisruptionBudget"
+  resourceName="poddisruptionbudgets"
+  listName="Pod Disruption Budgets"
+  name={name}
+  namespace={namespace}
+  transformer={pdbHelper.getPdbUI.bind(pdbHelper)}
+  SummaryComponent={PdbDetailsSummary} />

--- a/packages/webview/src/component/pdbs/PdbDetailsSummary.svelte
+++ b/packages/webview/src/component/pdbs/PdbDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1PodDisruptionBudget } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1PodDisruptionBudget;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/pdbs/PdbUI.ts
+++ b/packages/webview/src/component/pdbs/PdbUI.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface PdbUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  minAvailable: string;
+  maxUnavailable: string;
+  currentHealthy: number;
+  desiredHealthy: number;
+  allowedDisruptions: number;
+  expectedPods: number;
+}

--- a/packages/webview/src/component/pdbs/PdbsList.svelte
+++ b/packages/webview/src/component/pdbs/PdbsList.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import ActionsColumn from './columns/Actions.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { PdbUI } from './PdbUI';
+import { PdbHelper } from './pdb-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const pdbHelper = dependencyAccessor.get<PdbHelper>(PdbHelper);
+
+let statusColumn = new TableColumn<PdbUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<PdbUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let minAvailableColumn = new TableColumn<PdbUI, string>('Min Available', {
+  renderMapping: (obj): string => obj.minAvailable,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.minAvailable.localeCompare(b.minAvailable),
+});
+
+let maxUnavailableColumn = new TableColumn<PdbUI, string>('Max Unavailable', {
+  renderMapping: (obj): string => obj.maxUnavailable,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.maxUnavailable.localeCompare(b.maxUnavailable),
+});
+
+let currentHealthyColumn = new TableColumn<PdbUI, string>('Current Healthy', {
+  renderMapping: (obj): string => String(obj.currentHealthy),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.currentHealthy - b.currentHealthy,
+});
+
+let desiredHealthyColumn = new TableColumn<PdbUI, string>('Desired Healthy', {
+  renderMapping: (obj): string => String(obj.desiredHealthy),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.desiredHealthy - b.desiredHealthy,
+});
+
+let allowedDisruptionsColumn = new TableColumn<PdbUI, string>('Allowed Disruptions', {
+  renderMapping: (obj): string => String(obj.allowedDisruptions),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.allowedDisruptions - b.allowedDisruptions,
+});
+
+let expectedPodsColumn = new TableColumn<PdbUI, string>('Expected Pods', {
+  renderMapping: (obj): string => String(obj.expectedPods),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.expectedPods - b.expectedPods,
+});
+
+let ageColumn = new TableColumn<PdbUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  minAvailableColumn,
+  maxUnavailableColumn,
+  currentHealthyColumn,
+  desiredHealthyColumn,
+  allowedDisruptionsColumn,
+  expectedPodsColumn,
+  ageColumn,
+  new TableColumn<PdbUI>('Actions', { align: 'right', width: '150px', renderer: ActionsColumn, overflow: true }),
+];
+
+const row = new TableRow<PdbUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'poddisruptionbudgets',
+      transformer: pdbHelper.getPdbUI,
+    },
+  ]}
+  singular="pod disruption budget"
+  plural="pod disruption budgets"
+  isNamespaced={true}
+  icon={icon['PodDisruptionBudget']}
+  columns={columns}
+  row={row}>
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['PodDisruptionBudget']} resources={['poddisruptionbudgets']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/pdbs/_pdbs-module.ts
+++ b/packages/webview/src/component/pdbs/_pdbs-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { PdbHelper } from './pdb-helper';
+
+const pdbsModule = new ContainerModule(options => {
+  options.bind<PdbHelper>(PdbHelper).toSelf().inSingletonScope();
+});
+
+export { pdbsModule };

--- a/packages/webview/src/component/pdbs/columns/Actions.svelte
+++ b/packages/webview/src/component/pdbs/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/pdbs/columns/props.ts
+++ b/packages/webview/src/component/pdbs/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { PdbUI } from '/@/component/pdbs/PdbUI';
+
+export interface Props {
+  object: PdbUI;
+}

--- a/packages/webview/src/component/pdbs/pdb-helper.spec.ts
+++ b/packages/webview/src/component/pdbs/pdb-helper.spec.ts
@@ -1,0 +1,74 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1PodDisruptionBudget } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { PdbHelper } from './pdb-helper';
+
+let helper: PdbHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new PdbHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const pdb = {
+    metadata: {
+      name: 'my-pdb',
+      namespace: 'default',
+      uid: 'uid-pdb',
+    },
+    spec: { minAvailable: 1 },
+    status: {},
+  } as V1PodDisruptionBudget;
+  const ui = helper.getPdbUI(pdb);
+  expect(ui.kind).toEqual('PodDisruptionBudget');
+  expect(ui.name).toEqual('my-pdb');
+  expect(ui.namespace).toEqual('default');
+});
+
+test('expect minAvailable and maxUnavailable as strings', async () => {
+  const pdb = {
+    metadata: { name: 'pdb1' },
+    spec: { minAvailable: 2, maxUnavailable: 1 },
+    status: {},
+  } as V1PodDisruptionBudget;
+  const ui = helper.getPdbUI(pdb);
+  expect(ui.minAvailable).toEqual('2');
+  expect(ui.maxUnavailable).toEqual('1');
+});
+
+test('expect status fields with defaults', async () => {
+  const pdb = {
+    metadata: { name: 'pdb2' },
+    spec: {},
+    status: {
+      currentHealthy: 3,
+      desiredHealthy: 2,
+      disruptionsAllowed: 1,
+      expectedPods: 4,
+    },
+  } as V1PodDisruptionBudget;
+  const ui = helper.getPdbUI(pdb);
+  expect(ui.currentHealthy).toEqual(3);
+  expect(ui.desiredHealthy).toEqual(2);
+  expect(ui.allowedDisruptions).toEqual(1);
+  expect(ui.expectedPods).toEqual(4);
+});

--- a/packages/webview/src/component/pdbs/pdb-helper.ts
+++ b/packages/webview/src/component/pdbs/pdb-helper.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1PodDisruptionBudget } from '@kubernetes/client-node';
+
+import type { PdbUI } from './PdbUI';
+
+export class PdbHelper {
+  getPdbUI(pdb: V1PodDisruptionBudget): PdbUI {
+    return {
+      kind: 'PodDisruptionBudget',
+      uid: pdb.metadata?.uid ?? '',
+      name: pdb.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: pdb.metadata?.namespace ?? '',
+      created: pdb.metadata?.creationTimestamp,
+      selected: false,
+      minAvailable: String(pdb.spec?.minAvailable ?? 'N/A'),
+      maxUnavailable: String(pdb.spec?.maxUnavailable ?? 'N/A'),
+      currentHealthy: pdb.status?.currentHealthy ?? 0,
+      desiredHealthy: pdb.status?.desiredHealthy ?? 0,
+      allowedDisruptions: pdb.status?.disruptionsAllowed ?? 0,
+      expectedPods: pdb.status?.expectedPods ?? 0,
+    };
+  }
+}

--- a/packages/webview/src/component/priority-classes/PriorityClassDetails.svelte
+++ b/packages/webview/src/component/priority-classes/PriorityClassDetails.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { PriorityClassHelper } from './priority-class-helper';
+import type { PriorityClassUI } from './PriorityClassUI';
+import type { V1PriorityClass } from '@kubernetes/client-node';
+import PriorityClassDetailsSummary from './PriorityClassDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+}
+let { name }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const priorityClassHelper = dependencyAccessor.get<PriorityClassHelper>(PriorityClassHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1PriorityClass}
+  typedUI={{} as PriorityClassUI}
+  kind="PriorityClass"
+  resourceName="priorityclasses"
+  listName="Priority Classes"
+  name={name}
+  transformer={priorityClassHelper.getPriorityClassUI.bind(priorityClassHelper)}
+  SummaryComponent={PriorityClassDetailsSummary} />

--- a/packages/webview/src/component/priority-classes/PriorityClassDetailsSummary.svelte
+++ b/packages/webview/src/component/priority-classes/PriorityClassDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1PriorityClass } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1PriorityClass;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/priority-classes/PriorityClassUI.ts
+++ b/packages/webview/src/component/priority-classes/PriorityClassUI.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface PriorityClassUI extends KubernetesObjectUI {
+  uid: string;
+  created?: Date;
+  value: number;
+  globalDefault: string;
+  preemptionPolicy: string;
+}

--- a/packages/webview/src/component/priority-classes/PriorityClassesList.svelte
+++ b/packages/webview/src/component/priority-classes/PriorityClassesList.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { PriorityClassUI } from './PriorityClassUI';
+import { PriorityClassHelper } from './priority-class-helper';
+import GlobalDefaultColumn from './columns/GlobalDefault.svelte';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const priorityClassHelper = dependencyAccessor.get<PriorityClassHelper>(PriorityClassHelper);
+
+let statusColumn = new TableColumn<PriorityClassUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<PriorityClassUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let valueColumn = new TableColumn<PriorityClassUI, string>('Value', {
+  renderMapping: (obj): string => String(obj.value),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.value - b.value,
+});
+
+let globalDefaultColumn = new TableColumn<PriorityClassUI>('Global Default', {
+  renderer: GlobalDefaultColumn,
+  comparator: (a, b): number => a.globalDefault.localeCompare(b.globalDefault),
+});
+
+let preemptionPolicyColumn = new TableColumn<PriorityClassUI, string>('Preemption Policy', {
+  renderMapping: (obj): string => obj.preemptionPolicy,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.preemptionPolicy.localeCompare(b.preemptionPolicy),
+});
+
+let ageColumn = new TableColumn<PriorityClassUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [statusColumn, nameColumn, valueColumn, globalDefaultColumn, preemptionPolicyColumn, ageColumn];
+
+const row = new TableRow<PriorityClassUI>({});
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'priorityclasses',
+      transformer: priorityClassHelper.getPriorityClassUI.bind(priorityClassHelper),
+    },
+  ]}
+  singular="priority class"
+  plural="priority classes"
+  isNamespaced={false}
+  icon={icon['PriorityClass']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['PriorityClass']} resources={['priorityclasses']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/priority-classes/_priority-classes-module.ts
+++ b/packages/webview/src/component/priority-classes/_priority-classes-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { PriorityClassHelper } from './priority-class-helper';
+
+const priorityClassesModule = new ContainerModule(options => {
+  options.bind<PriorityClassHelper>(PriorityClassHelper).toSelf().inSingletonScope();
+});
+
+export { priorityClassesModule };

--- a/packages/webview/src/component/priority-classes/columns/GlobalDefault.svelte
+++ b/packages/webview/src/component/priority-classes/columns/GlobalDefault.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+import { faStar } from '@fortawesome/free-solid-svg-icons';
+import Fa from 'svelte-fa';
+
+import type { Props } from './props';
+import Label from '/@/component/label/Label.svelte';
+
+let { object }: Props = $props();
+</script>
+
+{#if object.globalDefault === 'true'}
+  <Label name="true">
+    <Fa size="1x" icon={faStar} class="text-(--pd-status-running)" />
+  </Label>
+{:else}
+  <span class="text-(--pd-table-body-text)">false</span>
+{/if}

--- a/packages/webview/src/component/priority-classes/columns/props.ts
+++ b/packages/webview/src/component/priority-classes/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { PriorityClassUI } from '/@/component/priority-classes/PriorityClassUI';
+
+export interface Props {
+  object: PriorityClassUI;
+}

--- a/packages/webview/src/component/priority-classes/priority-class-helper.spec.ts
+++ b/packages/webview/src/component/priority-classes/priority-class-helper.spec.ts
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { PriorityClassHelper } from './priority-class-helper';
+
+let helper: PriorityClassHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new PriorityClassHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const obj = {
+    metadata: {
+      name: 'high-priority',
+      uid: 'uid-pc',
+    },
+    value: 1000000,
+    globalDefault: false,
+    preemptionPolicy: 'PreemptLowerPriority',
+    description: 'High priority class',
+  } as KubernetesObject;
+  const ui = helper.getPriorityClassUI(obj);
+  expect(ui.kind).toEqual('PriorityClass');
+  expect(ui.name).toEqual('high-priority');
+  expect(ui.uid).toEqual('uid-pc');
+});
+
+test('expect value, globalDefault, and preemptionPolicy fields', async () => {
+  const obj = {
+    metadata: { name: 'pc1' },
+    value: 500,
+    globalDefault: true,
+    preemptionPolicy: 'Never',
+  } as KubernetesObject;
+  const ui = helper.getPriorityClassUI(obj);
+  expect(ui.value).toEqual(500);
+  expect(ui.globalDefault).toEqual('true');
+  expect(ui.preemptionPolicy).toEqual('Never');
+});
+
+test('expect defaults when fields are missing', async () => {
+  const obj = {
+    metadata: { name: 'pc2' },
+  } as KubernetesObject;
+  const ui = helper.getPriorityClassUI(obj);
+  expect(ui.value).toEqual(0);
+  expect(ui.globalDefault).toEqual('false');
+  expect(ui.preemptionPolicy).toEqual('PreemptLowerPriority');
+});

--- a/packages/webview/src/component/priority-classes/priority-class-helper.ts
+++ b/packages/webview/src/component/priority-classes/priority-class-helper.ts
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1PriorityClass } from '@kubernetes/client-node';
+
+import type { PriorityClassUI } from './PriorityClassUI';
+
+export class PriorityClassHelper {
+  getPriorityClassUI(obj: KubernetesObject): PriorityClassUI {
+    const priorityClass = obj as V1PriorityClass;
+    return {
+      kind: 'PriorityClass',
+      uid: priorityClass.metadata?.uid ?? '',
+      name: priorityClass.metadata?.name ?? '',
+      status: 'RUNNING',
+      created: priorityClass.metadata?.creationTimestamp,
+      value: priorityClass.value ?? 0,
+      globalDefault: priorityClass.globalDefault ? 'true' : 'false',
+      preemptionPolicy: priorityClass.preemptionPolicy ?? 'PreemptLowerPriority',
+    };
+  }
+}

--- a/packages/webview/src/component/resource-quotas/ResourceQuotaDetails.svelte
+++ b/packages/webview/src/component/resource-quotas/ResourceQuotaDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { ResourceQuotaHelper } from './resource-quota-helper';
+import type { ResourceQuotaUI } from './ResourceQuotaUI';
+import type { V1ResourceQuota } from '@kubernetes/client-node';
+import ResourceQuotaDetailsSummary from './ResourceQuotaDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const resourceQuotaHelper = dependencyAccessor.get<ResourceQuotaHelper>(ResourceQuotaHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1ResourceQuota}
+  typedUI={{} as ResourceQuotaUI}
+  kind="ResourceQuota"
+  resourceName="resourcequotas"
+  listName="Resource Quotas"
+  name={name}
+  namespace={namespace}
+  transformer={resourceQuotaHelper.getResourceQuotaUI.bind(resourceQuotaHelper)}
+  SummaryComponent={ResourceQuotaDetailsSummary} />

--- a/packages/webview/src/component/resource-quotas/ResourceQuotaDetailsSummary.svelte
+++ b/packages/webview/src/component/resource-quotas/ResourceQuotaDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1ResourceQuota } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1ResourceQuota;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/resource-quotas/ResourceQuotaUI.ts
+++ b/packages/webview/src/component/resource-quotas/ResourceQuotaUI.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface ResourceQuotaUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  requestCount: number;
+}

--- a/packages/webview/src/component/resource-quotas/ResourceQuotasList.svelte
+++ b/packages/webview/src/component/resource-quotas/ResourceQuotasList.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import ActionsColumn from './columns/Actions.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { ResourceQuotaUI } from './ResourceQuotaUI';
+import { ResourceQuotaHelper } from './resource-quota-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const resourceQuotaHelper = dependencyAccessor.get<ResourceQuotaHelper>(ResourceQuotaHelper);
+
+let statusColumn = new TableColumn<ResourceQuotaUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<ResourceQuotaUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let requestCountColumn = new TableColumn<ResourceQuotaUI, string>('Request Count', {
+  renderMapping: (obj): string => String(obj.requestCount),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.requestCount - b.requestCount,
+});
+
+let ageColumn = new TableColumn<ResourceQuotaUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  requestCountColumn,
+  ageColumn,
+  new TableColumn<ResourceQuotaUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<ResourceQuotaUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'resourcequotas',
+      transformer: resourceQuotaHelper.getResourceQuotaUI,
+    },
+  ]}
+  singular="resource quota"
+  plural="resource quotas"
+  isNamespaced={true}
+  icon={icon['ResourceQuota']}
+  columns={columns}
+  row={row}>
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['ResourceQuota']} resources={['resourcequotas']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/resource-quotas/_resource-quotas-module.ts
+++ b/packages/webview/src/component/resource-quotas/_resource-quotas-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { ResourceQuotaHelper } from './resource-quota-helper';
+
+const resourceQuotasModule = new ContainerModule(options => {
+  options.bind<ResourceQuotaHelper>(ResourceQuotaHelper).toSelf().inSingletonScope();
+});
+
+export { resourceQuotasModule };

--- a/packages/webview/src/component/resource-quotas/columns/Actions.svelte
+++ b/packages/webview/src/component/resource-quotas/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/resource-quotas/columns/props.ts
+++ b/packages/webview/src/component/resource-quotas/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ResourceQuotaUI } from '/@/component/resource-quotas/ResourceQuotaUI';
+
+export interface Props {
+  object: ResourceQuotaUI;
+}

--- a/packages/webview/src/component/resource-quotas/resource-quota-helper.spec.ts
+++ b/packages/webview/src/component/resource-quotas/resource-quota-helper.spec.ts
@@ -1,0 +1,66 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ResourceQuota } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { ResourceQuotaHelper } from './resource-quota-helper';
+
+let helper: ResourceQuotaHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new ResourceQuotaHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const rq = {
+    metadata: {
+      name: 'my-quota',
+      namespace: 'default',
+      uid: 'uid-123',
+    },
+    spec: { hard: { cpu: '4' } },
+    status: { hard: { cpu: '4' }, used: { cpu: '2' } },
+  } as V1ResourceQuota;
+  const ui = helper.getResourceQuotaUI(rq);
+  expect(ui.kind).toEqual('ResourceQuota');
+  expect(ui.name).toEqual('my-quota');
+  expect(ui.namespace).toEqual('default');
+  expect(ui.uid).toEqual('uid-123');
+});
+
+test('expect requestCount from status hard', async () => {
+  const rq = {
+    metadata: { name: 'q1' },
+    status: {
+      hard: { cpu: '4', memory: '8Gi' },
+      used: { cpu: '1', memory: '2Gi' },
+    },
+  } as V1ResourceQuota;
+  const ui = helper.getResourceQuotaUI(rq);
+  expect(ui.requestCount).toEqual(2);
+});
+
+test('expect zero requestCount when no spec or status', async () => {
+  const rq = {
+    metadata: { name: 'empty' },
+  } as V1ResourceQuota;
+  const ui = helper.getResourceQuotaUI(rq);
+  expect(ui.requestCount).toEqual(0);
+});

--- a/packages/webview/src/component/resource-quotas/resource-quota-helper.ts
+++ b/packages/webview/src/component/resource-quotas/resource-quota-helper.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1ResourceQuota } from '@kubernetes/client-node';
+
+import type { ResourceQuotaUI } from './ResourceQuotaUI';
+
+export class ResourceQuotaHelper {
+  getResourceQuotaUI(o: KubernetesObject): ResourceQuotaUI {
+    const obj = o as V1ResourceQuota;
+    const hard = obj.status?.hard ?? obj.spec?.hard ?? {};
+    const requestCount = Object.keys(hard).length;
+
+    return {
+      kind: 'ResourceQuota',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: obj.metadata?.namespace ?? '',
+      created: obj.metadata?.creationTimestamp,
+      selected: false,
+      requestCount,
+    };
+  }
+}

--- a/packages/webview/src/component/runtime-classes/RuntimeClassDetails.svelte
+++ b/packages/webview/src/component/runtime-classes/RuntimeClassDetails.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { RuntimeClassHelper } from './runtime-class-helper';
+import type { RuntimeClassUI } from './RuntimeClassUI';
+import type { V1RuntimeClass } from '@kubernetes/client-node';
+import RuntimeClassDetailsSummary from './RuntimeClassDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+}
+let { name }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const runtimeClassHelper = dependencyAccessor.get<RuntimeClassHelper>(RuntimeClassHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1RuntimeClass}
+  typedUI={{} as RuntimeClassUI}
+  kind="RuntimeClass"
+  resourceName="runtimeclasses"
+  listName="Runtime Classes"
+  name={name}
+  transformer={runtimeClassHelper.getRuntimeClassUI.bind(runtimeClassHelper)}
+  SummaryComponent={RuntimeClassDetailsSummary} />

--- a/packages/webview/src/component/runtime-classes/RuntimeClassDetailsSummary.svelte
+++ b/packages/webview/src/component/runtime-classes/RuntimeClassDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1RuntimeClass } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1RuntimeClass;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/runtime-classes/RuntimeClassUI.ts
+++ b/packages/webview/src/component/runtime-classes/RuntimeClassUI.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface RuntimeClassUI extends KubernetesObjectUI {
+  uid: string;
+  created?: Date;
+  handler: string;
+}

--- a/packages/webview/src/component/runtime-classes/RuntimeClassesList.svelte
+++ b/packages/webview/src/component/runtime-classes/RuntimeClassesList.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { RuntimeClassUI } from './RuntimeClassUI';
+import { RuntimeClassHelper } from './runtime-class-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const runtimeClassHelper = dependencyAccessor.get<RuntimeClassHelper>(RuntimeClassHelper);
+
+let statusColumn = new TableColumn<RuntimeClassUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<RuntimeClassUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let handlerColumn = new TableColumn<RuntimeClassUI, string>('Handler', {
+  renderMapping: (obj): string => obj.handler,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.handler.localeCompare(b.handler),
+});
+
+let ageColumn = new TableColumn<RuntimeClassUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [statusColumn, nameColumn, handlerColumn, ageColumn];
+
+const row = new TableRow<RuntimeClassUI>({});
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'runtimeclasses',
+      transformer: runtimeClassHelper.getRuntimeClassUI.bind(runtimeClassHelper),
+    },
+  ]}
+  singular="runtime class"
+  plural="runtime classes"
+  isNamespaced={false}
+  icon={icon['RuntimeClass']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['RuntimeClass']} resources={['runtimeclasses']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/runtime-classes/_runtime-classes-module.ts
+++ b/packages/webview/src/component/runtime-classes/_runtime-classes-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { RuntimeClassHelper } from './runtime-class-helper';
+
+const runtimeClassesModule = new ContainerModule(options => {
+  options.bind<RuntimeClassHelper>(RuntimeClassHelper).toSelf().inSingletonScope();
+});
+
+export { runtimeClassesModule };

--- a/packages/webview/src/component/runtime-classes/runtime-class-helper.spec.ts
+++ b/packages/webview/src/component/runtime-classes/runtime-class-helper.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { RuntimeClassHelper } from './runtime-class-helper';
+
+let helper: RuntimeClassHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new RuntimeClassHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const obj = {
+    metadata: {
+      name: 'my-runtime',
+      uid: 'uid-rc',
+    },
+    handler: 'runc',
+  } as KubernetesObject;
+  const ui = helper.getRuntimeClassUI(obj);
+  expect(ui.kind).toEqual('RuntimeClass');
+  expect(ui.name).toEqual('my-runtime');
+  expect(ui.uid).toEqual('uid-rc');
+});
+
+test('expect handler field', async () => {
+  const obj = {
+    metadata: { name: 'kata-runtime' },
+    handler: 'kata',
+  } as KubernetesObject;
+  const ui = helper.getRuntimeClassUI(obj);
+  expect(ui.handler).toEqual('kata');
+});
+
+test('expect empty handler when missing', async () => {
+  const obj = {
+    metadata: { name: 'no-handler' },
+  } as KubernetesObject;
+  const ui = helper.getRuntimeClassUI(obj);
+  expect(ui.handler).toEqual('');
+});

--- a/packages/webview/src/component/runtime-classes/runtime-class-helper.ts
+++ b/packages/webview/src/component/runtime-classes/runtime-class-helper.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1RuntimeClass } from '@kubernetes/client-node';
+
+import type { RuntimeClassUI } from './RuntimeClassUI';
+
+export class RuntimeClassHelper {
+  getRuntimeClassUI(obj: KubernetesObject): RuntimeClassUI {
+    const runtimeClass = obj as V1RuntimeClass;
+    return {
+      kind: 'RuntimeClass',
+      uid: runtimeClass.metadata?.uid ?? '',
+      name: runtimeClass.metadata?.name ?? '',
+      status: 'RUNNING',
+      created: runtimeClass.metadata?.creationTimestamp,
+      handler: runtimeClass.handler ?? '',
+    };
+  }
+}

--- a/packages/webview/src/component/validating-webhooks/ValidatingWebhookDetails.svelte
+++ b/packages/webview/src/component/validating-webhooks/ValidatingWebhookDetails.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { ValidatingWebhookHelper } from './validating-webhook-helper';
+import type { ValidatingWebhookUI } from './ValidatingWebhookUI';
+import type { V1ValidatingWebhookConfiguration } from '@kubernetes/client-node';
+import ValidatingWebhookDetailsSummary from './ValidatingWebhookDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+}
+let { name }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const validatingWebhookHelper = dependencyAccessor.get<ValidatingWebhookHelper>(ValidatingWebhookHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1ValidatingWebhookConfiguration}
+  typedUI={{} as ValidatingWebhookUI}
+  kind="ValidatingWebhookConfiguration"
+  resourceName="validatingwebhookconfigurations"
+  listName="Validating Webhook Configurations"
+  name={name}
+  transformer={validatingWebhookHelper.getValidatingWebhookUI.bind(validatingWebhookHelper)}
+  SummaryComponent={ValidatingWebhookDetailsSummary} />

--- a/packages/webview/src/component/validating-webhooks/ValidatingWebhookDetailsSummary.svelte
+++ b/packages/webview/src/component/validating-webhooks/ValidatingWebhookDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1ValidatingWebhookConfiguration } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1ValidatingWebhookConfiguration;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/validating-webhooks/ValidatingWebhookUI.ts
+++ b/packages/webview/src/component/validating-webhooks/ValidatingWebhookUI.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface ValidatingWebhookUI extends KubernetesObjectUI {
+  uid: string;
+  created?: Date;
+  webhooks: number;
+  failurePolicy: string;
+}

--- a/packages/webview/src/component/validating-webhooks/ValidatingWebhooksList.svelte
+++ b/packages/webview/src/component/validating-webhooks/ValidatingWebhooksList.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import ActionsColumn from './columns/Actions.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { ValidatingWebhookUI } from './ValidatingWebhookUI';
+import { ValidatingWebhookHelper } from './validating-webhook-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const validatingWebhookHelper = dependencyAccessor.get<ValidatingWebhookHelper>(ValidatingWebhookHelper);
+
+let statusColumn = new TableColumn<ValidatingWebhookUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<ValidatingWebhookUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let webhooksColumn = new TableColumn<ValidatingWebhookUI, string>('Webhooks', {
+  renderMapping: (obj): string => String(obj.webhooks),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.webhooks - b.webhooks,
+});
+
+let failurePolicyColumn = new TableColumn<ValidatingWebhookUI, string>('Failure Policy', {
+  renderMapping: (obj): string => obj.failurePolicy,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.failurePolicy.localeCompare(b.failurePolicy),
+});
+
+let ageColumn = new TableColumn<ValidatingWebhookUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  webhooksColumn,
+  failurePolicyColumn,
+  ageColumn,
+  new TableColumn<ValidatingWebhookUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<ValidatingWebhookUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'validatingwebhookconfigurations',
+      transformer: validatingWebhookHelper.getValidatingWebhookUI.bind(validatingWebhookHelper),
+    },
+  ]}
+  singular="validating webhook configuration"
+  plural="validating webhook configurations"
+  isNamespaced={false}
+  icon={icon['ValidatingWebhookConfiguration']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen
+      icon={icon['ValidatingWebhookConfiguration']}
+      resources={['validatingwebhookconfigurations']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/validating-webhooks/_validating-webhooks-module.ts
+++ b/packages/webview/src/component/validating-webhooks/_validating-webhooks-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { ValidatingWebhookHelper } from './validating-webhook-helper';
+
+const validatingWebhooksModule = new ContainerModule(options => {
+  options.bind<ValidatingWebhookHelper>(ValidatingWebhookHelper).toSelf().inSingletonScope();
+});
+
+export { validatingWebhooksModule };

--- a/packages/webview/src/component/validating-webhooks/columns/Actions.svelte
+++ b/packages/webview/src/component/validating-webhooks/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/validating-webhooks/columns/props.ts
+++ b/packages/webview/src/component/validating-webhooks/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ValidatingWebhookUI } from '/@/component/validating-webhooks/ValidatingWebhookUI';
+
+export interface Props {
+  object: ValidatingWebhookUI;
+}

--- a/packages/webview/src/component/validating-webhooks/validating-webhook-helper.spec.ts
+++ b/packages/webview/src/component/validating-webhooks/validating-webhook-helper.spec.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ValidatingWebhookConfiguration } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { ValidatingWebhookHelper } from './validating-webhook-helper';
+
+let helper: ValidatingWebhookHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new ValidatingWebhookHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const obj = {
+    metadata: {
+      name: 'my-validating-webhook',
+      uid: 'uid-vw',
+    },
+    webhooks: [],
+  } as V1ValidatingWebhookConfiguration;
+  const ui = helper.getValidatingWebhookUI(obj);
+  expect(ui.kind).toEqual('ValidatingWebhookConfiguration');
+  expect(ui.name).toEqual('my-validating-webhook');
+  expect(ui.uid).toEqual('uid-vw');
+});
+
+test('expect webhooks count', async () => {
+  const obj = {
+    metadata: { name: 'vw1' },
+    webhooks: [
+      { name: 'hook1', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+      { name: 'hook2', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+    ],
+  } as V1ValidatingWebhookConfiguration;
+  const ui = helper.getValidatingWebhookUI(obj);
+  expect(ui.webhooks).toEqual(2);
+});
+
+test('expect failurePolicy from webhooks', async () => {
+  const obj = {
+    metadata: { name: 'vw2' },
+    webhooks: [
+      { name: 'h1', failurePolicy: 'Fail', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+      { name: 'h2', failurePolicy: 'Ignore', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+    ],
+  } as V1ValidatingWebhookConfiguration;
+  const ui = helper.getValidatingWebhookUI(obj);
+  expect(ui.failurePolicy).toEqual('Fail, Ignore');
+});

--- a/packages/webview/src/component/validating-webhooks/validating-webhook-helper.ts
+++ b/packages/webview/src/component/validating-webhooks/validating-webhook-helper.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ValidatingWebhookConfiguration } from '@kubernetes/client-node';
+
+import type { ValidatingWebhookUI } from './ValidatingWebhookUI';
+
+export class ValidatingWebhookHelper {
+  getValidatingWebhookUI(obj: V1ValidatingWebhookConfiguration): ValidatingWebhookUI {
+    return {
+      kind: 'ValidatingWebhookConfiguration',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      created: obj.metadata?.creationTimestamp,
+      webhooks: obj.webhooks?.length ?? 0,
+      failurePolicy: [...new Set((obj.webhooks ?? []).map(w => w.failurePolicy ?? 'Fail'))].join(', '),
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -42,6 +42,15 @@ import { annotationsModule } from '/@/annotations/_annotations-module';
 import { daemonSetsModule } from '/@/component/daemonsets/_daemonsets-module';
 import { statefulSetsModule } from '/@/component/statefulsets/_statefulsets-module';
 import { replicaSetsModule } from '/@/component/replicasets/_replicasets-module';
+import { resourceQuotasModule } from '/@/component/resource-quotas/_resource-quotas-module';
+import { limitRangesModule } from '/@/component/limit-ranges/_limit-ranges-module';
+import { hpasModule } from '/@/component/hpas/_hpas-module';
+import { pdbsModule } from '/@/component/pdbs/_pdbs-module';
+import { priorityClassesModule } from '/@/component/priority-classes/_priority-classes-module';
+import { runtimeClassesModule } from '/@/component/runtime-classes/_runtime-classes-module';
+import { leasesModule } from '/@/component/leases/_leases-module';
+import { mutatingWebhooksModule } from '/@/component/mutating-webhooks/_mutating-webhooks-module';
+import { validatingWebhooksModule } from '/@/component/validating-webhooks/_validating-webhooks-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -78,6 +87,15 @@ export class InversifyBinding {
     await this.#container.load(daemonSetsModule);
     await this.#container.load(statefulSetsModule);
     await this.#container.load(replicaSetsModule);
+    await this.#container.load(resourceQuotasModule);
+    await this.#container.load(limitRangesModule);
+    await this.#container.load(hpasModule);
+    await this.#container.load(pdbsModule);
+    await this.#container.load(priorityClassesModule);
+    await this.#container.load(runtimeClassesModule);
+    await this.#container.load(leasesModule);
+    await this.#container.load(mutatingWebhooksModule);
+    await this.#container.load(validatingWebhooksModule);
 
     return this.#container;
   }

--- a/packages/webview/src/navigation/navigator.ts
+++ b/packages/webview/src/navigation/navigator.ts
@@ -77,6 +77,10 @@ export class Navigator {
       return 'ingressesRoutes';
     } else if (kind === 'ConfigMap' || kind === 'Secret') {
       return 'configmapsSecrets';
+    } else if (kind === 'PriorityClass') {
+      return 'priorityclasses';
+    } else if (kind === 'RuntimeClass') {
+      return 'runtimeclasses';
     }
     // otherwise do the simple conversion
     return kind.toLowerCase() + 's';


### PR DESCRIPTION
feat(config): add config section resources

### What does this PR do?

Adds resource views for HPAs, Leases, LimitRanges, MutatingWebhooks, PodDisruptionBudgets, PriorityClasses, ResourceQuotas, RuntimeClasses, and ValidatingWebhooks under the Config section.

### Screenshot / video of UI



https://github.com/user-attachments/assets/598726d9-d5e9-4491-ab9a-a272f1381064



### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Connect to a cluster with examples of each resource
2. Confirm you are able to view each new section / able to view the
   resource / etc.
   
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
