### PR TITLE
fix: update monaco-editor imports for 0.56.0 module reorganization

### DIFF
--- a/packages/webview/src/component/editor/MonacoEditor.svelte
+++ b/packages/webview/src/component/editor/MonacoEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
-import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
+import type * as Monaco from 'monaco-editor';
 import type { HTMLAttributes } from 'svelte/elements';
 import { MonacoManager } from './monaco';
 

--- a/packages/webview/src/component/editor/monaco.ts
+++ b/packages/webview/src/component/editor/monaco.ts
@@ -1,19 +1,12 @@
-import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
+import type * as Monaco from 'monaco-editor';
 
 export class MonacoManager {
   protected static monaco: typeof Monaco | undefined;
 
-  protected static async importLanguages(): Promise<Awaited<unknown>[]> {
-    return Promise.all([import('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js')]);
-  }
-
   static async getMonaco(): Promise<typeof Monaco> {
     if (MonacoManager.monaco) return MonacoManager.monaco;
 
-    // import languages dynamically
-    await this.importLanguages();
-
-    // import monaco editor dynamically
+    // import monaco editor dynamically (languages are bundled in the main entry)
     this.monaco = await import('monaco-editor');
     this.registerTheme();
 

--- a/packages/webview/src/component/editor/monaco.ts
+++ b/packages/webview/src/component/editor/monaco.ts
@@ -7,11 +7,11 @@ export class MonacoManager {
     if (MonacoManager.monaco) return MonacoManager.monaco;
 
     // import monaco editor dynamically (languages are bundled in the main entry)
-    this.monaco = await import('monaco-editor');
-    this.registerTheme();
+    MonacoManager.monaco = await import('monaco-editor');
+    MonacoManager.registerTheme();
 
     // return the full monaco
-    return this.monaco;
+    return MonacoManager.monaco;
   }
 
   public static getThemeName(): string {
@@ -21,7 +21,7 @@ export class MonacoManager {
   protected static registerTheme(): void {
     if (!MonacoManager.monaco) throw new Error('cannot register theme if monaco is not imported');
 
-    const terminalBg = this.getTerminalBg();
+    const terminalBg = MonacoManager.getTerminalBg();
     const isDarkTheme: boolean = terminalBg === '#000000';
 
     // define custom theme

--- a/packages/webview/src/monaco-environment.ts
+++ b/packages/webview/src/monaco-environment.ts
@@ -1,5 +1,5 @@
-import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
-import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
+import editorWorker from 'monaco-editor/editor/editor.worker?worker';
+import jsonWorker from 'monaco-editor/language/json/json.worker?worker';
 
 self.MonacoEnvironment = {
   getWorker(_moduleId: unknown, languageId: string): Worker {


### PR DESCRIPTION
### What does this PR do?

0.56.0 reorganized ESM exports with a new package.json exports map, breaking deep internal imports like `esm/vs/editor/editor.api.js` and `esm/vs/basic-languages/yaml/yaml.contribution.js`. Switch to the main `monaco-editor` entry point which already re-exports the editor API and registers all languages.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes problem on https://github.com/podman-desktop/extension-kubernetes-dashboard/pull/1189

### How to test this PR?

<!-- Please explain steps to reproduce -->
