### PR TITLE
feat: Allow me to view logs of a container that is no longer running.

### DIFF
--- a/packages/webview/src/component/pods/PodLogsCustomizable.spec.ts
+++ b/packages/webview/src/component/pods/PodLogsCustomizable.spec.ts
@@ -39,7 +39,13 @@ const fakePod2containersRunning: V1Pod = {
   },
 } as V1Pod;
 
-const fakePod1containerRunning: V1Pod = {
+const fakePodSingleContainerRunning: V1Pod = {
+  status: {
+    containerStatuses: [{ name: 'container1', state: { running: {} } }],
+  },
+} as V1Pod;
+
+const fakePodOneRunningOneTerminated: V1Pod = {
   status: {
     containerStatuses: [
       { name: 'container1', state: { running: {} } },
@@ -48,13 +54,19 @@ const fakePod1containerRunning: V1Pod = {
   },
 } as V1Pod;
 
-const fakePodNoContainerRunning: V1Pod = {
+// Simulates a pod whose container(s) crashed: no container is running anymore, but their
+// previous logs should still be reachable through the toolbar.
+const fakePodAllContainersTerminated: V1Pod = {
   status: {
     containerStatuses: [
       { name: 'container1', state: { terminated: {} } },
       { name: 'container2', state: { terminated: {} } },
     ],
   },
+} as V1Pod;
+
+const fakePodNoContainerStatus: V1Pod = {
+  status: {},
 } as V1Pod;
 
 const dependencyMocks = new DependencyMocks();
@@ -73,9 +85,48 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-test('renders with no container running', () => {
-  render(PodLogsCustomizable, { object: fakePodNoContainerRunning });
-  expect(screen.getByText('No container running')).toBeDefined();
+test('renders empty screen when pod has no container status', () => {
+  render(PodLogsCustomizable, { object: fakePodNoContainerStatus });
+  expect(screen.getByText('No container found')).toBeDefined();
+});
+
+test('still renders toolbar and logs when all containers are terminated, so previous logs remain accessible', async () => {
+  render(PodLogsCustomizable, { object: fakePodAllContainersTerminated });
+  expect(screen.queryByText('No container found')).not.toBeInTheDocument();
+
+  const containerDropdown = screen.getByLabelText('Select container');
+  within(containerDropdown).getByText('All containers');
+  expect(vi.mocked(PodLogs)).toHaveBeenCalledWith(expect.anything(), {
+    object: fakePodAllContainersTerminated,
+    containerName: '',
+    colorizer: 'colorizer 1',
+    timestamps: false,
+    previous: false,
+  });
+
+  // Containers that are not running are still selectable and flagged as such
+  await userEvent.click(within(containerDropdown).getByText('All containers'));
+  within(containerDropdown).getByText('container1 (not running)');
+  const container2Option = within(containerDropdown).getByText('container2 (not running)');
+  await userEvent.click(container2Option);
+  expect(vi.mocked(PodLogs)).toHaveBeenCalledWith(expect.anything(), {
+    object: fakePodAllContainersTerminated,
+    containerName: 'container2',
+    colorizer: 'colorizer 1',
+    timestamps: false,
+    previous: false,
+  });
+
+  // Previous logs can still be requested for the crashed container
+  const previousCheckbox = screen.getByLabelText('Previous logs');
+  await userEvent.click(previousCheckbox);
+  expect(vi.mocked(PodLogs)).toHaveBeenCalledWith(expect.anything(), {
+    object: fakePodAllContainersTerminated,
+    containerName: 'container2',
+    colorizer: 'colorizer 1',
+    timestamps: false,
+    previous: true,
+  });
 });
 
 test('renders with 2 containers running', async () => {
@@ -160,8 +211,27 @@ test('renders with 2 containers running', async () => {
   });
 });
 
+test('renders with one running and one terminated container, terminated container flagged as not running', async () => {
+  render(PodLogsCustomizable, { object: fakePodOneRunningOneTerminated });
+  const containerDropdown = screen.getByLabelText('Select container');
+
+  await userEvent.click(within(containerDropdown).getByText('All containers'));
+  within(containerDropdown).getByText('container1');
+  within(containerDropdown).getByText('container2 (not running)');
+
+  const container2 = within(containerDropdown).getByText('container2 (not running)');
+  await userEvent.click(container2);
+  expect(vi.mocked(PodLogs)).toHaveBeenCalledWith(expect.anything(), {
+    object: fakePodOneRunningOneTerminated,
+    containerName: 'container2',
+    colorizer: 'colorizer 1',
+    timestamps: false,
+    previous: false,
+  });
+});
+
 test('renders with 1 container running', async () => {
-  render(PodLogsCustomizable, { object: fakePod1containerRunning });
+  render(PodLogsCustomizable, { object: fakePodSingleContainerRunning });
   expect(screen.queryByText('container1')).not.toBeInTheDocument();
 
   const colorizerDropdown = screen.getByLabelText('Select colorization');
@@ -171,7 +241,7 @@ test('renders with 1 container running', async () => {
   const colorizer2 = within(colorizerDropdown).getByText('colorizer 2');
   await userEvent.click(colorizer2);
   expect(vi.mocked(PodLogs)).toHaveBeenCalledWith(expect.anything(), {
-    object: fakePod1containerRunning,
+    object: fakePodSingleContainerRunning,
     containerName: '',
     colorizer: 'colorizer 2',
     timestamps: false,
@@ -183,10 +253,10 @@ test('renders with 1 container running with colors annotation', async () => {
   vi.mocked(dependencyMocks.get(Annotations).getAnnotations).mockReturnValue({ 'logs-colors': 'colorizer 2' });
   vi.mocked(dependencyMocks.get(PodLogsHelper).resolveColorizer).mockImplementation(s => s ?? 'colorizer 1');
 
-  render(PodLogsCustomizable, { object: fakePod1containerRunning });
+  render(PodLogsCustomizable, { object: fakePodSingleContainerRunning });
 
   expect(vi.mocked(PodLogs)).toHaveBeenCalledWith(expect.anything(), {
-    object: fakePod1containerRunning,
+    object: fakePodSingleContainerRunning,
     containerName: '',
     colorizer: 'colorizer 2',
     timestamps: false,
@@ -197,7 +267,7 @@ test('renders with 1 container running with colors annotation', async () => {
 test('renders with 1 container running with timestamps annotation', async () => {
   vi.mocked(dependencyMocks.get(Annotations).getAnnotations).mockReturnValue({ 'logs-timestamps': 'true' });
 
-  render(PodLogsCustomizable, { object: fakePod1containerRunning });
+  render(PodLogsCustomizable, { object: fakePodSingleContainerRunning });
   expect(screen.queryByText('container1')).not.toBeInTheDocument();
 
   const colorizerDropdown = screen.getByLabelText('Select colorization');
@@ -207,7 +277,7 @@ test('renders with 1 container running with timestamps annotation', async () => 
   const colorizer2 = within(colorizerDropdown).getByText('colorizer 2');
   await userEvent.click(colorizer2);
   expect(vi.mocked(PodLogs)).toHaveBeenCalledWith(expect.anything(), {
-    object: fakePod1containerRunning,
+    object: fakePodSingleContainerRunning,
     containerName: '',
     colorizer: 'colorizer 2',
     timestamps: true,
@@ -218,7 +288,7 @@ test('renders with 1 container running with timestamps annotation', async () => 
 test('renders with 1 container running with tailLines annotation', async () => {
   vi.mocked(dependencyMocks.get(Annotations).getAnnotations).mockReturnValue({ 'logs-tail-lines': '10' });
 
-  render(PodLogsCustomizable, { object: fakePod1containerRunning });
+  render(PodLogsCustomizable, { object: fakePodSingleContainerRunning });
   expect(screen.queryByText('container1')).not.toBeInTheDocument();
 
   const colorizerDropdown = screen.getByLabelText('Select colorization');
@@ -228,7 +298,7 @@ test('renders with 1 container running with tailLines annotation', async () => {
   const colorizer2 = within(colorizerDropdown).getByText('colorizer 2');
   await userEvent.click(colorizer2);
   expect(vi.mocked(PodLogs)).toHaveBeenCalledWith(expect.anything(), {
-    object: fakePod1containerRunning,
+    object: fakePodSingleContainerRunning,
     containerName: '',
     colorizer: 'colorizer 2',
     timestamps: false,
@@ -240,7 +310,7 @@ test('renders with 1 container running with tailLines annotation', async () => {
 test('renders with 1 container running with sinceSeconds annotation', async () => {
   vi.mocked(dependencyMocks.get(Annotations).getAnnotations).mockReturnValue({ 'logs-since-seconds': '35' });
 
-  render(PodLogsCustomizable, { object: fakePod1containerRunning });
+  render(PodLogsCustomizable, { object: fakePodSingleContainerRunning });
   expect(screen.queryByText('container1')).not.toBeInTheDocument();
 
   const colorizerDropdown = screen.getByLabelText('Select colorization');
@@ -250,7 +320,7 @@ test('renders with 1 container running with sinceSeconds annotation', async () =
   const colorizer2 = within(colorizerDropdown).getByText('colorizer 2');
   await userEvent.click(colorizer2);
   expect(vi.mocked(PodLogs)).toHaveBeenCalledWith(expect.anything(), {
-    object: fakePod1containerRunning,
+    object: fakePodSingleContainerRunning,
     containerName: '',
     colorizer: 'colorizer 2',
     timestamps: false,

--- a/packages/webview/src/component/pods/PodLogsCustomizable.svelte
+++ b/packages/webview/src/component/pods/PodLogsCustomizable.svelte
@@ -19,7 +19,9 @@ const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
 const podLogsHelper = dependencyAccessor.get<PodLogsHelper>(PodLogsHelper);
 const annotations = dependencyAccessor.get<Annotations>(Annotations);
 
-const runningContainers = $derived(object.status?.containerStatuses?.filter(status => status.state?.running) ?? []);
+// Containers are kept in the selection as long as they have reported a status, even if they
+// are not currently running, so previous logs of a crashed/terminated container remain accessible.
+const containerStatuses = $derived(object.status?.containerStatuses ?? []);
 
 const colorsAnnotations = $derived(annotations.getAnnotations(object.metadata, { key: 'logs-colors' }));
 const timestampsAnnotations = $derived(annotations.getAnnotations(object.metadata, { key: 'logs-timestamps' }));
@@ -35,9 +37,9 @@ let sinceSeconds = $derived<string>(sinceSecondsAnnotations['logs-since-seconds'
 
 let containerSelection = $derived([
   { label: 'All containers', value: '' },
-  ...runningContainers.map(container => ({
-    label: container.name,
-    value: container.name,
+  ...containerStatuses.map(status => ({
+    label: status.state?.running ? status.name : `${status.name} (not running)`,
+    value: status.name,
   })),
 ]);
 
@@ -65,10 +67,10 @@ function debounce(func: (event: Event) => void, delay: number): (event: Event) =
 }
 </script>
 
-{#if runningContainers.length > 0}
+{#if containerStatuses.length > 0}
   <div class="flex grow flex-col h-full w-full">
     <div class="flex flex-wrap flex-row p-2 h-min-[40px] gap-x-4">
-      {#if runningContainers.length > 1}
+      {#if containerStatuses.length > 1}
         <div class="w-48">
           <Dropdown
             ariaLabel="Select container"
@@ -134,5 +136,5 @@ function debounce(func: (event: Event) => void, delay: number): (event: Event) =
     </div>
   </div>
 {:else}
-  <EmptyScreen icon={NoLogIcon} title="No Logs" message="No container running" />
+  <EmptyScreen icon={NoLogIcon} title="No Logs" message="No container found" />
 {/if}


### PR DESCRIPTION
### What does this PR do?
Still shows logs from a failed/stopped container

### Screenshot / video of UI
<img width="1117" height="83" alt="image" src="https://github.com/user-attachments/assets/e81830de-8b93-4a47-9712-f655d9a98227" />

BEFORE:
<img width="664" height="486" alt="image" src="https://github.com/user-attachments/assets/4182354e-a4a4-4b6a-83eb-8dd5f6f8d4fb" />

AFTER:
<img width="1042" height="268" alt="image" src="https://github.com/user-attachments/assets/a663afbf-efcf-4cc2-a143-0521654c78d5" />

### What issues does this PR fix or reference?
#1151 

### How to test this PR?
Cause your container to fail to start up... then check the logs
