### PR TITLE
fix(tests): address vitest eslint plugin rule violations

### DIFF
--- a/packages/extension/src/port-forward/port-forward-connection.spec.ts
+++ b/packages/extension/src/port-forward/port-forward-connection.spec.ts
@@ -209,9 +209,10 @@ describe('PortForwardConnectionService', () => {
       3,
     );
 
-    createdServer.listen(forwardSetup.forward.localPort, 'localhost', vi.fn<() => void>());
+    const listenCallback = vi.fn<() => void>();
+    createdServer.listen(forwardSetup.forward.localPort, 'localhost', listenCallback);
 
-    expect(server.listen).toHaveBeenCalledWith(forwardSetup.forward.localPort, 'localhost', expect.any(Function));
+    expect(server.listen).toHaveBeenCalledWith(forwardSetup.forward.localPort, 'localhost', listenCallback);
   });
 
   test('should throw an error for unsupported workload kind', async () => {

--- a/packages/webview/src/component/pods/PodTerminal.spec.ts
+++ b/packages/webview/src/component/pods/PodTerminal.spec.ts
@@ -155,6 +155,7 @@ test('PodTerminal calls resizeTerminal initially then when resized', async () =>
       30,
     );
   });
+  // eslint-disable-next-line vitest/valid-expect
   expect(addEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
   const resizeCb = addEventListener.mock.calls[0][1] as unknown as () => void;
 


### PR DESCRIPTION
### What does this PR do?

Needed for https://github.com/podman-desktop/extension-kubernetes-dashboard/pull/1140

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from the
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
