### PR TITLE
test(e2e): always run, no need for area/ci/e2e label

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -17,14 +17,11 @@
 
 name: e2e-tests
 
-on:
-  pull_request:
-    types: [labeled, synchronize, opened, ready_for_review, reopened]
+on: [pull_request]
 
 jobs:
   # Dedicated step to build the extension image
   build-container:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'area/ci/e2e') }}
     name: Build Extension Image
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
### What does this PR do?

Run e2e tests for each PR, without the need for area/ci/e2e label

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #1045 

### How to test this PR?

<!-- Please explain steps to reproduce -->
