### PR TITLE
feat(access-control): add new access control section

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -76,6 +76,11 @@ import { EndpointSlicesResourceFactory } from '/@/resources/endpoint-slices-reso
 import { DaemonSetsResourceFactory } from '/@/resources/daemonsets-resource-factory.js';
 import { StatefulSetsResourceFactory } from '/@/resources/statefulsets-resource-factory.js';
 import { ReplicaSetsResourceFactory } from '/@/resources/replicasets-resource-factory.js';
+import { ServiceAccountsResourceFactory } from '/@/resources/service-accounts-resource-factory.js';
+import { ClusterRolesResourceFactory } from '/@/resources/cluster-roles-resource-factory.js';
+import { RolesResourceFactory } from '/@/resources/roles-resource-factory.js';
+import { ClusterRoleBindingsResourceFactory } from '/@/resources/cluster-role-bindings-resource-factory.js';
+import { RoleBindingsResourceFactory } from '/@/resources/role-bindings-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -187,6 +192,11 @@ export class ContextsManager implements ContextsApi {
       new DaemonSetsResourceFactory(),
       new StatefulSetsResourceFactory(),
       new ReplicaSetsResourceFactory(),
+      new ServiceAccountsResourceFactory(),
+      new ClusterRolesResourceFactory(),
+      new RolesResourceFactory(),
+      new ClusterRoleBindingsResourceFactory(),
+      new RoleBindingsResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/cluster-role-bindings-resource-factory.ts
+++ b/packages/extension/src/resources/cluster-role-bindings-resource-factory.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  KubernetesObject,
+  V1ClusterRoleBinding,
+  V1ClusterRoleBindingList,
+  V1Status,
+} from '@kubernetes/client-node';
+import { RbacAuthorizationV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class ClusterRoleBindingsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'clusterrolebindings',
+      kind: 'ClusterRoleBinding',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'rbac.authorization.k8s.io',
+          resource: 'clusterrolebindings',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteClusterRoleBinding);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1ClusterRoleBinding> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    const listFn = (): Promise<V1ClusterRoleBindingList> => apiClient.listClusterRoleBinding();
+    const path = `/apis/rbac.authorization.k8s.io/v1/clusterrolebindings`;
+    return new ResourceInformer<V1ClusterRoleBinding>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'clusterrolebindings',
+    });
+  }
+
+  deleteClusterRoleBinding(kubeconfig: KubeConfigSingleContext, name: string): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    return apiClient.deleteClusterRoleBinding({ name });
+  }
+}

--- a/packages/extension/src/resources/cluster-roles-resource-factory.ts
+++ b/packages/extension/src/resources/cluster-roles-resource-factory.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1ClusterRole, V1ClusterRoleList, V1Status } from '@kubernetes/client-node';
+import { RbacAuthorizationV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class ClusterRolesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'clusterroles',
+      kind: 'ClusterRole',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'rbac.authorization.k8s.io',
+          resource: 'clusterroles',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteClusterRole);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1ClusterRole> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    const listFn = (): Promise<V1ClusterRoleList> => apiClient.listClusterRole();
+    const path = `/apis/rbac.authorization.k8s.io/v1/clusterroles`;
+    return new ResourceInformer<V1ClusterRole>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'clusterroles',
+    });
+  }
+
+  deleteClusterRole(kubeconfig: KubeConfigSingleContext, name: string): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    return apiClient.deleteClusterRole({ name });
+  }
+}

--- a/packages/extension/src/resources/role-bindings-resource-factory.ts
+++ b/packages/extension/src/resources/role-bindings-resource-factory.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1RoleBinding, V1RoleBindingList, V1Status } from '@kubernetes/client-node';
+import { RbacAuthorizationV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class RoleBindingsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'rolebindings',
+      kind: 'RoleBinding',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'rbac.authorization.k8s.io',
+          resource: 'rolebindings',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteRoleBinding);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1RoleBinding> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    const listFn = (): Promise<V1RoleBindingList> => apiClient.listNamespacedRoleBinding({ namespace });
+    const path = `/apis/rbac.authorization.k8s.io/v1/namespaces/${namespace}/rolebindings`;
+    return new ResourceInformer<V1RoleBinding>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'rolebindings',
+    });
+  }
+
+  deleteRoleBinding(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    return apiClient.deleteNamespacedRoleBinding({ name, namespace });
+  }
+}

--- a/packages/extension/src/resources/roles-resource-factory.ts
+++ b/packages/extension/src/resources/roles-resource-factory.ts
@@ -1,0 +1,71 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1Role, V1RoleList, V1Status } from '@kubernetes/client-node';
+import { RbacAuthorizationV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class RolesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'roles',
+      kind: 'Role',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'rbac.authorization.k8s.io',
+          resource: 'roles',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteRole);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Role> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    const listFn = (): Promise<V1RoleList> => apiClient.listNamespacedRole({ namespace });
+    const path = `/apis/rbac.authorization.k8s.io/v1/namespaces/${namespace}/roles`;
+    return new ResourceInformer<V1Role>({ kubeconfig, path, listFn, kind: this.kind, plural: 'roles' });
+  }
+
+  deleteRole(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    return apiClient.deleteNamespacedRole({ name, namespace });
+  }
+}

--- a/packages/extension/src/resources/service-accounts-resource-factory.ts
+++ b/packages/extension/src/resources/service-accounts-resource-factory.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1ServiceAccount, V1ServiceAccountList, V1Status } from '@kubernetes/client-node';
+import { CoreV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class ServiceAccountsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'serviceaccounts',
+      kind: 'ServiceAccount',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'serviceaccounts',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteServiceAccount);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1ServiceAccount> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    const listFn = (): Promise<V1ServiceAccountList> => apiClient.listNamespacedServiceAccount({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/serviceaccounts`;
+    return new ResourceInformer<V1ServiceAccount>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'serviceaccounts',
+    });
+  }
+
+  deleteServiceAccount(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    return apiClient.deleteNamespacedServiceAccount({ name, namespace });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -32,6 +32,16 @@ import StatefulSetsList from '/@/component/statefulsets/StatefulSetsList.svelte'
 import StatefulSetDetails from '/@/component/statefulsets/StatefulSetDetails.svelte';
 import ReplicaSetsList from '/@/component/replicasets/ReplicaSetsList.svelte';
 import ReplicaSetDetails from '/@/component/replicasets/ReplicaSetDetails.svelte';
+import ServiceAccountsList from './component/service-accounts/ServiceAccountsList.svelte';
+import ServiceAccountDetails from './component/service-accounts/ServiceAccountDetails.svelte';
+import ClusterRolesList from './component/cluster-roles/ClusterRolesList.svelte';
+import ClusterRoleDetails from './component/cluster-roles/ClusterRoleDetails.svelte';
+import RolesList from './component/roles/RolesList.svelte';
+import RoleDetails from './component/roles/RoleDetails.svelte';
+import ClusterRoleBindingsList from './component/cluster-role-bindings/ClusterRoleBindingsList.svelte';
+import ClusterRoleBindingDetails from './component/cluster-role-bindings/ClusterRoleBindingDetails.svelte';
+import RoleBindingsList from './component/role-bindings/RoleBindingsList.svelte';
+import RoleBindingDetails from './component/role-bindings/RoleBindingDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -168,5 +178,45 @@ const { meta }: Props = $props();
 
   <Route path="/replicasets/:name/:namespace/*" let:meta>
     <ReplicaSetDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/serviceaccounts">
+    <ServiceAccountsList />
+  </Route>
+
+  <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
+    <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/clusterroles">
+    <ClusterRolesList />
+  </Route>
+
+  <Route path="/clusterroles/:name/*" let:meta>
+    <ClusterRoleDetails name={decodeURI(meta.params.name)} />
+  </Route>
+
+  <Route path="/roles">
+    <RolesList />
+  </Route>
+
+  <Route path="/roles/:name/:namespace/*" let:meta>
+    <RoleDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/clusterrolebindings">
+    <ClusterRoleBindingsList />
+  </Route>
+
+  <Route path="/clusterrolebindings/:name/*" let:meta>
+    <ClusterRoleBindingDetails name={decodeURI(meta.params.name)} />
+  </Route>
+
+  <Route path="/rolebindings">
+    <RoleBindingsList />
+  </Route>
+
+  <Route path="/rolebindings/:name/:namespace/*" let:meta>
+    <RoleBindingDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
   </Route>
 </div>

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -8,6 +8,7 @@ import {
   faLayerGroup,
   faNetworkWired,
   faServer,
+  faShieldHalved,
 } from '@fortawesome/free-solid-svg-icons';
 import { getContext, setContext } from 'svelte';
 import { Navigator } from '/@/navigation/navigator';
@@ -52,6 +53,14 @@ const networkUrls = [
 
 const storageUrls = [navigator.kubernetesResourcesURL('PersistentVolumeClaim')];
 
+const accessControlUrls = [
+  navigator.kubernetesResourcesURL('ServiceAccount'),
+  navigator.kubernetesResourcesURL('ClusterRole'),
+  navigator.kubernetesResourcesURL('Role'),
+  navigator.kubernetesResourcesURL('ClusterRoleBinding'),
+  navigator.kubernetesResourcesURL('RoleBinding'),
+];
+
 const STORAGE_KEY = 'nav-sections-expanded';
 
 function loadExpanded(): Record<string, boolean> {
@@ -78,12 +87,14 @@ let workloadsExpanded = $state(initExpanded('compute', workloadUrls));
 let configExpanded = $state(initExpanded('config', configUrls));
 let networkExpanded = $state(initExpanded('network', networkUrls));
 let storageExpanded = $state(initExpanded('storage', storageUrls));
+let accessControlExpanded = $state(initExpanded('accessControl', accessControlUrls));
 
 $effect(() => {
   if (isUnderSection(workloadUrls)) workloadsExpanded = true;
   if (isUnderSection(configUrls)) configExpanded = true;
   if (isUnderSection(networkUrls)) networkExpanded = true;
   if (isUnderSection(storageUrls)) storageExpanded = true;
+  if (isUnderSection(accessControlUrls)) accessControlExpanded = true;
 });
 
 $effect(() => {
@@ -97,6 +108,9 @@ $effect(() => {
 });
 $effect(() => {
   saveExpanded('storage', storageExpanded);
+});
+$effect(() => {
+  saveExpanded('accessControl', accessControlExpanded);
 });
 </script>
 
@@ -149,6 +163,24 @@ $effect(() => {
         title="Persistent Volume Claims"
         child={true}
         href={navigator.kubernetesResourcesURL('PersistentVolumeClaim')} />
+    {/if}
+
+    <!-- Access Control section -->
+    <NavItem
+      title="Access Control"
+      icon={faShieldHalved}
+      section={true}
+      bind:expanded={accessControlExpanded}
+      href="" />
+    {#if accessControlExpanded}
+      <NavItem title="Service Accounts" child={true} href={navigator.kubernetesResourcesURL('ServiceAccount')} />
+      <NavItem title="Cluster Roles" child={true} href={navigator.kubernetesResourcesURL('ClusterRole')} />
+      <NavItem title="Roles" child={true} href={navigator.kubernetesResourcesURL('Role')} />
+      <NavItem
+        title="Cluster Role Bindings"
+        child={true}
+        href={navigator.kubernetesResourcesURL('ClusterRoleBinding')} />
+      <NavItem title="Role Bindings" child={true} href={navigator.kubernetesResourcesURL('RoleBinding')} />
     {/if}
 
     <NavItem title="Namespaces" icon={faLayerGroup} href={navigator.kubernetesResourcesURL('Namespace')} />

--- a/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingDetails.svelte
+++ b/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingDetails.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { ClusterRoleBindingHelper } from './cluster-role-binding-helper';
+import type { ClusterRoleBindingUI } from './ClusterRoleBindingUI';
+import type { V1ClusterRoleBinding } from '@kubernetes/client-node';
+import ClusterRoleBindingDetailsSummary from './ClusterRoleBindingDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+}
+let { name }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const clusterRoleBindingHelper = dependencyAccessor.get<ClusterRoleBindingHelper>(ClusterRoleBindingHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1ClusterRoleBinding}
+  typedUI={{} as ClusterRoleBindingUI}
+  kind="ClusterRoleBinding"
+  resourceName="clusterrolebindings"
+  listName="Cluster Role Bindings"
+  name={name}
+  transformer={clusterRoleBindingHelper.getClusterRoleBindingUI.bind(clusterRoleBindingHelper)}
+  SummaryComponent={ClusterRoleBindingDetailsSummary} />

--- a/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingDetailsSummary.svelte
+++ b/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1ClusterRoleBinding } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1ClusterRoleBinding;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingUI.ts
+++ b/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingUI.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface ClusterRoleBindingUI extends KubernetesObjectUI {
+  uid: string;
+  created?: Date;
+  bindings: string;
+  role: string;
+}

--- a/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingsList.svelte
+++ b/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingsList.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { ClusterRoleBindingUI } from './ClusterRoleBindingUI';
+import { ClusterRoleBindingHelper } from './cluster-role-binding-helper';
+import ActionsColumn from './columns/Actions.svelte';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const clusterRoleBindingHelper = dependencyAccessor.get<ClusterRoleBindingHelper>(ClusterRoleBindingHelper);
+
+let statusColumn = new TableColumn<ClusterRoleBindingUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<ClusterRoleBindingUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let bindingsColumn = new TableColumn<ClusterRoleBindingUI, string>('Bindings', {
+  width: '2fr',
+  renderMapping: (obj): string => obj.bindings,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.bindings.localeCompare(b.bindings),
+});
+
+let roleColumn = new TableColumn<ClusterRoleBindingUI, string>('Role', {
+  renderMapping: (obj): string => obj.role,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.role.localeCompare(b.role),
+});
+
+let ageColumn = new TableColumn<ClusterRoleBindingUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  bindingsColumn,
+  roleColumn,
+  ageColumn,
+  new TableColumn<ClusterRoleBindingUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<ClusterRoleBindingUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'clusterrolebindings',
+      transformer: clusterRoleBindingHelper.getClusterRoleBindingUI.bind(clusterRoleBindingHelper),
+    },
+  ]}
+  singular="cluster role binding"
+  plural="cluster role bindings"
+  isNamespaced={false}
+  icon={icon['ClusterRoleBinding']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['ClusterRoleBinding']} resources={['clusterrolebindings']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/cluster-role-bindings/_cluster-role-bindings-module.ts
+++ b/packages/webview/src/component/cluster-role-bindings/_cluster-role-bindings-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { ClusterRoleBindingHelper } from './cluster-role-binding-helper';
+
+const clusterRoleBindingsModule = new ContainerModule(options => {
+  options.bind<ClusterRoleBindingHelper>(ClusterRoleBindingHelper).toSelf().inSingletonScope();
+});
+
+export { clusterRoleBindingsModule };

--- a/packages/webview/src/component/cluster-role-bindings/cluster-role-binding-helper.spec.ts
+++ b/packages/webview/src/component/cluster-role-bindings/cluster-role-binding-helper.spec.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ClusterRoleBinding } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { ClusterRoleBindingHelper } from './cluster-role-binding-helper';
+
+let helper: ClusterRoleBindingHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new ClusterRoleBindingHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const crb: V1ClusterRoleBinding = {
+    metadata: {
+      uid: 'crb-uid-1',
+      name: 'admin-binding',
+      creationTimestamp: new Date('2026-05-01T14:00:00Z'),
+    },
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'ClusterRole',
+      name: 'cluster-admin',
+    },
+    subjects: [{ kind: 'User', name: 'alice', apiGroup: 'rbac.authorization.k8s.io' }],
+  };
+
+  const result = helper.getClusterRoleBindingUI(crb);
+
+  expect(result.kind).toBe('ClusterRoleBinding');
+  expect(result.uid).toBe('crb-uid-1');
+  expect(result.name).toBe('admin-binding');
+  expect(result.status).toBe('RUNNING');
+  expect(result.created).toEqual(new Date('2026-05-01T14:00:00Z'));
+});
+
+test('expect bindings joined from subjects names', async () => {
+  const crb: V1ClusterRoleBinding = {
+    metadata: { uid: 'crb-uid-2', name: 'multi-binding' },
+    roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'ClusterRole', name: 'view' },
+    subjects: [
+      { kind: 'User', name: 'alice', apiGroup: 'rbac.authorization.k8s.io' },
+      { kind: 'User', name: 'bob', apiGroup: 'rbac.authorization.k8s.io' },
+      { kind: 'ServiceAccount', name: 'deployer', apiGroup: '' },
+    ],
+  };
+
+  const result = helper.getClusterRoleBindingUI(crb);
+
+  expect(result.bindings).toBe('alice, bob, deployer');
+});
+
+test('expect role from roleRef name', async () => {
+  const crb: V1ClusterRoleBinding = {
+    metadata: { uid: 'crb-uid-3', name: 'editor-binding' },
+    roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'ClusterRole', name: 'edit' },
+  };
+
+  const result = helper.getClusterRoleBindingUI(crb);
+
+  expect(result.role).toBe('edit');
+  expect(result.bindings).toBe('');
+});

--- a/packages/webview/src/component/cluster-role-bindings/cluster-role-binding-helper.ts
+++ b/packages/webview/src/component/cluster-role-bindings/cluster-role-binding-helper.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1ClusterRoleBinding } from '@kubernetes/client-node';
+
+import type { ClusterRoleBindingUI } from './ClusterRoleBindingUI';
+
+export class ClusterRoleBindingHelper {
+  getClusterRoleBindingUI(o: KubernetesObject): ClusterRoleBindingUI {
+    const obj = o as V1ClusterRoleBinding;
+    return {
+      kind: 'ClusterRoleBinding',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      created: obj.metadata?.creationTimestamp,
+      bindings: (obj.subjects ?? []).map(s => s.name).join(', '),
+      role: obj.roleRef?.name ?? '',
+    };
+  }
+}

--- a/packages/webview/src/component/cluster-role-bindings/columns/Actions.svelte
+++ b/packages/webview/src/component/cluster-role-bindings/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/cluster-role-bindings/columns/props.ts
+++ b/packages/webview/src/component/cluster-role-bindings/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ClusterRoleBindingUI } from '/@/component/cluster-role-bindings/ClusterRoleBindingUI';
+
+export interface Props {
+  object: ClusterRoleBindingUI;
+}

--- a/packages/webview/src/component/cluster-roles/ClusterRoleDetails.svelte
+++ b/packages/webview/src/component/cluster-roles/ClusterRoleDetails.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { ClusterRoleHelper } from './cluster-role-helper';
+import type { ClusterRoleUI } from './ClusterRoleUI';
+import type { V1ClusterRole } from '@kubernetes/client-node';
+import ClusterRoleDetailsSummary from './ClusterRoleDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+}
+let { name }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const clusterRoleHelper = dependencyAccessor.get<ClusterRoleHelper>(ClusterRoleHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1ClusterRole}
+  typedUI={{} as ClusterRoleUI}
+  kind="ClusterRole"
+  resourceName="clusterroles"
+  listName="Cluster Roles"
+  name={name}
+  transformer={clusterRoleHelper.getClusterRoleUI.bind(clusterRoleHelper)}
+  SummaryComponent={ClusterRoleDetailsSummary} />

--- a/packages/webview/src/component/cluster-roles/ClusterRoleDetailsSummary.svelte
+++ b/packages/webview/src/component/cluster-roles/ClusterRoleDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1ClusterRole } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1ClusterRole;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/cluster-roles/ClusterRoleUI.ts
+++ b/packages/webview/src/component/cluster-roles/ClusterRoleUI.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface ClusterRoleUI extends KubernetesObjectUI {
+  uid: string;
+  created?: Date;
+  rules: number;
+}

--- a/packages/webview/src/component/cluster-roles/ClusterRolesList.svelte
+++ b/packages/webview/src/component/cluster-roles/ClusterRolesList.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { ClusterRoleUI } from './ClusterRoleUI';
+import { ClusterRoleHelper } from './cluster-role-helper';
+import ActionsColumn from './columns/Actions.svelte';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const clusterRoleHelper = dependencyAccessor.get<ClusterRoleHelper>(ClusterRoleHelper);
+
+let statusColumn = new TableColumn<ClusterRoleUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<ClusterRoleUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let rulesColumn = new TableColumn<ClusterRoleUI, string>('Rules', {
+  renderMapping: (obj): string => String(obj.rules),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.rules - b.rules,
+});
+
+let ageColumn = new TableColumn<ClusterRoleUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  rulesColumn,
+  ageColumn,
+  new TableColumn<ClusterRoleUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<ClusterRoleUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'clusterroles',
+      transformer: clusterRoleHelper.getClusterRoleUI.bind(clusterRoleHelper),
+    },
+  ]}
+  singular="cluster role"
+  plural="cluster roles"
+  isNamespaced={false}
+  icon={icon['ClusterRole']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['ClusterRole']} resources={['clusterroles']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/cluster-roles/_cluster-roles-module.ts
+++ b/packages/webview/src/component/cluster-roles/_cluster-roles-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { ClusterRoleHelper } from './cluster-role-helper';
+
+const clusterRolesModule = new ContainerModule(options => {
+  options.bind<ClusterRoleHelper>(ClusterRoleHelper).toSelf().inSingletonScope();
+});
+
+export { clusterRolesModule };

--- a/packages/webview/src/component/cluster-roles/cluster-role-helper.spec.ts
+++ b/packages/webview/src/component/cluster-roles/cluster-role-helper.spec.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ClusterRole } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { ClusterRoleHelper } from './cluster-role-helper';
+
+let helper: ClusterRoleHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new ClusterRoleHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const cr: V1ClusterRole = {
+    metadata: {
+      uid: 'cr-uid-1',
+      name: 'cluster-admin',
+      creationTimestamp: new Date('2026-02-20T12:00:00Z'),
+    },
+    rules: [
+      { apiGroups: ['*'], resources: ['*'], verbs: ['*'] },
+      { apiGroups: [''], resources: ['pods'], verbs: ['get', 'list'] },
+    ],
+  };
+
+  const result = helper.getClusterRoleUI(cr);
+
+  expect(result.kind).toBe('ClusterRole');
+  expect(result.uid).toBe('cr-uid-1');
+  expect(result.name).toBe('cluster-admin');
+  expect(result.status).toBe('RUNNING');
+  expect(result.created).toEqual(new Date('2026-02-20T12:00:00Z'));
+});
+
+test('expect rules count from rules array length', async () => {
+  const cr: V1ClusterRole = {
+    metadata: { uid: 'cr-uid-2', name: 'role-with-rules' },
+    rules: [
+      { apiGroups: [''], resources: ['pods'], verbs: ['get'] },
+      { apiGroups: [''], resources: ['services'], verbs: ['list'] },
+      { apiGroups: ['apps'], resources: ['deployments'], verbs: ['create'] },
+    ],
+  };
+
+  const result = helper.getClusterRoleUI(cr);
+
+  expect(result.rules).toBe(3);
+});
+
+test('expect rules count zero when no rules', async () => {
+  const cr: V1ClusterRole = {
+    metadata: { uid: 'cr-uid-3', name: 'role-no-rules' },
+  };
+
+  const result = helper.getClusterRoleUI(cr);
+
+  expect(result.rules).toBe(0);
+});

--- a/packages/webview/src/component/cluster-roles/cluster-role-helper.ts
+++ b/packages/webview/src/component/cluster-roles/cluster-role-helper.ts
@@ -1,0 +1,34 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ClusterRole } from '@kubernetes/client-node';
+
+import type { ClusterRoleUI } from './ClusterRoleUI';
+
+export class ClusterRoleHelper {
+  getClusterRoleUI(obj: V1ClusterRole): ClusterRoleUI {
+    return {
+      kind: 'ClusterRole',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      created: obj.metadata?.creationTimestamp,
+      rules: obj.rules?.length ?? 0,
+    };
+  }
+}

--- a/packages/webview/src/component/cluster-roles/columns/Actions.svelte
+++ b/packages/webview/src/component/cluster-roles/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/cluster-roles/columns/props.ts
+++ b/packages/webview/src/component/cluster-roles/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ClusterRoleUI } from '/@/component/cluster-roles/ClusterRoleUI';
+
+export interface Props {
+  object: ClusterRoleUI;
+}

--- a/packages/webview/src/component/role-bindings/RoleBindingDetails.svelte
+++ b/packages/webview/src/component/role-bindings/RoleBindingDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { RoleBindingHelper } from './role-binding-helper';
+import type { RoleBindingUI } from './RoleBindingUI';
+import type { V1RoleBinding } from '@kubernetes/client-node';
+import RoleBindingDetailsSummary from './RoleBindingDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const roleBindingHelper = dependencyAccessor.get<RoleBindingHelper>(RoleBindingHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1RoleBinding}
+  typedUI={{} as RoleBindingUI}
+  kind="RoleBinding"
+  resourceName="rolebindings"
+  listName="Role Bindings"
+  name={name}
+  namespace={namespace}
+  transformer={roleBindingHelper.getRoleBindingUI.bind(roleBindingHelper)}
+  SummaryComponent={RoleBindingDetailsSummary} />

--- a/packages/webview/src/component/role-bindings/RoleBindingDetailsSummary.svelte
+++ b/packages/webview/src/component/role-bindings/RoleBindingDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1RoleBinding } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1RoleBinding;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/role-bindings/RoleBindingUI.ts
+++ b/packages/webview/src/component/role-bindings/RoleBindingUI.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface RoleBindingUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  bindings: string;
+  role: string;
+}

--- a/packages/webview/src/component/role-bindings/RoleBindingsList.svelte
+++ b/packages/webview/src/component/role-bindings/RoleBindingsList.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { RoleBindingUI } from './RoleBindingUI';
+import { RoleBindingHelper } from './role-binding-helper';
+import ActionsColumn from './columns/Actions.svelte';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const roleBindingHelper = dependencyAccessor.get<RoleBindingHelper>(RoleBindingHelper);
+
+let statusColumn = new TableColumn<RoleBindingUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<RoleBindingUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let bindingsColumn = new TableColumn<RoleBindingUI, string>('Bindings', {
+  width: '2fr',
+  renderMapping: (obj): string => obj.bindings,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.bindings.localeCompare(b.bindings),
+});
+
+let roleColumn = new TableColumn<RoleBindingUI, string>('Role', {
+  renderMapping: (obj): string => obj.role,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.role.localeCompare(b.role),
+});
+
+let ageColumn = new TableColumn<RoleBindingUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  bindingsColumn,
+  roleColumn,
+  ageColumn,
+  new TableColumn<RoleBindingUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<RoleBindingUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'rolebindings',
+      transformer: roleBindingHelper.getRoleBindingUI,
+    },
+  ]}
+  singular="role binding"
+  plural="role bindings"
+  isNamespaced={true}
+  icon={icon['RoleBinding']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['RoleBinding']} resources={['rolebindings']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/role-bindings/_role-bindings-module.ts
+++ b/packages/webview/src/component/role-bindings/_role-bindings-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { RoleBindingHelper } from './role-binding-helper';
+
+const roleBindingsModule = new ContainerModule(options => {
+  options.bind<RoleBindingHelper>(RoleBindingHelper).toSelf().inSingletonScope();
+});
+
+export { roleBindingsModule };

--- a/packages/webview/src/component/role-bindings/columns/Actions.svelte
+++ b/packages/webview/src/component/role-bindings/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/role-bindings/columns/props.ts
+++ b/packages/webview/src/component/role-bindings/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { RoleBindingUI } from '/@/component/role-bindings/RoleBindingUI';
+
+export interface Props {
+  object: RoleBindingUI;
+}

--- a/packages/webview/src/component/role-bindings/role-binding-helper.spec.ts
+++ b/packages/webview/src/component/role-bindings/role-binding-helper.spec.ts
@@ -1,0 +1,83 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1RoleBinding } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { RoleBindingHelper } from './role-binding-helper';
+
+let helper: RoleBindingHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new RoleBindingHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const rb: V1RoleBinding = {
+    metadata: {
+      uid: 'rb-uid-1',
+      name: 'dev-binding',
+      namespace: 'development',
+      creationTimestamp: new Date('2026-06-15T09:00:00Z'),
+    },
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'Role',
+      name: 'pod-reader',
+    },
+    subjects: [{ kind: 'User', name: 'dev-user', apiGroup: 'rbac.authorization.k8s.io' }],
+  };
+
+  const result = helper.getRoleBindingUI(rb);
+
+  expect(result.kind).toBe('RoleBinding');
+  expect(result.uid).toBe('rb-uid-1');
+  expect(result.name).toBe('dev-binding');
+  expect(result.namespace).toBe('development');
+  expect(result.status).toBe('RUNNING');
+  expect(result.selected).toBe(false);
+  expect(result.created).toEqual(new Date('2026-06-15T09:00:00Z'));
+});
+
+test('expect bindings joined from subjects names', async () => {
+  const rb: V1RoleBinding = {
+    metadata: { uid: 'rb-uid-2', name: 'team-binding', namespace: 'prod' },
+    roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'Role', name: 'editor' },
+    subjects: [
+      { kind: 'User', name: 'carol', apiGroup: 'rbac.authorization.k8s.io' },
+      { kind: 'Group', name: 'developers', apiGroup: 'rbac.authorization.k8s.io' },
+    ],
+  };
+
+  const result = helper.getRoleBindingUI(rb);
+
+  expect(result.bindings).toBe('carol, developers');
+});
+
+test('expect role from roleRef name', async () => {
+  const rb: V1RoleBinding = {
+    metadata: { uid: 'rb-uid-3', name: 'viewer-binding', namespace: 'default' },
+    roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'Role', name: 'view' },
+  };
+
+  const result = helper.getRoleBindingUI(rb);
+
+  expect(result.role).toBe('view');
+  expect(result.bindings).toBe('');
+});

--- a/packages/webview/src/component/role-bindings/role-binding-helper.ts
+++ b/packages/webview/src/component/role-bindings/role-binding-helper.ts
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1RoleBinding } from '@kubernetes/client-node';
+
+import type { RoleBindingUI } from './RoleBindingUI';
+
+export class RoleBindingHelper {
+  getRoleBindingUI(o: KubernetesObject): RoleBindingUI {
+    const obj = o as V1RoleBinding;
+    return {
+      kind: 'RoleBinding',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: obj.metadata?.namespace ?? '',
+      created: obj.metadata?.creationTimestamp,
+      selected: false,
+      bindings: (obj.subjects ?? []).map(s => s.name).join(', '),
+      role: obj.roleRef?.name ?? '',
+    };
+  }
+}

--- a/packages/webview/src/component/roles/RoleDetails.svelte
+++ b/packages/webview/src/component/roles/RoleDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { RoleHelper } from './role-helper';
+import type { RoleUI } from './RoleUI';
+import type { V1Role } from '@kubernetes/client-node';
+import RoleDetailsSummary from './RoleDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const roleHelper = dependencyAccessor.get<RoleHelper>(RoleHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1Role}
+  typedUI={{} as RoleUI}
+  kind="Role"
+  resourceName="roles"
+  listName="Roles"
+  name={name}
+  namespace={namespace}
+  transformer={roleHelper.getRoleUI.bind(roleHelper)}
+  SummaryComponent={RoleDetailsSummary} />

--- a/packages/webview/src/component/roles/RoleDetailsSummary.svelte
+++ b/packages/webview/src/component/roles/RoleDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1Role } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1Role;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/roles/RoleUI.ts
+++ b/packages/webview/src/component/roles/RoleUI.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface RoleUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  rules: number;
+}

--- a/packages/webview/src/component/roles/RolesList.svelte
+++ b/packages/webview/src/component/roles/RolesList.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { RoleUI } from './RoleUI';
+import { RoleHelper } from './role-helper';
+import ActionsColumn from './columns/Actions.svelte';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const roleHelper = dependencyAccessor.get<RoleHelper>(RoleHelper);
+
+let statusColumn = new TableColumn<RoleUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<RoleUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let rulesColumn = new TableColumn<RoleUI, string>('Rules', {
+  renderMapping: (obj): string => String(obj.rules),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.rules - b.rules,
+});
+
+let ageColumn = new TableColumn<RoleUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  rulesColumn,
+  ageColumn,
+  new TableColumn<RoleUI>('Actions', { align: 'right', width: '150px', renderer: ActionsColumn, overflow: true }),
+];
+
+const row = new TableRow<RoleUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'roles',
+      transformer: roleHelper.getRoleUI,
+    },
+  ]}
+  singular="role"
+  plural="roles"
+  isNamespaced={true}
+  icon={icon['Role']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['Role']} resources={['roles']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/roles/_roles-module.ts
+++ b/packages/webview/src/component/roles/_roles-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { RoleHelper } from './role-helper';
+
+const rolesModule = new ContainerModule(options => {
+  options.bind<RoleHelper>(RoleHelper).toSelf().inSingletonScope();
+});
+
+export { rolesModule };

--- a/packages/webview/src/component/roles/columns/Actions.svelte
+++ b/packages/webview/src/component/roles/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/roles/columns/props.ts
+++ b/packages/webview/src/component/roles/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { RoleUI } from '/@/component/roles/RoleUI';
+
+export interface Props {
+  object: RoleUI;
+}

--- a/packages/webview/src/component/roles/role-helper.spec.ts
+++ b/packages/webview/src/component/roles/role-helper.spec.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Role } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { RoleHelper } from './role-helper';
+
+let helper: RoleHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new RoleHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const role: V1Role = {
+    metadata: {
+      uid: 'role-uid-1',
+      name: 'pod-reader',
+      namespace: 'default',
+      creationTimestamp: new Date('2026-04-10T08:30:00Z'),
+    },
+    rules: [{ apiGroups: [''], resources: ['pods'], verbs: ['get', 'watch', 'list'] }],
+  };
+
+  const result = helper.getRoleUI(role);
+
+  expect(result.kind).toBe('Role');
+  expect(result.uid).toBe('role-uid-1');
+  expect(result.name).toBe('pod-reader');
+  expect(result.namespace).toBe('default');
+  expect(result.status).toBe('RUNNING');
+  expect(result.selected).toBe(false);
+  expect(result.created).toEqual(new Date('2026-04-10T08:30:00Z'));
+});
+
+test('expect rules count from rules array length', async () => {
+  const role: V1Role = {
+    metadata: { uid: 'role-uid-2', name: 'multi-rule-role', namespace: 'staging' },
+    rules: [
+      { apiGroups: [''], resources: ['pods'], verbs: ['get'] },
+      { apiGroups: [''], resources: ['configmaps'], verbs: ['get', 'list'] },
+    ],
+  };
+
+  const result = helper.getRoleUI(role);
+
+  expect(result.rules).toBe(2);
+});
+
+test('expect rules count zero when no rules', async () => {
+  const role: V1Role = {
+    metadata: { uid: 'role-uid-3', name: 'empty-role', namespace: 'default' },
+  };
+
+  const result = helper.getRoleUI(role);
+
+  expect(result.rules).toBe(0);
+});

--- a/packages/webview/src/component/roles/role-helper.ts
+++ b/packages/webview/src/component/roles/role-helper.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Role } from '@kubernetes/client-node';
+
+import type { RoleUI } from './RoleUI';
+
+export class RoleHelper {
+  getRoleUI(obj: V1Role): RoleUI {
+    return {
+      kind: 'Role',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: obj.metadata?.namespace ?? '',
+      created: obj.metadata?.creationTimestamp,
+      selected: false,
+      rules: obj.rules?.length ?? 0,
+    };
+  }
+}

--- a/packages/webview/src/component/service-accounts/ServiceAccountDetails.svelte
+++ b/packages/webview/src/component/service-accounts/ServiceAccountDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { ServiceAccountHelper } from './service-account-helper';
+import type { ServiceAccountUI } from './ServiceAccountUI';
+import type { V1ServiceAccount } from '@kubernetes/client-node';
+import ServiceAccountDetailsSummary from './ServiceAccountDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const serviceAccountHelper = dependencyAccessor.get<ServiceAccountHelper>(ServiceAccountHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1ServiceAccount}
+  typedUI={{} as ServiceAccountUI}
+  kind="ServiceAccount"
+  resourceName="serviceaccounts"
+  listName="Service Accounts"
+  name={name}
+  namespace={namespace}
+  transformer={serviceAccountHelper.getServiceAccountUI.bind(serviceAccountHelper)}
+  SummaryComponent={ServiceAccountDetailsSummary} />

--- a/packages/webview/src/component/service-accounts/ServiceAccountDetailsSummary.svelte
+++ b/packages/webview/src/component/service-accounts/ServiceAccountDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1ServiceAccount } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1ServiceAccount;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/service-accounts/ServiceAccountUI.ts
+++ b/packages/webview/src/component/service-accounts/ServiceAccountUI.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface ServiceAccountUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  secrets: number;
+}

--- a/packages/webview/src/component/service-accounts/ServiceAccountsList.svelte
+++ b/packages/webview/src/component/service-accounts/ServiceAccountsList.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { ServiceAccountUI } from './ServiceAccountUI';
+import { ServiceAccountHelper } from './service-account-helper';
+import ActionsColumn from './columns/Actions.svelte';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const serviceAccountHelper = dependencyAccessor.get<ServiceAccountHelper>(ServiceAccountHelper);
+
+let statusColumn = new TableColumn<ServiceAccountUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<ServiceAccountUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let secretsColumn = new TableColumn<ServiceAccountUI, string>('Secrets', {
+  renderMapping: (obj): string => String(obj.secrets),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.secrets - b.secrets,
+});
+
+let ageColumn = new TableColumn<ServiceAccountUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  secretsColumn,
+  ageColumn,
+  new TableColumn<ServiceAccountUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<ServiceAccountUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'serviceaccounts',
+      transformer: serviceAccountHelper.getServiceAccountUI,
+    },
+  ]}
+  singular="service account"
+  plural="service accounts"
+  isNamespaced={true}
+  icon={icon['ServiceAccount']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['ServiceAccount']} resources={['serviceaccounts']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/service-accounts/_service-accounts-module.ts
+++ b/packages/webview/src/component/service-accounts/_service-accounts-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { ServiceAccountHelper } from './service-account-helper';
+
+const serviceAccountsModule = new ContainerModule(options => {
+  options.bind<ServiceAccountHelper>(ServiceAccountHelper).toSelf().inSingletonScope();
+});
+
+export { serviceAccountsModule };

--- a/packages/webview/src/component/service-accounts/columns/Actions.svelte
+++ b/packages/webview/src/component/service-accounts/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/service-accounts/columns/props.ts
+++ b/packages/webview/src/component/service-accounts/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ServiceAccountUI } from '/@/component/service-accounts/ServiceAccountUI';
+
+export interface Props {
+  object: ServiceAccountUI;
+}

--- a/packages/webview/src/component/service-accounts/service-account-helper.spec.ts
+++ b/packages/webview/src/component/service-accounts/service-account-helper.spec.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ServiceAccount } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { ServiceAccountHelper } from './service-account-helper';
+
+let helper: ServiceAccountHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new ServiceAccountHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const sa: V1ServiceAccount = {
+    metadata: {
+      uid: 'sa-uid-1',
+      name: 'my-service-account',
+      namespace: 'kube-system',
+      creationTimestamp: new Date('2026-03-15T10:00:00Z'),
+    },
+    secrets: [{ name: 'secret-1' }, { name: 'secret-2' }],
+  };
+
+  const result = helper.getServiceAccountUI(sa);
+
+  expect(result.kind).toBe('ServiceAccount');
+  expect(result.uid).toBe('sa-uid-1');
+  expect(result.name).toBe('my-service-account');
+  expect(result.namespace).toBe('kube-system');
+  expect(result.status).toBe('RUNNING');
+  expect(result.selected).toBe(false);
+  expect(result.created).toEqual(new Date('2026-03-15T10:00:00Z'));
+});
+
+test('expect secrets count from secrets array length', async () => {
+  const sa: V1ServiceAccount = {
+    metadata: { uid: 'sa-uid-2', name: 'sa-with-secrets' },
+    secrets: [{ name: 'secret-a' }, { name: 'secret-b' }, { name: 'secret-c' }],
+  };
+
+  const result = helper.getServiceAccountUI(sa);
+
+  expect(result.secrets).toBe(3);
+});
+
+test('expect secrets count zero when no secrets', async () => {
+  const sa: V1ServiceAccount = {
+    metadata: { uid: 'sa-uid-3', name: 'sa-no-secrets' },
+  };
+
+  const result = helper.getServiceAccountUI(sa);
+
+  expect(result.secrets).toBe(0);
+});

--- a/packages/webview/src/component/service-accounts/service-account-helper.ts
+++ b/packages/webview/src/component/service-accounts/service-account-helper.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ServiceAccount } from '@kubernetes/client-node';
+
+import type { ServiceAccountUI } from './ServiceAccountUI';
+
+export class ServiceAccountHelper {
+  getServiceAccountUI(obj: V1ServiceAccount): ServiceAccountUI {
+    return {
+      kind: 'ServiceAccount',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: obj.metadata?.namespace ?? '',
+      created: obj.metadata?.creationTimestamp,
+      selected: false,
+      secrets: obj.secrets?.length ?? 0,
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -42,6 +42,11 @@ import { annotationsModule } from '/@/annotations/_annotations-module';
 import { daemonSetsModule } from '/@/component/daemonsets/_daemonsets-module';
 import { statefulSetsModule } from '/@/component/statefulsets/_statefulsets-module';
 import { replicaSetsModule } from '/@/component/replicasets/_replicasets-module';
+import { serviceAccountsModule } from '/@/component/service-accounts/_service-accounts-module';
+import { clusterRolesModule } from '/@/component/cluster-roles/_cluster-roles-module';
+import { rolesModule } from '/@/component/roles/_roles-module';
+import { clusterRoleBindingsModule } from '/@/component/cluster-role-bindings/_cluster-role-bindings-module';
+import { roleBindingsModule } from '/@/component/role-bindings/_role-bindings-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -78,6 +83,11 @@ export class InversifyBinding {
     await this.#container.load(daemonSetsModule);
     await this.#container.load(statefulSetsModule);
     await this.#container.load(replicaSetsModule);
+    await this.#container.load(serviceAccountsModule);
+    await this.#container.load(clusterRolesModule);
+    await this.#container.load(rolesModule);
+    await this.#container.load(clusterRoleBindingsModule);
+    await this.#container.load(roleBindingsModule);
 
     return this.#container;
   }


### PR DESCRIPTION
feat(access-control): add new access control section

### What does this PR do?

We've been missing an access control section for a while.

This section will add the ability to view your service accounts, cluster
roles, etc.

This adds:

- Service Accounts
- Cluster Roles
- Roles
- Cluster Role Bindings
- Role Bindings

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/user-attachments/assets/0180522a-3ac0-41f2-bad4-3bf412c22c57



### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/983

### How to test this PR?

1. Click on access control section
2. Go through each part and validate it lists your information / you can
   press and go to summary / page, etc.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
