### PR TITLE
fix: pass GITHUB_TOKEN to Podman Desktop build step in E2E workflow

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -123,6 +123,8 @@ jobs:
         if: steps.cache-pd.outputs.cache-hit != 'true'
         shell: bash
         working-directory: ${{ github.workspace }}/podman-desktop
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm install
           pnpm test:e2e:build


### PR DESCRIPTION
### What does this PR do?

The Podman Desktop build step calls a download script that fetches GitHub releases, hitting the unauthenticated rate limit (60 req/hour). Passing GITHUB_TOKEN raises it to 5,000 req/hour.

Failing job: https://github.com/podman-desktop/extension-kubernetes-dashboard/actions/runs/29811642704/job/88576918135?pr=1196

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #1197 

### How to test this PR?

<!-- Please explain steps to reproduce -->
