### PR TITLE
fix(lint): fix sonarjs 4.1.0 lint errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -267,4 +267,13 @@ export default [
       'sonarjs/no-hardcoded-ip': 'off',
     },
   },
+
+  {
+    files: ['tests/playwright/**'],
+
+    rules: {
+      'sonarjs/assertions-in-tests': 'off',
+      'sonarjs/no-skipped-tests': 'off',
+    },
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-redundant-undefined": "^1.0.0",
     "eslint-plugin-simple-import-sort": "^13.0.0",
-    "eslint-plugin-sonarjs": "^4.0.3",
+    "eslint-plugin-sonarjs": "^4.1.0",
     "eslint-plugin-svelte": "^3.20.0",
     "eslint-plugin-unicorn": "^69.0.0",
     "node-gyp": "^13.0.0",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-redundant-undefined": "^1.0.0",
-    "eslint-plugin-sonarjs": "^4.0.3",
+    "eslint-plugin-sonarjs": "^4.1.0",
     "memfs": "^4.57.8",
     "prettier": "^3.9.4",
     "typescript": "5.9.3",

--- a/packages/extension/src/manager/contexts-manager.spec.ts
+++ b/packages/extension/src/manager/contexts-manager.spec.ts
@@ -922,7 +922,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
       await manager.update(kc);
 
       const result = manager.getResourceDetails('context1', 'resource1', 'obj1', 'ns1');
-      expect(result).toEqual(undefined);
+      expect(result).toBeUndefined();
     });
 
     test('getResourceEvents', async () => {

--- a/packages/webview/src/component/ingresses-routes/ingress-route-helper.spec.ts
+++ b/packages/webview/src/component/ingresses-routes/ingress-route-helper.spec.ts
@@ -239,14 +239,14 @@ test('expect to return one hostPathObject with ingress that has one host/path', 
     selected: false,
   };
   const result = ingressRouteHelper.getIngressHostPaths(ingressUI);
-  expect(result.length).toBe(1);
+  expect(result).toHaveLength(1);
   expect(result[0].label).toEqual('foo.bar.com/foo');
   expect(result[0].url).toEqual('https://foo.bar.com/foo');
 });
 
 test('expect to return one hostPathObject with ingress that has multiple host/path', async () => {
   const result = ingressRouteHelper.getIngressHostPaths(ingressUIWith2Paths);
-  expect(result.length).toBe(2);
+  expect(result).toHaveLength(2);
   expect(result[0].label).toEqual('foo.bar.com/foo');
   expect(result[0].url).toEqual('https://foo.bar.com/foo');
   expect(result[1].label).toEqual('foo.bar.com/foo2');
@@ -255,14 +255,14 @@ test('expect to return one hostPathObject with ingress that has multiple host/pa
 
 test('expect to return one hostPathObject without any link if ingress has no host defined', async () => {
   const result = ingressRouteHelper.getIngressHostPaths(ingressUI);
-  expect(result.length).toBe(1);
+  expect(result).toHaveLength(1);
   expect(result[0].label).toEqual('/foo');
   expect(result[0].url).toBeUndefined();
 });
 
 test('expect to return one hostPathObject if item is route', async () => {
   const result = ingressRouteHelper.getRouteHostPaths(routeUI);
-  expect(result.length).toBe(1);
+  expect(result).toHaveLength(1);
   expect(result[0].label).toEqual('foo.bar.com');
   expect(result[0].url).toEqual('https://foo.bar.com');
 });
@@ -293,19 +293,19 @@ test('expect getIngressBackends is not called with RouteUI object', async () => 
   const getIngressBackendsMock = vi.spyOn(ingressRouteHelper, 'getIngressBackends');
   const result = ingressRouteHelper.getBackends(routeUI);
   expect(getIngressBackendsMock).not.toHaveBeenCalled();
-  expect(result.length).toBe(1);
+  expect(result).toHaveLength(1);
   expect(result[0]).toEqual('Service service');
 });
 
 test('expect to return one item array with ingress that has one host/path', async () => {
   const result = ingressRouteHelper.getIngressBackends(ingressUI);
-  expect(result.length).toBe(1);
+  expect(result).toHaveLength(1);
   expect(result[0]).toEqual('StorageBucket bucket');
 });
 
 test('expect to return one hostPathObject with ingress that has multiple path', async () => {
   const result = ingressRouteHelper.getIngressBackends(ingressUIWith2Paths);
-  expect(result.length).toBe(2);
+  expect(result).toHaveLength(2);
   expect(result[0]).toEqual('StorageBucket bucket');
   expect(result[1]).toEqual('bucket-2:80');
 });

--- a/packages/webview/src/component/objects/NamespaceDropdown.spec.ts
+++ b/packages/webview/src/component/objects/NamespaceDropdown.spec.ts
@@ -137,7 +137,7 @@ test('Expect namespaces are in the dropdown', async () => {
   // first namespace is in the original button and in the dropdown
   const item1 = screen.getAllByRole('button', { name: new RegExp(`${firstNS}$`) });
 
-  expect(item1.length).toEqual(2);
+  expect(item1).toHaveLength(2);
 
   // second namespace is also clickable
   const item2 = screen.getByRole('button', { name: secondNS });

--- a/packages/webview/src/component/objects/details/ConditionsTable.spec.ts
+++ b/packages/webview/src/component/objects/details/ConditionsTable.spec.ts
@@ -40,7 +40,7 @@ test('conditions are displayed in a table', async () => {
   expect(table).toBeInTheDocument();
   const rows = within(table).getAllByRole('row');
   // the first row is the header
-  expect(rows.length).toBe(2);
+  expect(rows).toHaveLength(2);
   const row = rows[1];
   within(row).getByText('Ready');
   within(row).getByText('True');

--- a/packages/webview/src/component/objects/details/EventsTable.spec.ts
+++ b/packages/webview/src/component/objects/details/EventsTable.spec.ts
@@ -67,7 +67,7 @@ test('expect the events are displayed reactively', async () => {
   expect(table).toBeDefined();
   let rows = await within(table).findAllByRole('row');
   expect(rows).toBeDefined();
-  expect(rows.length).toBe(3);
+  expect(rows).toHaveLength(3);
 
   expect(within(rows[1]).getByText('25 seconds')).toBeInTheDocument();
   expect(within(rows[1]).getByText('Normal')).toBeInTheDocument();
@@ -96,7 +96,7 @@ test('expect the events are displayed reactively', async () => {
   vi.advanceTimersByTime(10_000);
   await rendered.rerender({ events: events });
   rows = await within(table).findAllByRole('row');
-  expect(rows.length).toBe(4);
+  expect(rows).toHaveLength(4);
 
   expect(within(rows[1]).getByText('35 seconds')).toBeInTheDocument();
   expect(within(rows[2]).getByText('30 seconds (2x over 35 seconds)')).toBeInTheDocument();

--- a/packages/webview/src/component/pods/dots/Dots.spec.ts
+++ b/packages/webview/src/component/pods/dots/Dots.spec.ts
@@ -98,15 +98,15 @@ test('getStatusColor returns the correct colors', () => {
 
 test('organizeContainers returns a record of containers organized by status', () => {
   const organizedContainers = organizeContainers(mockContainers);
-  expect(organizedContainers.running.length).toBe(1);
-  expect(organizedContainers.terminated.length).toBe(1);
-  expect(organizedContainers.waiting.length).toBe(1);
-  expect(organizedContainers.stopped.length).toBe(1);
-  expect(organizedContainers.paused.length).toBe(1);
-  expect(organizedContainers.exited.length).toBe(1);
-  expect(organizedContainers.dead.length).toBe(1);
-  expect(organizedContainers.created.length).toBe(1);
-  expect(organizedContainers.degraded.length).toBe(1);
+  expect(organizedContainers.running).toHaveLength(1);
+  expect(organizedContainers.terminated).toHaveLength(1);
+  expect(organizedContainers.waiting).toHaveLength(1);
+  expect(organizedContainers.stopped).toHaveLength(1);
+  expect(organizedContainers.paused).toHaveLength(1);
+  expect(organizedContainers.exited).toHaveLength(1);
+  expect(organizedContainers.dead).toHaveLength(1);
+  expect(organizedContainers.created).toHaveLength(1);
+  expect(organizedContainers.degraded).toHaveLength(1);
 });
 
 test('randomly re-order the containers and ensure they are still organized correctly after in the correct order', () => {

--- a/packages/webview/src/component/port-forward/PortForwardingList.spec.ts
+++ b/packages/webview/src/component/port-forward/PortForwardingList.spec.ts
@@ -101,7 +101,7 @@ test('One port forwarded should display correct table content', async () => {
 
   const rowgroups = getAllByRole('rowgroup');
   expect(rowgroups).toBeDefined();
-  expect(rowgroups.length).toBe(2);
+  expect(rowgroups).toHaveLength(2);
 
   const tableBody = rowgroups[1];
   const row = within(tableBody).getByRole('row');
@@ -140,7 +140,7 @@ test('Multiple (10) port forwards should render all rows', async () => {
 
   const rowgroups = getAllByRole('rowgroup');
   expect(rowgroups).toBeDefined();
-  expect(rowgroups.length).toBe(2);
+  expect(rowgroups).toHaveLength(2);
 
   const tableBody = rowgroups[1];
   const rows = within(tableBody).getAllByRole('row');
@@ -190,7 +190,7 @@ test('Column sorting should reorder the table data', async () => {
 
   const rowgroups = getAllByRole('rowgroup');
   expect(rowgroups).toBeDefined();
-  expect(rowgroups.length).toBe(2);
+  expect(rowgroups).toHaveLength(2);
 
   const tableBody = rowgroups[1];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,8 +98,8 @@ importers:
         specifier: ^13.0.0
         version: 13.0.0(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-sonarjs:
-        specifier: ^4.0.3
-        version: 4.0.3(eslint@10.6.0(jiti@2.7.0))
+        specifier: ^4.1.0
+        version: 4.1.0(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-svelte:
         specifier: ^3.20.0
         version: 3.20.0(eslint@10.6.0(jiti@2.7.0))(svelte@5.56.4(@typescript-eslint/types@8.62.1))
@@ -218,8 +218,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3)
       eslint-plugin-sonarjs:
-        specifier: ^4.0.3
-        version: 4.0.3(eslint@10.6.0(jiti@2.7.0))
+        specifier: ^4.1.0
+        version: 4.1.0(eslint@10.6.0(jiti@2.7.0))
       isomorphic-ws:
         specifier: ^5.0.0
         version: 5.0.0(ws@8.21.0)
@@ -2468,8 +2468,8 @@ packages:
     peerDependencies:
       eslint: '>=5.0.0'
 
-  eslint-plugin-sonarjs@4.0.3:
-    resolution: {integrity: sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==}
+  eslint-plugin-sonarjs@4.1.0:
+    resolution: {integrity: sha512-rh+FlVz0yfd2RNIb6WqSkuGh0addX/Qi5scwQ5FphXDFrM6fZKcxP1+attJ78yUKcyYfiu6MTaISPpAFPzqRJw==}
     peerDependencies:
       eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
 
@@ -2716,10 +2716,6 @@ packages:
 
   globals@16.5.0:
     resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
-    engines: {node: '>=18'}
-
-  globals@17.5.0:
-    resolution: {integrity: sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==}
     engines: {node: '>=18'}
 
   globals@17.7.0:
@@ -3711,11 +3707,6 @@ packages:
 
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5603,7 +5594,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.9
-      semver: 7.7.4
+      semver: 7.8.5
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -5664,7 +5655,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
       eslint: 10.6.0(jiti@2.7.0)
-      semver: 7.7.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6623,21 +6614,22 @@ snapshots:
     dependencies:
       eslint: 10.6.0(jiti@2.7.0)
 
-  eslint-plugin-sonarjs@4.0.3(eslint@10.6.0(jiti@2.7.0)):
+  eslint-plugin-sonarjs@4.1.0(eslint@10.6.0(jiti@2.7.0)):
     dependencies:
       '@eslint-community/regexpp': 4.12.2
       builtin-modules: 3.3.0
       bytes: 3.1.2
       eslint: 10.6.0(jiti@2.7.0)
       functional-red-black-tree: 1.0.1
-      globals: 17.5.0
+      globals: 17.7.0
       jsx-ast-utils-x: 0.1.0
       lodash.merge: 4.6.2
       minimatch: 10.2.5
       scslre: 0.3.0
-      semver: 7.7.4
+      semver: 7.8.5
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
+      yaml: 2.9.0
 
   eslint-plugin-svelte@3.20.0(eslint@10.6.0(jiti@2.7.0))(svelte@5.56.4(@typescript-eslint/types@8.62.1)):
     dependencies:
@@ -6926,8 +6918,6 @@ snapshots:
 
   globals@16.5.0: {}
 
-  globals@17.5.0: {}
-
   globals@17.7.0: {}
 
   globalthis@1.0.4:
@@ -7056,7 +7046,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   is-callable@1.2.7: {}
 
@@ -7980,8 +7970,6 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
     optional: true
-
-  semver@7.7.4: {}
 
   semver@7.8.1: {}
 

--- a/tests/playwright/src/anonymous-user.ts
+++ b/tests/playwright/src/anonymous-user.ts
@@ -36,6 +36,7 @@ export function anonymousUserTests(): void {
     const kubeConfigPathDst = path.resolve(__dirname, '..', 'tests', 'playwright', 'resources', 'kube-config');
     fs.mkdirSync(path.dirname(kubeConfigPathDst), { recursive: true });
     fs.copyFileSync(kubeConfigPathSrc, kubeConfigPathDst);
+    playExpect(fs.existsSync(kubeConfigPathDst)).toBeTruthy();
   });
 
   test('Open Extension webview and verify the dashboard is connected', async ({ runner, page, navigationBar }) => {


### PR DESCRIPTION
### What does this PR do?

- Disable sonarjs/assertions-in-tests and sonarjs/no-skipped-tests for Playwright tests (playExpect alias not recognized; conditional test.skip is a valid Playwright runtime gate)
- Add file-existence assertion to kubeconfig setup test
- Replace .length matchers with toHaveLength() per sonarjs prefer-expect-assertions
- Replace toEqual(undefined) with toBeUndefined()

### Screenshot / video of UI


### What issues does this PR fix or reference?

<!-- Include any related issues from the
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
