### PR TITLE
feat: Allow me to unfollow the log stream so i can actually parse an …

### DIFF
--- a/packages/webview/src/component/pods/PodLogs.spec.ts
+++ b/packages/webview/src/component/pods/PodLogs.spec.ts
@@ -109,6 +109,38 @@ describe('pod with one container', async () => {
     await vi.advanceTimersByTimeAsync(1_100);
     expect(EmptyScreen).not.toHaveBeenCalled();
   });
+
+  test('follow defaults to true when not specified', async () => {
+    const subscribeSpy = vi.spyOn(streamPodLogsMock, 'subscribe');
+    render(PodLogs, { object: pod, colorizer: 'no colors', timestamps: false, previous: false });
+
+    await vi.waitFor(() => {
+      expect(subscribeSpy).toHaveBeenCalled();
+    });
+    expect(subscribeSpy).toHaveBeenCalledWith(
+      'podName',
+      'namespace',
+      'containerName',
+      expect.objectContaining({ follow: true }),
+      expect.any(Function),
+    );
+  });
+
+  test('follow is forwarded as false when streaming is disabled', async () => {
+    const subscribeSpy = vi.spyOn(streamPodLogsMock, 'subscribe');
+    render(PodLogs, { object: pod, colorizer: 'no colors', timestamps: false, previous: false, follow: false });
+
+    await vi.waitFor(() => {
+      expect(subscribeSpy).toHaveBeenCalled();
+    });
+    expect(subscribeSpy).toHaveBeenCalledWith(
+      'podName',
+      'namespace',
+      'containerName',
+      expect.objectContaining({ follow: false }),
+      expect.any(Function),
+    );
+  });
 });
 
 describe('pod with two containers', async () => {

--- a/packages/webview/src/component/pods/PodLogs.svelte
+++ b/packages/webview/src/component/pods/PodLogs.svelte
@@ -17,10 +17,20 @@ interface Props {
   colorizer: string;
   timestamps: boolean;
   previous: boolean;
+  follow?: boolean;
   tailLines?: string;
   sinceSeconds?: string;
 }
-let { object, containerName, colorizer, timestamps, previous, tailLines = '1000', sinceSeconds }: Props = $props();
+let {
+  object,
+  containerName,
+  colorizer,
+  timestamps,
+  previous,
+  follow = true,
+  tailLines = '1000',
+  sinceSeconds,
+}: Props = $props();
 
 // Logs has been initialized
 let noLogs = $state<boolean>();
@@ -51,6 +61,7 @@ onMount(async () => {
         {
           timestamps,
           previous,
+          follow,
           tailLines: getFiniteNumber(tailLines),
           sinceSeconds: getFiniteNumber(sinceSeconds),
         },

--- a/packages/webview/src/component/pods/PodLogsCustomizable.spec.ts
+++ b/packages/webview/src/component/pods/PodLogsCustomizable.spec.ts
@@ -90,6 +90,7 @@ test('renders with 2 containers running', async () => {
     colorizer: 'colorizer 1',
     timestamps: false,
     previous: false,
+    follow: true,
   });
 
   await userEvent.click(containerDropdownButton);
@@ -101,6 +102,7 @@ test('renders with 2 containers running', async () => {
     colorizer: 'colorizer 1',
     timestamps: false,
     previous: false,
+    follow: true,
   });
 
   await userEvent.click(colorizerDropdownButton);
@@ -112,6 +114,7 @@ test('renders with 2 containers running', async () => {
     colorizer: 'colorizer 2',
     timestamps: false,
     previous: false,
+    follow: true,
   });
 
   const previousCheckbox = screen.getByLabelText('Previous logs');
@@ -122,6 +125,7 @@ test('renders with 2 containers running', async () => {
     colorizer: 'colorizer 2',
     timestamps: false,
     previous: true,
+    follow: true,
   });
 
   // Tail lines waits for 1 second before dispatching the new value
@@ -138,6 +142,7 @@ test('renders with 2 containers running', async () => {
     colorizer: 'colorizer 2',
     timestamps: false,
     previous: true,
+    follow: true,
     tailLines: '10',
   });
 
@@ -155,6 +160,25 @@ test('renders with 2 containers running', async () => {
     colorizer: 'colorizer 2',
     timestamps: false,
     previous: true,
+    follow: true,
+    tailLines: '10',
+    sinceSeconds: '35',
+  });
+
+  // Stream logs checkbox is checked by default and disables follow when unchecked
+  const followCheckbox = screen.getByLabelText('Stream logs');
+  expect(followCheckbox).toBeChecked();
+  vi.mocked(PodLogs).mockClear();
+  await userEvent.click(followCheckbox);
+  expect(followCheckbox).not.toBeChecked();
+  expect(PodLogs).toHaveBeenCalledOnce();
+  expect(PodLogs).toHaveBeenCalledWith(expect.anything(), {
+    object: fakePod2containersRunning,
+    containerName: 'container2',
+    colorizer: 'colorizer 2',
+    timestamps: false,
+    previous: true,
+    follow: false,
     tailLines: '10',
     sinceSeconds: '35',
   });
@@ -176,6 +200,7 @@ test('renders with 1 container running', async () => {
     colorizer: 'colorizer 2',
     timestamps: false,
     previous: false,
+    follow: true,
   });
 });
 
@@ -191,6 +216,7 @@ test('renders with 1 container running with colors annotation', async () => {
     colorizer: 'colorizer 2',
     timestamps: false,
     previous: false,
+    follow: true,
   });
 });
 
@@ -212,6 +238,7 @@ test('renders with 1 container running with timestamps annotation', async () => 
     colorizer: 'colorizer 2',
     timestamps: true,
     previous: false,
+    follow: true,
   });
 });
 
@@ -233,6 +260,7 @@ test('renders with 1 container running with tailLines annotation', async () => {
     colorizer: 'colorizer 2',
     timestamps: false,
     previous: false,
+    follow: true,
     tailLines: '10',
   });
 });
@@ -255,6 +283,7 @@ test('renders with 1 container running with sinceSeconds annotation', async () =
     colorizer: 'colorizer 2',
     timestamps: false,
     previous: false,
+    follow: true,
     sinceSeconds: '35',
   });
 });

--- a/packages/webview/src/component/pods/PodLogsCustomizable.svelte
+++ b/packages/webview/src/component/pods/PodLogsCustomizable.svelte
@@ -30,6 +30,7 @@ const sinceSecondsAnnotations = $derived(annotations.getAnnotations(object.metad
 let selectedContainerName = $state<string>('');
 let selectedTimestamps = $derived<boolean>(timestampsAnnotations['logs-timestamps'] === 'true');
 let selectedPrevious = $state<boolean>(false);
+let selectedFollow = $state<boolean>(true);
 let tailLines = $derived<string>(tailLinesAnnotations['logs-tail-lines']);
 let sinceSeconds = $derived<string>(sinceSecondsAnnotations['logs-since-seconds']);
 
@@ -95,6 +96,9 @@ function debounce(func: (event: Event) => void, delay: number): (event: Event) =
           >Previous logs</Checkbox>
       </div>
       <div>
+        <Checkbox class="pt-2" name="follow" title="Stream logs" bind:checked={selectedFollow}>Stream logs</Checkbox>
+      </div>
+      <div>
         <Input
           type="number"
           placeholder="1000"
@@ -119,7 +123,7 @@ function debounce(func: (event: Event) => void, delay: number): (event: Event) =
     </div>
 
     <div class="flex w-full h-full min-h-0">
-      {#key [selectedContainerName, selectedColorizer, selectedTimestamps, selectedPrevious, tailLines, sinceSeconds]}
+      {#key [selectedContainerName, selectedColorizer, selectedTimestamps, selectedPrevious, selectedFollow, tailLines, sinceSeconds]}
         {#if selectedContainerName !== undefined}
           <PodLogs
             object={object}
@@ -127,6 +131,7 @@ function debounce(func: (event: Event) => void, delay: number): (event: Event) =
             colorizer={selectedColorizer}
             timestamps={selectedTimestamps}
             previous={selectedPrevious}
+            follow={selectedFollow}
             tailLines={tailLines}
             sinceSeconds={sinceSeconds} />
         {/if}


### PR DESCRIPTION
…error without losing my place

### What does this PR do?
Allows my to stop log streaming so i can view errors of a container that's throwing a lot of errors quickly and constantly.

### Screenshot / video of UI
<img width="880" height="214" alt="image" src="https://github.com/user-attachments/assets/9208b62e-914f-43eb-bdda-70206450e3c7" />


### What issues does this PR fix or reference?
#1156 

### How to test this PR?
Uncheck the box, the view should stop updating, checking it again should resume streaming.
