### PR TITLE
feat(networking): adds Endpoints resource view

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -83,6 +83,7 @@ import { RolesResourceFactory } from '/@/resources/roles-resource-factory.js';
 import { RoleBindingsResourceFactory } from '/@/resources/role-bindings-resource-factory.js';
 import { ClusterRolesResourceFactory } from '/@/resources/cluster-roles-resource-factory.js';
 import { ClusterRoleBindingsResourceFactory } from '/@/resources/cluster-role-bindings-resource-factory.js';
+import { EndpointsResourceFactory } from '/@/resources/endpoints-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -201,6 +202,7 @@ export class ContextsManager implements ContextsApi {
       new RoleBindingsResourceFactory(),
       new ClusterRolesResourceFactory(),
       new ClusterRoleBindingsResourceFactory(),
+      new EndpointsResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/endpoints-resource-factory.spec.ts
+++ b/packages/extension/src/resources/endpoints-resource-factory.spec.ts
@@ -1,0 +1,32 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { EndpointsResourceFactory } from './endpoints-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new EndpointsResourceFactory();
+  expect(factory.resource).toBe('endpoints');
+  expect(factory.kind).toBe('Endpoints');
+});
+
+test('deleteObject is defined', () => {
+  const factory = new EndpointsResourceFactory();
+  expect(factory.deleteObject).toBeDefined();
+});

--- a/packages/extension/src/resources/endpoints-resource-factory.ts
+++ b/packages/extension/src/resources/endpoints-resource-factory.ts
@@ -1,0 +1,70 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1Endpoints, V1EndpointsList, V1Status } from '@kubernetes/client-node';
+import { CoreV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class EndpointsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'endpoints',
+      kind: 'Endpoints',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'endpoints',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteEndpoints);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Endpoints> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    const listFn = (): Promise<V1EndpointsList> => apiClient.listNamespacedEndpoints({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/endpoints`;
+    return new ResourceInformer<V1Endpoints>({ kubeconfig, path, listFn, kind: this.kind, plural: 'endpoints' });
+  }
+
+  deleteEndpoints(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    return apiClient.deleteNamespacedEndpoints({ name, namespace });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -47,6 +47,8 @@ import ClusterRolesList from './component/cluster-roles/ClusterRolesList.svelte'
 import ClusterRoleDetails from './component/cluster-roles/ClusterRoleDetails.svelte';
 import ClusterRoleBindingsList from './component/cluster-role-bindings/ClusterRoleBindingsList.svelte';
 import ClusterRoleBindingDetails from './component/cluster-role-bindings/ClusterRoleBindingDetails.svelte';
+import EndpointsList from './component/endpoints/EndpointsList.svelte';
+import EndpointDetails from './component/endpoints/EndpointDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -243,5 +245,13 @@ const { meta }: Props = $props();
 
   <Route path="/roles/:name/:namespace/*" let:meta>
     <RoleDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/endpoints">
+    <EndpointsList />
+  </Route>
+
+  <Route path="/endpoints/:name/:namespace/*" let:meta>
+    <EndpointDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
   </Route>
 </div>

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -47,6 +47,7 @@ const configUrls = [navigator.kubernetesResourcesURL('ConfigMap'), navigator.kub
 
 const networkUrls = [
   navigator.kubernetesResourcesURL('Service'),
+  navigator.kubernetesResourcesURL('Endpoints'),
   navigator.kubernetesResourcesURL('Ingress'),
   '/portForward',
 ];
@@ -156,6 +157,7 @@ $effect(() => {
     <NavItem title="Network" icon={faNetworkWired} section={true} bind:expanded={networkExpanded} href="" />
     {#if networkExpanded}
       <NavItem title="Services" child={true} href={navigator.kubernetesResourcesURL('Service')} />
+      <NavItem title="Endpoints" child={true} href={navigator.kubernetesResourcesURL('Endpoints')} />
       <NavItem title="Ingresses &amp; Routes" child={true} href={navigator.kubernetesResourcesURL('Ingress')} />
       <NavItem title="Port Forwarding" child={true} href="/portForward" />
     {/if}

--- a/packages/webview/src/component/endpoints/EndpointDetails.svelte
+++ b/packages/webview/src/component/endpoints/EndpointDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { EndpointHelper } from './endpoint-helper';
+import type { EndpointUI } from './EndpointUI';
+import type { V1Endpoints } from '@kubernetes/client-node';
+import EndpointDetailsSummary from './EndpointDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const endpointHelper = dependencyAccessor.get<EndpointHelper>(EndpointHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1Endpoints}
+  typedUI={{} as EndpointUI}
+  kind="Endpoints"
+  resourceName="endpoints"
+  listName="Endpoints"
+  name={name}
+  namespace={namespace}
+  transformer={endpointHelper.getEndpointUI.bind(endpointHelper)}
+  SummaryComponent={EndpointDetailsSummary} />

--- a/packages/webview/src/component/endpoints/EndpointDetails.svelte
+++ b/packages/webview/src/component/endpoints/EndpointDetails.svelte
@@ -6,6 +6,7 @@ import { EndpointHelper } from './endpoint-helper';
 import type { EndpointUI } from './EndpointUI';
 import type { V1Endpoints } from '@kubernetes/client-node';
 import EndpointDetailsSummary from './EndpointDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -26,4 +27,5 @@ const endpointHelper = dependencyAccessor.get<EndpointHelper>(EndpointHelper);
   name={name}
   namespace={namespace}
   transformer={endpointHelper.getEndpointUI.bind(endpointHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={EndpointDetailsSummary} />

--- a/packages/webview/src/component/endpoints/EndpointDetailsSummary.svelte
+++ b/packages/webview/src/component/endpoints/EndpointDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1Endpoints } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1Endpoints;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/endpoints/EndpointUI.ts
+++ b/packages/webview/src/component/endpoints/EndpointUI.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface EndpointUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  endpoints: string;
+  ports: string;
+}

--- a/packages/webview/src/component/endpoints/EndpointsList.svelte
+++ b/packages/webview/src/component/endpoints/EndpointsList.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { EndpointUI } from './EndpointUI';
+import { EndpointHelper } from './endpoint-helper';
+import ActionsColumn from './columns/Actions.svelte';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const endpointHelper = dependencyAccessor.get<EndpointHelper>(EndpointHelper);
+
+let statusColumn = new TableColumn<EndpointUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<EndpointUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let endpointsColumn = new TableColumn<EndpointUI, string>('Endpoints', {
+  width: '2fr',
+  renderMapping: (obj): string => obj.endpoints,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.endpoints.localeCompare(b.endpoints),
+});
+
+let portsColumn = new TableColumn<EndpointUI, string>('Ports', {
+  renderMapping: (obj): string => obj.ports,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.ports.localeCompare(b.ports),
+});
+
+let ageColumn = new TableColumn<EndpointUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  endpointsColumn,
+  portsColumn,
+  ageColumn,
+  new TableColumn<EndpointUI>('Actions', { align: 'right', width: '150px', renderer: ActionsColumn, overflow: true }),
+];
+
+const row = new TableRow<EndpointUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'endpoints',
+      transformer: endpointHelper.getEndpointUI.bind(endpointHelper),
+    },
+  ]}
+  singular="endpoint"
+  plural="endpoints"
+  isNamespaced={true}
+  icon={icon['Endpoints']}
+  columns={columns}
+  row={row}>
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['Endpoints']} resources={['endpoints']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/endpoints/_endpoints-module.ts
+++ b/packages/webview/src/component/endpoints/_endpoints-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { EndpointHelper } from './endpoint-helper';
+
+const endpointsModule = new ContainerModule(options => {
+  options.bind<EndpointHelper>(EndpointHelper).toSelf().inSingletonScope();
+});
+
+export { endpointsModule };

--- a/packages/webview/src/component/endpoints/columns/Actions.svelte
+++ b/packages/webview/src/component/endpoints/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/endpoints/columns/props.ts
+++ b/packages/webview/src/component/endpoints/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { EndpointUI } from '/@/component/endpoints/EndpointUI';
+
+export interface Props {
+  object: EndpointUI;
+}

--- a/packages/webview/src/component/endpoints/endpoint-helper.spec.ts
+++ b/packages/webview/src/component/endpoints/endpoint-helper.spec.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Endpoints } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { EndpointHelper } from './endpoint-helper';
+
+let helper: EndpointHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new EndpointHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const obj = {
+    metadata: {
+      uid: 'uid-1',
+      name: 'my-endpoint',
+      namespace: 'default',
+      creationTimestamp: '2025-01-01T00:00:00Z',
+    },
+    subsets: [],
+  } as unknown as V1Endpoints;
+
+  const ui = helper.getEndpointUI(obj);
+  expect(ui.kind).toEqual('Endpoints');
+  expect(ui.name).toEqual('my-endpoint');
+  expect(ui.namespace).toEqual('default');
+  expect(ui.uid).toEqual('uid-1');
+  expect(ui.status).toEqual('RUNNING');
+  expect(ui.selected).toEqual(false);
+});
+
+test('expect endpoints from subsets addresses joined by comma', async () => {
+  const obj = {
+    metadata: { name: 'ep-1' },
+    subsets: [{ addresses: [{ ip: '10.0.0.1' }, { ip: '10.0.0.2' }] }, { addresses: [{ ip: '10.0.0.3' }] }],
+  } as unknown as V1Endpoints;
+
+  const ui = helper.getEndpointUI(obj);
+  expect(ui.endpoints).toEqual('10.0.0.1, 10.0.0.2, 10.0.0.3');
+});
+
+test('expect ports from subsets formatted as port/protocol', async () => {
+  const obj = {
+    metadata: { name: 'ep-1' },
+    subsets: [
+      {
+        ports: [
+          { port: 80, protocol: 'TCP' },
+          { port: 443, protocol: 'TCP' },
+        ],
+      },
+      { ports: [{ port: 8080, protocol: 'UDP' }] },
+    ],
+  } as unknown as V1Endpoints;
+
+  const ui = helper.getEndpointUI(obj);
+  expect(ui.ports).toEqual('80/TCP, 443/TCP, 8080/UDP');
+});

--- a/packages/webview/src/component/endpoints/endpoint-helper.ts
+++ b/packages/webview/src/component/endpoints/endpoint-helper.ts
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Endpoints } from '@kubernetes/client-node';
+
+import type { EndpointUI } from './EndpointUI';
+
+export class EndpointHelper {
+  getEndpointUI(obj: V1Endpoints): EndpointUI {
+    return {
+      kind: 'Endpoints',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: obj.metadata?.namespace ?? '',
+      created: obj.metadata?.creationTimestamp,
+      selected: false,
+      endpoints: (obj.subsets ?? []).flatMap(s => (s.addresses ?? []).map(a => a.ip)).join(', '),
+      ports: (obj.subsets ?? []).flatMap(s => (s.ports ?? []).map(p => `${p.port}/${p.protocol ?? 'TCP'}`)).join(', '),
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -49,6 +49,7 @@ import { rolesModule } from '/@/component/roles/_roles-module';
 import { roleBindingsModule } from '/@/component/role-bindings/_role-bindings-module';
 import { clusterRolesModule } from '/@/component/cluster-roles/_cluster-roles-module';
 import { clusterRoleBindingsModule } from '/@/component/cluster-role-bindings/_cluster-role-bindings-module';
+import { endpointsModule } from '/@/component/endpoints/_endpoints-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -92,6 +93,7 @@ export class InversifyBinding {
     await this.#container.load(roleBindingsModule);
     await this.#container.load(clusterRolesModule);
     await this.#container.load(clusterRoleBindingsModule);
+    await this.#container.load(endpointsModule);
 
     return this.#container;
   }

--- a/packages/webview/src/navigation/navigator.ts
+++ b/packages/webview/src/navigation/navigator.ts
@@ -79,6 +79,8 @@ export class Navigator {
       return 'configmapsSecrets';
     } else if (kind === 'StorageClass') {
       return 'storageclasses';
+    } else if (kind === 'Endpoints') {
+      return 'endpoints';
     }
     // otherwise do the simple conversion
     return kind.toLowerCase() + 's';

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -195,6 +195,12 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     await playExpect.poll(async () => ingresssRoutesPage.isEmpty('No ingresses or routes')).toBeTruthy();
   });
 
+  test('go to endpoints page', async () => {
+    const endpointsPage = await navigation.openTabPage(KubernetesResources.Endpoints);
+    await playExpect(endpointsPage.heading).toBeVisible();
+    await playExpect.poll(async () => endpointsPage.rowsAreVisible()).toBeTruthy();
+  });
+
   test('go to pvc page', async () => {
     const pvcPage = await navigation.openTabPage(KubernetesResources.PVCs);
     await playExpect(pvcPage.heading).toBeVisible();
@@ -537,6 +543,18 @@ test.describe('With resources', { tag: '@integration' }, () => {
       KubernetesResources.StorageClasses,
     );
     await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+  });
+
+  test('go to endpoint1 page', async () => {
+    const endpointsPage = await navigation.openTabPage(KubernetesResources.Endpoints);
+    await playExpect(endpointsPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await endpointsPage.openResourceDetails(
+      'endpoint1',
+      KubernetesResources.Endpoints,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
   });
 });
 

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -33,6 +33,7 @@ export enum KubernetesResources {
   ReplicaSets = 'ReplicaSets',
   Services = 'Services',
   IngressesRoutes = 'Ingresses & Routes',
+  Endpoints = 'Endpoints',
   PVCs = 'Persistent Volume Claims',
   PersistentVolumes = 'Persistent Volumes',
   StorageClasses = 'Storage Classes',
@@ -57,6 +58,7 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   [KubernetesResources.ReplicaSets]: ['Status', 'Name', 'Desired', 'Current', 'Ready', 'Owner', 'Age'],
   [KubernetesResources.Services]: ['Selected', 'Status', 'Name', 'Type', 'Cluster IP', 'Ports', 'Age', 'Actions'],
   [KubernetesResources.IngressesRoutes]: ['Selected', 'Status', 'Name', 'Host/Path', 'Backend', 'Age', 'Actions'],
+  [KubernetesResources.Endpoints]: ['Selected', 'Status', 'Name', 'Endpoints', 'Ports', 'Age', 'Actions'],
   [KubernetesResources.PVCs]: ['Selected', 'Status', 'Name', 'Environment', 'Age', 'Size', 'Actions'],
   [KubernetesResources.PersistentVolumes]: [
     'Selected',

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -34,6 +34,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.ConfigMapsSecrets]: NavSection.Config,
   [KubernetesResources.Services]: NavSection.Network,
   [KubernetesResources.IngressesRoutes]: NavSection.Network,
+  [KubernetesResources.Endpoints]: NavSection.Network,
   [KubernetesResources.PortForwarding]: NavSection.Network,
   [KubernetesResources.PVCs]: NavSection.Storage,
   [KubernetesResources.PersistentVolumes]: NavSection.Storage,

--- a/tests/resources/cluster-resources.yaml
+++ b/tests/resources/cluster-resources.yaml
@@ -899,3 +899,17 @@ provisioner: kubernetes.io/no-provisioner
 reclaimPolicy: Retain
 volumeBindingMode: WaitForFirstConsumer
 ---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  creationTimestamp: '2026-02-09T10:15:00Z'
+  name: endpoint1
+  namespace: default
+  uid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+subsets:
+  - addresses:
+      - ip: 10.0.0.1
+    ports:
+      - port: 8080
+        protocol: TCP
+---


### PR DESCRIPTION
feat(networking): adds Endpoints resource view

### What does this PR do?

Adds Endpoints resource view under the Network navigation section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/e51d953b-7c37-4b89-b65f-733da148ae2c

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/980

### How to test this PR?

1. Build extension
2. Go to Endpoints section and confirm that artifacts appear there

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
