### PR TITLE
fix: add 'New Cluster' button to navigate to NoContextPage

### DIFF
--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -2,6 +2,7 @@
 import NamespacesList from './component/namespaces/NamespacesList.svelte';
 import ConfigMapSecretList from './component/configmaps-secrets/ConfigMapSecretList.svelte';
 import Dashboard from '/@/component/dashboard/Dashboard.svelte';
+import NoContextPage from '/@/component/dashboard/NoContextPage.svelte';
 import NodesList from '/@/component/nodes/NodesList.svelte';
 import Navigation from '/@/Navigation.svelte';
 import Route from '/@/Route.svelte';
@@ -48,6 +49,10 @@ const { meta }: Props = $props();
 <div class="flex flex-col w-full h-full overflow-hidden">
   <Route path="/">
     <Dashboard />
+  </Route>
+
+  <Route path="/newCluster">
+    <NoContextPage title="Create Kubernetes Cluster" />
   </Route>
 
   <Route path="/nodes">

--- a/packages/webview/src/component/dashboard/Dashboard.svelte
+++ b/packages/webview/src/component/dashboard/Dashboard.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-import { Expandable, Link } from '@podman-desktop/ui-svelte';
+import { Button, Expandable, Link } from '@podman-desktop/ui-svelte';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import { router } from 'tinro';
 import DashboardResources from './DashboardResources.svelte';
 import CurrentContextConnectionBadge from '/@/component/connection/CurrentContextConnectionBadge.svelte';
 import { Remote } from '/@/remote/remote';
@@ -44,9 +46,13 @@ onDestroy(() => {
       {#snippet title()}
         <div class="flex flex-row w-full items-center">
           <div class="text-xl font-bold capitalize text-(--pd-content-header)">Dashboard</div>
-          <div class="flex grow justify-end"><CurrentContextConnectionBadge /></div>
+          <div class="flex grow justify-end items-center gap-3">
+            <CurrentContextConnectionBadge />
+            <Button on:click={(): void => router.goto('/newCluster')} icon={faPlus}>New Cluster…</Button>
+          </div>
         </div>
       {/snippet}
+
       <div class="flex flex-col gap-4">
         <div>
           Here you can manage and interact with Kubernetes clusters with features like connecting to clusters, and

--- a/packages/webview/src/component/dashboard/NoContextPage.svelte
+++ b/packages/webview/src/component/dashboard/NoContextPage.svelte
@@ -6,6 +6,12 @@ import type { Unsubscriber } from 'svelte/store';
 import KubernetesProviderCard from '/@/component/dashboard/KubernetesProviderCard.svelte';
 import NewProviderCard from '/@/component/dashboard/NewProviderCard.svelte';
 
+interface Props {
+  title?: string;
+}
+
+const { title = 'No Kubernetes cluster' }: Props = $props();
+
 const states = getContext<States>(States);
 const kubernetesProviders = states.stateKubernetesProvidersInfoUI;
 
@@ -25,7 +31,7 @@ onDestroy(() => {
     <div class="flex justify-center text-(--pd-details-empty-icon) py-2">
       <KubeIcon size="80" />
     </div>
-    <h1 class="text-xl text-(--pd-details-empty-header)">No Kubernetes cluster</h1>
+    <h1 class="text-xl text-(--pd-details-empty-header)">{title}</h1>
     <div class="text-(--pd-details-empty-sub-header) text-balance">
       A Kubernetes cluster is a group of nodes (virtual or physical) that run Kubernetes, a system for automating the
       deployment and management of containerized applications.


### PR DESCRIPTION
### What does this PR do?

Adds 'New Cluster...' button to dashboard title to let installing kubernetes related extensions and create/connect to new clusters

### Screenshot / video of UI

https://github.com/user-attachments/assets/d11ba271-74b0-485e-a70b-7952e0854a9d

### What issues does this PR fix or reference?

Fix #1132.

### How to test this PR?

<!-- Please explain steps to reproduce -->
