### PR TITLE
fix: remove redundant build:deps from concurrent sub-package builds

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build:deps": "pnpm --filter @kubernetes-dashboard/rpc run build && pnpm --filter @kubernetes-dashboard/channels run build",
-    "build": "pnpm run build:deps && vite build",
+    "build": "vite build",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch --coverage",
     "format:check": "prettier --check \"src/**/*.ts\"",

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "preview": "vite preview",
     "build:deps": "pnpm --filter @kubernetes-dashboard/rpc run build && pnpm --filter @kubernetes-dashboard/channels run build",
-    "build": "pnpm run build:deps && vite build",
+    "build": "vite build",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch --coverage",
     "format:check": "prettier --check \"src/**/*.ts\"",


### PR DESCRIPTION
### What does this PR do?

The root build script already builds rpc and channels sequentially before launching webview and extension builds concurrently. Having both sub-packages re-run build:deps caused two simultaneous vite builds of the channels package, which fails on Windows with EPERM when one process tries to empty dist/ while the other holds file locks.

### Screenshot / video of UI


### What issues does this PR fix or reference?

Fixes #1195 

### How to test this PR?

<!-- Please explain steps to reproduce -->
