### PR TITLE
feat(networking): adds Ingress Classes resource view

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -85,6 +85,7 @@ import { ClusterRolesResourceFactory } from '/@/resources/cluster-roles-resource
 import { ClusterRoleBindingsResourceFactory } from '/@/resources/cluster-role-bindings-resource-factory.js';
 import { EndpointsResourceFactory } from '/@/resources/endpoints-resource-factory.js';
 import { NetworkPoliciesResourceFactory } from '/@/resources/network-policies-resource-factory.js';
+import { IngressClassesResourceFactory } from '/@/resources/ingress-classes-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -205,6 +206,7 @@ export class ContextsManager implements ContextsApi {
       new ClusterRoleBindingsResourceFactory(),
       new EndpointsResourceFactory(),
       new NetworkPoliciesResourceFactory(),
+      new IngressClassesResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/ingress-classes-resource-factory.spec.ts
+++ b/packages/extension/src/resources/ingress-classes-resource-factory.spec.ts
@@ -1,0 +1,32 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { IngressClassesResourceFactory } from './ingress-classes-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new IngressClassesResourceFactory();
+  expect(factory.resource).toBe('ingressclasses');
+  expect(factory.kind).toBe('IngressClass');
+});
+
+test('deleteObject is defined', () => {
+  const factory = new IngressClassesResourceFactory();
+  expect(factory.deleteObject).toBeDefined();
+});

--- a/packages/extension/src/resources/ingress-classes-resource-factory.ts
+++ b/packages/extension/src/resources/ingress-classes-resource-factory.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1IngressClass, V1IngressClassList, V1Status } from '@kubernetes/client-node';
+import { NetworkingV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class IngressClassesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'ingressclasses',
+      kind: 'IngressClass',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'networking.k8s.io',
+          resource: 'ingressclasses',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteIngressClass);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1IngressClass> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(NetworkingV1Api);
+    const listFn = (): Promise<V1IngressClassList> => apiClient.listIngressClass();
+    const path = `/apis/networking.k8s.io/v1/ingressclasses`;
+    return new ResourceInformer<V1IngressClass>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'ingressclasses',
+    });
+  }
+
+  deleteIngressClass(kubeconfig: KubeConfigSingleContext, name: string): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(NetworkingV1Api);
+    return apiClient.deleteIngressClass({ name });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -219,6 +219,8 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
   <Route path="/ingressclasses">
     <IngressClassesList />
   </Route>

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -53,6 +53,8 @@ import EndpointSlicesList from './component/endpoint-slices/EndpointSlicesList.s
 import EndpointSliceDetails from './component/endpoint-slices/EndpointSliceDetails.svelte';
 import NetworkPoliciesList from './component/network-policies/NetworkPoliciesList.svelte';
 import NetworkPolicyDetails from './component/network-policies/NetworkPolicyDetails.svelte';
+import IngressClassesList from './component/ingress-classes/IngressClassesList.svelte';
+import IngressClassDetails from './component/ingress-classes/IngressClassDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -217,6 +219,12 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  <Route path="/ingressclasses">
+    <IngressClassesList />
+  </Route>
+
+  <Route path="/ingressclasses/:name/*" let:meta>
+    <IngressClassDetails name={decodeURI(meta.params.name)} />
   </Route>
 
   <Route path="/networkpolicies">

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -51,6 +51,7 @@ const networkUrls = [
   navigator.kubernetesResourcesURL('EndpointSlice'),
   navigator.kubernetesResourcesURL('Ingress'),
   navigator.kubernetesResourcesURL('NetworkPolicy'),
+  navigator.kubernetesResourcesURL('IngressClass'),
   '/portForward',
 ];
 
@@ -163,6 +164,7 @@ $effect(() => {
       <NavItem title="Endpoint Slices" child={true} href={navigator.kubernetesResourcesURL('EndpointSlice')} />
       <NavItem title="Ingresses &amp; Routes" child={true} href={navigator.kubernetesResourcesURL('Ingress')} />
       <NavItem title="Network Policies" child={true} href={navigator.kubernetesResourcesURL('NetworkPolicy')} />
+      <NavItem title="Ingress Classes" child={true} href={navigator.kubernetesResourcesURL('IngressClass')} />
       <NavItem title="Port Forwarding" child={true} href="/portForward" />
     {/if}
 

--- a/packages/webview/src/component/ingress-classes/IngressClassDetails.svelte
+++ b/packages/webview/src/component/ingress-classes/IngressClassDetails.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { IngressClassHelper } from './ingress-class-helper';
+import type { IngressClassUI } from './IngressClassUI';
+import type { V1IngressClass } from '@kubernetes/client-node';
+import IngressClassDetailsSummary from './IngressClassDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+}
+let { name }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const ingressClassHelper = dependencyAccessor.get<IngressClassHelper>(IngressClassHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1IngressClass}
+  typedUI={{} as IngressClassUI}
+  kind="IngressClass"
+  resourceName="ingressclasses"
+  listName="Ingress Classes"
+  name={name}
+  transformer={ingressClassHelper.getIngressClassUI.bind(ingressClassHelper)}
+  SummaryComponent={IngressClassDetailsSummary} />

--- a/packages/webview/src/component/ingress-classes/IngressClassDetails.svelte
+++ b/packages/webview/src/component/ingress-classes/IngressClassDetails.svelte
@@ -6,6 +6,7 @@ import { IngressClassHelper } from './ingress-class-helper';
 import type { IngressClassUI } from './IngressClassUI';
 import type { V1IngressClass } from '@kubernetes/client-node';
 import IngressClassDetailsSummary from './IngressClassDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -24,4 +25,5 @@ const ingressClassHelper = dependencyAccessor.get<IngressClassHelper>(IngressCla
   listName="Ingress Classes"
   name={name}
   transformer={ingressClassHelper.getIngressClassUI.bind(ingressClassHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={IngressClassDetailsSummary} />

--- a/packages/webview/src/component/ingress-classes/IngressClassDetailsSummary.svelte
+++ b/packages/webview/src/component/ingress-classes/IngressClassDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1IngressClass } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1IngressClass;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/ingress-classes/IngressClassUI.ts
+++ b/packages/webview/src/component/ingress-classes/IngressClassUI.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface IngressClassUI extends KubernetesObjectUI {
+  uid: string;
+  created?: Date;
+  controller: string;
+  isDefault: string;
+}

--- a/packages/webview/src/component/ingress-classes/IngressClassesList.svelte
+++ b/packages/webview/src/component/ingress-classes/IngressClassesList.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { IngressClassUI } from './IngressClassUI';
+import { IngressClassHelper } from './ingress-class-helper';
+import DefaultColumn from './columns/Default.svelte';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const ingressClassHelper = dependencyAccessor.get<IngressClassHelper>(IngressClassHelper);
+
+let statusColumn = new TableColumn<IngressClassUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<IngressClassUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let controllerColumn = new TableColumn<IngressClassUI, string>('Controller', {
+  width: '2fr',
+  renderMapping: (obj): string => obj.controller,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.controller.localeCompare(b.controller),
+});
+
+let isDefaultColumn = new TableColumn<IngressClassUI>('Default', {
+  renderer: DefaultColumn,
+  comparator: (a, b): number => a.isDefault.localeCompare(b.isDefault),
+});
+
+let ageColumn = new TableColumn<IngressClassUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [statusColumn, nameColumn, controllerColumn, isDefaultColumn, ageColumn];
+
+const row = new TableRow<IngressClassUI>({});
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'ingressclasses',
+      transformer: ingressClassHelper.getIngressClassUI.bind(ingressClassHelper),
+    },
+  ]}
+  singular="ingress class"
+  plural="ingress classes"
+  isNamespaced={false}
+  icon={icon['IngressClass']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['IngressClass']} resources={['ingressclasses']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/ingress-classes/IngressClassesList.svelte
+++ b/packages/webview/src/component/ingress-classes/IngressClassesList.svelte
@@ -11,6 +11,7 @@ import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.sv
 import { icon } from '/@/component/icons/icon';
 import type { IngressClassUI } from './IngressClassUI';
 import { IngressClassHelper } from './ingress-class-helper';
+import ActionsColumn from './columns/Actions.svelte';
 import DefaultColumn from './columns/Default.svelte';
 
 const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
@@ -47,9 +48,20 @@ let ageColumn = new TableColumn<IngressClassUI, Date | undefined>('Age', {
   comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
 });
 
-const columns = [statusColumn, nameColumn, controllerColumn, isDefaultColumn, ageColumn];
+const columns = [
+  statusColumn,
+  nameColumn,
+  controllerColumn,
+  isDefaultColumn,
+  ageColumn,
+  new TableColumn<IngressClassUI>('Actions', {
+    align: 'right',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
 
-const row = new TableRow<IngressClassUI>({});
+const row = new TableRow<IngressClassUI>({ selectable: (_obj): boolean => true });
 </script>
 
 <KubernetesObjectsList

--- a/packages/webview/src/component/ingress-classes/_ingress-classes-module.ts
+++ b/packages/webview/src/component/ingress-classes/_ingress-classes-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { IngressClassHelper } from './ingress-class-helper';
+
+const ingressClassesModule = new ContainerModule(options => {
+  options.bind<IngressClassHelper>(IngressClassHelper).toSelf().inSingletonScope();
+});
+
+export { ingressClassesModule };

--- a/packages/webview/src/component/ingress-classes/columns/Actions.svelte
+++ b/packages/webview/src/component/ingress-classes/columns/Actions.svelte
@@ -1,4 +1,4 @@
-/**********************************************************************
+<!--********************************************************************
  * Copyright (C) 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- ***********************************************************************/
+ **********************************************************************-->
 <script lang="ts">
 import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
 import type { Props } from './props';

--- a/packages/webview/src/component/ingress-classes/columns/Actions.svelte
+++ b/packages/webview/src/component/ingress-classes/columns/Actions.svelte
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/ingress-classes/columns/Default.svelte
+++ b/packages/webview/src/component/ingress-classes/columns/Default.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+{object.isDefault}

--- a/packages/webview/src/component/ingress-classes/columns/props.ts
+++ b/packages/webview/src/component/ingress-classes/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IngressClassUI } from '/@/component/ingress-classes/IngressClassUI';
+
+export interface Props {
+  object: IngressClassUI;
+}

--- a/packages/webview/src/component/ingress-classes/ingress-class-helper.spec.ts
+++ b/packages/webview/src/component/ingress-classes/ingress-class-helper.spec.ts
@@ -1,0 +1,74 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1IngressClass } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { IngressClassHelper } from './ingress-class-helper';
+
+let helper: IngressClassHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new IngressClassHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const obj = {
+    metadata: {
+      uid: 'uid-1',
+      name: 'nginx',
+      creationTimestamp: '2025-01-01T00:00:00Z',
+    },
+    spec: {
+      controller: 'k8s.io/ingress-nginx',
+    },
+  } as unknown as V1IngressClass;
+
+  const ui = helper.getIngressClassUI(obj);
+  expect(ui.kind).toEqual('IngressClass');
+  expect(ui.name).toEqual('nginx');
+  expect(ui.uid).toEqual('uid-1');
+  expect(ui.status).toEqual('RUNNING');
+  expect(ui.controller).toEqual('k8s.io/ingress-nginx');
+});
+
+test('expect isDefault true when annotation is true', async () => {
+  const obj = {
+    metadata: {
+      name: 'nginx',
+      annotations: {
+        'ingressclass.kubernetes.io/is-default-class': 'true',
+      },
+    },
+    spec: { controller: 'k8s.io/ingress-nginx' },
+  } as unknown as V1IngressClass;
+
+  const ui = helper.getIngressClassUI(obj);
+  expect(ui.isDefault).toEqual('true');
+});
+
+test('expect isDefault false when annotation is missing', async () => {
+  const obj = {
+    metadata: { name: 'nginx' },
+    spec: { controller: 'k8s.io/ingress-nginx' },
+  } as unknown as V1IngressClass;
+
+  const ui = helper.getIngressClassUI(obj);
+  expect(ui.isDefault).toEqual('false');
+});

--- a/packages/webview/src/component/ingress-classes/ingress-class-helper.ts
+++ b/packages/webview/src/component/ingress-classes/ingress-class-helper.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1IngressClass } from '@kubernetes/client-node';
+
+import type { IngressClassUI } from './IngressClassUI';
+
+export class IngressClassHelper {
+  getIngressClassUI(obj: V1IngressClass): IngressClassUI {
+    return {
+      kind: 'IngressClass',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      created: obj.metadata?.creationTimestamp,
+      controller: obj.spec?.controller ?? '',
+      isDefault:
+        obj.metadata?.annotations?.['ingressclass.kubernetes.io/is-default-class'] === 'true' ? 'true' : 'false',
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -52,6 +52,7 @@ import { clusterRoleBindingsModule } from '/@/component/cluster-role-bindings/_c
 import { endpointsModule } from '/@/component/endpoints/_endpoints-module';
 import { endpointSlicesModule } from '/@/component/endpoint-slices/_endpoint-slices-module';
 import { networkPoliciesModule } from '/@/component/network-policies/_network-policies-module';
+import { ingressClassesModule } from '/@/component/ingress-classes/_ingress-classes-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -98,6 +99,7 @@ export class InversifyBinding {
     await this.#container.load(endpointsModule);
     await this.#container.load(endpointSlicesModule);
     await this.#container.load(networkPoliciesModule);
+    await this.#container.load(ingressClassesModule);
 
     return this.#container;
   }

--- a/packages/webview/src/navigation/navigator.ts
+++ b/packages/webview/src/navigation/navigator.ts
@@ -83,6 +83,8 @@ export class Navigator {
       return 'endpoints';
     } else if (kind === 'NetworkPolicy') {
       return 'networkpolicies';
+    } else if (kind === 'IngressClass') {
+      return 'ingressclasses';
     }
     // otherwise do the simple conversion
     return kind.toLowerCase() + 's';

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -213,6 +213,12 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     await playExpect.poll(async () => networkPoliciesPage.isEmpty('No networkpolicies')).toBeTruthy();
   });
 
+  test('go to ingress classes page', async () => {
+    const ingressClassesPage = await navigation.openTabPage(KubernetesResources.IngressClasses);
+    await playExpect(ingressClassesPage.heading).toBeVisible();
+    await playExpect.poll(async () => ingressClassesPage.isEmpty('No ingressclasses')).toBeTruthy();
+  });
+
   test('go to pvc page', async () => {
     const pvcPage = await navigation.openTabPage(KubernetesResources.PVCs);
     await playExpect(pvcPage.heading).toBeVisible();
@@ -576,6 +582,18 @@ test.describe('With resources', { tag: '@integration' }, () => {
     const kubernetesResourceDetails = await networkPoliciesPage.openResourceDetails(
       'network-policy1',
       KubernetesResources.NetworkPolicies,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to ingress-class1 page', async () => {
+    const ingressClassesPage = await navigation.openTabPage(KubernetesResources.IngressClasses);
+    await playExpect(ingressClassesPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await ingressClassesPage.openResourceDetails(
+      'ingress-class1',
+      KubernetesResources.IngressClasses,
     );
     await playExpect(kubernetesResourceDetails.heading).toBeVisible();
     await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -590,6 +590,7 @@ test.describe('With resources', { tag: '@integration' }, () => {
   test('go to ingress-class1 page', async () => {
     const ingressClassesPage = await navigation.openTabPage(KubernetesResources.IngressClasses);
     await playExpect(ingressClassesPage.heading).toBeVisible();
+    await playExpect.poll(async () => ingressClassesPage.rowsAreVisible()).toBeTruthy();
 
     const kubernetesResourceDetails = await ingressClassesPage.openResourceDetails(
       'ingress-class1',

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -36,6 +36,7 @@ export enum KubernetesResources {
   Endpoints = 'Endpoints',
   EndpointSlices = 'Endpoint Slices',
   NetworkPolicies = 'Network Policies',
+  IngressClasses = 'Ingress Classes',
   PVCs = 'Persistent Volume Claims',
   PersistentVolumes = 'Persistent Volumes',
   StorageClasses = 'Storage Classes',
@@ -81,6 +82,7 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
     'Age',
     'Actions',
   ],
+  [KubernetesResources.IngressClasses]: ['Status', 'Name', 'Controller', 'Default', 'Age'],
   [KubernetesResources.PVCs]: ['Selected', 'Status', 'Name', 'Environment', 'Age', 'Size', 'Actions'],
   [KubernetesResources.PersistentVolumes]: [
     'Selected',

--- a/tests/playwright/src/model/pages/kubernetes-resource-page.ts
+++ b/tests/playwright/src/model/pages/kubernetes-resource-page.ts
@@ -72,7 +72,11 @@ export class KubernetesResourcePage extends MainPage {
       const resourceRow = await this.fetchKubernetesResource(resourceName, timeout);
 
       let resourceRowName: Locator;
-      if (resourceType === KubernetesResources.Nodes || resourceType === KubernetesResources.StorageClasses) {
+      if (
+        resourceType === KubernetesResources.Nodes ||
+        resourceType === KubernetesResources.StorageClasses ||
+        resourceType === KubernetesResources.IngressClasses
+      ) {
         resourceRowName = resourceRow.getByRole('cell').nth(2);
       } else {
         resourceRowName = resourceRow.getByRole('cell').nth(3);

--- a/tests/playwright/src/model/pages/kubernetes-resource-page.ts
+++ b/tests/playwright/src/model/pages/kubernetes-resource-page.ts
@@ -72,11 +72,7 @@ export class KubernetesResourcePage extends MainPage {
       const resourceRow = await this.fetchKubernetesResource(resourceName, timeout);
 
       let resourceRowName: Locator;
-      if (
-        resourceType === KubernetesResources.Nodes ||
-        resourceType === KubernetesResources.StorageClasses ||
-        resourceType === KubernetesResources.IngressClasses
-      ) {
+      if (resourceType === KubernetesResources.Nodes || resourceType === KubernetesResources.StorageClasses) {
         resourceRowName = resourceRow.getByRole('cell').nth(2);
       } else {
         resourceRowName = resourceRow.getByRole('cell').nth(3);

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -37,6 +37,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.Endpoints]: NavSection.Network,
   [KubernetesResources.EndpointSlices]: NavSection.Network,
   [KubernetesResources.NetworkPolicies]: NavSection.Network,
+  [KubernetesResources.IngressClasses]: NavSection.Network,
   [KubernetesResources.PortForwarding]: NavSection.Network,
   [KubernetesResources.PVCs]: NavSection.Storage,
   [KubernetesResources.PersistentVolumes]: NavSection.Storage,
@@ -98,6 +99,8 @@ export class KubernetesBar {
         return new KubernetesResourcePage(this.page, 'endpoint slices');
       case 'Network Policies':
         return new KubernetesResourcePage(this.page, 'network policies');
+      case 'Ingress Classes':
+        return new KubernetesResourcePage(this.page, 'ingress classes');
       default:
         return new KubernetesResourcePage(this.page, kubernetesResource);
     }

--- a/tests/resources/cluster-resources.yaml
+++ b/tests/resources/cluster-resources.yaml
@@ -944,3 +944,12 @@ spec:
         - protocol: TCP
           port: 8080
 ---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  creationTimestamp: '2026-02-09T10:17:00Z'
+  name: ingress-class1
+  uid: c3d4e5f6-a7b8-9012-cdef-123456789012
+spec:
+  controller: example.com/ingress-controller
+---


### PR DESCRIPTION
feat(networking): adds Ingress Classes resource view

### What does this PR do?

Adds Ingress Classes resource view under the Network navigation section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/e51d953b-7c37-4b89-b65f-733da148ae2c

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/980

### How to test this PR?

1. Build extension
2. Go to Ingress Classes section and confirm that artifacts appear there

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
