### PR TITLE
feat(networking): adds Gateway Classes resource view

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -87,6 +87,7 @@ import { EndpointsResourceFactory } from '/@/resources/endpoints-resource-factor
 import { NetworkPoliciesResourceFactory } from '/@/resources/network-policies-resource-factory.js';
 import { IngressClassesResourceFactory } from '/@/resources/ingress-classes-resource-factory.js';
 import { HttpRoutesResourceFactory } from '/@/resources/httproutes-resource-factory.js';
+import { GatewayClassesResourceFactory } from '/@/resources/gatewayclasses-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -209,6 +210,7 @@ export class ContextsManager implements ContextsApi {
       new NetworkPoliciesResourceFactory(),
       new IngressClassesResourceFactory(),
       new HttpRoutesResourceFactory(),
+      new GatewayClassesResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/gatewayclasses-resource-factory.spec.ts
+++ b/packages/extension/src/resources/gatewayclasses-resource-factory.spec.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { GatewayClassesResourceFactory } from './gatewayclasses-resource-factory.js';
+
+test('factory has correct resource and kind', () => {
+  const factory = new GatewayClassesResourceFactory();
+  expect(factory.resource).toBe('gatewayclasses');
+  expect(factory.kind).toBe('GatewayClass');
+});

--- a/packages/extension/src/resources/gatewayclasses-resource-factory.ts
+++ b/packages/extension/src/resources/gatewayclasses-resource-factory.ts
@@ -1,0 +1,86 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesListObject, KubernetesObject, V1Status } from '@kubernetes/client-node';
+import { CustomObjectsApi } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+const GROUP = 'gateway.networking.k8s.io';
+const VERSION = 'v1';
+const PLURAL = 'gatewayclasses';
+
+export class GatewayClassesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: PLURAL,
+      kind: 'GatewayClass',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: GROUP,
+          resource: PLURAL,
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteGatewayClass);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CustomObjectsApi);
+    const listFn = (): Promise<KubernetesListObject<KubernetesObject>> =>
+      apiClient.listClusterCustomObject({
+        group: GROUP,
+        version: VERSION,
+        plural: PLURAL,
+      }) as Promise<KubernetesListObject<KubernetesObject>>;
+    const path = `/apis/${GROUP}/${VERSION}/${PLURAL}`;
+    return new ResourceInformer<KubernetesObject>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: PLURAL,
+    });
+  }
+
+  deleteGatewayClass(kubeconfig: KubeConfigSingleContext, name: string): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CustomObjectsApi);
+    return apiClient.deleteClusterCustomObject({
+      group: GROUP,
+      version: VERSION,
+      plural: PLURAL,
+      name,
+    }) as Promise<V1Status | KubernetesObject>;
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -57,6 +57,8 @@ import IngressClassesList from './component/ingress-classes/IngressClassesList.s
 import IngressClassDetails from './component/ingress-classes/IngressClassDetails.svelte';
 import HttpRoutesList from './component/httproutes/HttpRoutesList.svelte';
 import HttpRouteDetails from './component/httproutes/HttpRouteDetails.svelte';
+import GatewayClassesList from './component/gatewayclasses/GatewayClassesList.svelte';
+import GatewayClassDetails from './component/gatewayclasses/GatewayClassDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -221,6 +223,14 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/gatewayclasses">
+    <GatewayClassesList />
+  </Route>
+
+  <Route path="/gatewayclasses/:name/*" let:meta>
+    <GatewayClassDetails name={decodeURI(meta.params.name)} />
   </Route>
 
   <Route path="/httproutes">

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -52,6 +52,7 @@ const networkUrls = [
   navigator.kubernetesResourcesURL('Ingress'),
   navigator.kubernetesResourcesURL('NetworkPolicy'),
   navigator.kubernetesResourcesURL('IngressClass'),
+  navigator.kubernetesResourcesURL('GatewayClass'),
   navigator.kubernetesResourcesURL('HTTPRoute'),
   '/portForward',
 ];
@@ -166,6 +167,7 @@ $effect(() => {
       <NavItem title="Ingresses &amp; Routes" child={true} href={navigator.kubernetesResourcesURL('Ingress')} />
       <NavItem title="Network Policies" child={true} href={navigator.kubernetesResourcesURL('NetworkPolicy')} />
       <NavItem title="Ingress Classes" child={true} href={navigator.kubernetesResourcesURL('IngressClass')} />
+      <NavItem title="Gateway Classes" child={true} href={navigator.kubernetesResourcesURL('GatewayClass')} />
       <NavItem title="HTTPRoutes" child={true} href={navigator.kubernetesResourcesURL('HTTPRoute')} />
       <NavItem title="Port Forwarding" child={true} href="/portForward" />
     {/if}

--- a/packages/webview/src/component/gatewayclasses/GatewayClassDetails.svelte
+++ b/packages/webview/src/component/gatewayclasses/GatewayClassDetails.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { GatewayClassHelper } from './gatewayclass-helper';
+import type { GatewayClassUI } from './GatewayClassUI';
+import type { KubernetesObject } from '@kubernetes/client-node';
+import GatewayClassDetailsSummary from './GatewayClassDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+}
+let { name }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const gatewayClassHelper = dependencyAccessor.get<GatewayClassHelper>(GatewayClassHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as KubernetesObject}
+  typedUI={{} as GatewayClassUI}
+  kind="GatewayClass"
+  resourceName="gatewayclasses"
+  listName="Gateway Classes"
+  name={name}
+  transformer={gatewayClassHelper.getGatewayClassUI.bind(gatewayClassHelper)}
+  SummaryComponent={GatewayClassDetailsSummary} />

--- a/packages/webview/src/component/gatewayclasses/GatewayClassDetails.svelte
+++ b/packages/webview/src/component/gatewayclasses/GatewayClassDetails.svelte
@@ -6,6 +6,7 @@ import { GatewayClassHelper } from './gatewayclass-helper';
 import type { GatewayClassUI } from './GatewayClassUI';
 import type { KubernetesObject } from '@kubernetes/client-node';
 import GatewayClassDetailsSummary from './GatewayClassDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -24,4 +25,5 @@ const gatewayClassHelper = dependencyAccessor.get<GatewayClassHelper>(GatewayCla
   listName="Gateway Classes"
   name={name}
   transformer={gatewayClassHelper.getGatewayClassUI.bind(gatewayClassHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={GatewayClassDetailsSummary} />

--- a/packages/webview/src/component/gatewayclasses/GatewayClassDetailsSummary.svelte
+++ b/packages/webview/src/component/gatewayclasses/GatewayClassDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { KubernetesObject } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: KubernetesObject;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/gatewayclasses/GatewayClassUI.ts
+++ b/packages/webview/src/component/gatewayclasses/GatewayClassUI.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI.ts';
+
+export interface GatewayClassUI extends KubernetesObjectUI {
+  uid: string;
+  controller: string;
+  created?: Date;
+}

--- a/packages/webview/src/component/gatewayclasses/GatewayClassesList.svelte
+++ b/packages/webview/src/component/gatewayclasses/GatewayClassesList.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { GatewayClassUI } from './GatewayClassUI';
+import { GatewayClassHelper } from './gatewayclass-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const gatewayClassHelper = dependencyAccessor.get<GatewayClassHelper>(GatewayClassHelper);
+
+let statusColumn = new TableColumn<GatewayClassUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<GatewayClassUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let controllerColumn = new TableColumn<GatewayClassUI, string>('Controller', {
+  width: '2fr',
+  renderMapping: (obj): string => obj.controller,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.controller.localeCompare(b.controller),
+});
+
+let ageColumn = new TableColumn<GatewayClassUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [statusColumn, nameColumn, controllerColumn, ageColumn];
+
+const row = new TableRow<GatewayClassUI>({});
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'gatewayclasses',
+      transformer: gatewayClassHelper.getGatewayClassUI.bind(gatewayClassHelper),
+    },
+  ]}
+  singular="gateway class"
+  plural="gateway classes"
+  isNamespaced={false}
+  icon={icon['GatewayClass']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['GatewayClass']} resources={['gatewayclasses']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/gatewayclasses/GatewayClassesList.svelte
+++ b/packages/webview/src/component/gatewayclasses/GatewayClassesList.svelte
@@ -11,6 +11,7 @@ import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.sv
 import { icon } from '/@/component/icons/icon';
 import type { GatewayClassUI } from './GatewayClassUI';
 import { GatewayClassHelper } from './gatewayclass-helper';
+import ActionsColumn from './columns/Actions.svelte';
 
 const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
 const gatewayClassHelper = dependencyAccessor.get<GatewayClassHelper>(GatewayClassHelper);
@@ -41,9 +42,19 @@ let ageColumn = new TableColumn<GatewayClassUI, Date | undefined>('Age', {
   comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
 });
 
-const columns = [statusColumn, nameColumn, controllerColumn, ageColumn];
+const columns = [
+  statusColumn,
+  nameColumn,
+  controllerColumn,
+  ageColumn,
+  new TableColumn<GatewayClassUI>('Actions', {
+    align: 'right',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
 
-const row = new TableRow<GatewayClassUI>({});
+const row = new TableRow<GatewayClassUI>({ selectable: (_obj): boolean => true });
 </script>
 
 <KubernetesObjectsList

--- a/packages/webview/src/component/gatewayclasses/_gatewayclasses-module.ts
+++ b/packages/webview/src/component/gatewayclasses/_gatewayclasses-module.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { GatewayClassHelper } from './gatewayclass-helper';
+
+const gatewayClassesModule = new ContainerModule(options => {
+  options.bind<GatewayClassHelper>(GatewayClassHelper).toSelf().inSingletonScope();
+});
+
+export { gatewayClassesModule };

--- a/packages/webview/src/component/gatewayclasses/columns/Actions.svelte
+++ b/packages/webview/src/component/gatewayclasses/columns/Actions.svelte
@@ -1,4 +1,4 @@
-/**********************************************************************
+<!--********************************************************************
  * Copyright (C) 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- ***********************************************************************/
+ **********************************************************************-->
 <script lang="ts">
 import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
 import type { Props } from './props';

--- a/packages/webview/src/component/gatewayclasses/columns/Actions.svelte
+++ b/packages/webview/src/component/gatewayclasses/columns/Actions.svelte
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/gatewayclasses/columns/props.ts
+++ b/packages/webview/src/component/gatewayclasses/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { GatewayClassUI } from '/@/component/gatewayclasses/GatewayClassUI';
+
+export interface Props {
+  object: GatewayClassUI;
+}

--- a/packages/webview/src/component/gatewayclasses/gatewayclass-helper.spec.ts
+++ b/packages/webview/src/component/gatewayclasses/gatewayclass-helper.spec.ts
@@ -1,0 +1,70 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { GatewayClassHelper } from './gatewayclass-helper';
+
+let helper: GatewayClassHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new GatewayClassHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const obj = {
+    metadata: {
+      uid: 'uid-1',
+      name: 'istio',
+      creationTimestamp: '2025-01-01T00:00:00Z',
+    },
+    spec: {
+      controllerName: 'istio.io/gateway-controller',
+    },
+  } as unknown as KubernetesObject;
+
+  const ui = helper.getGatewayClassUI(obj);
+  expect(ui.kind).toEqual('GatewayClass');
+  expect(ui.name).toEqual('istio');
+  expect(ui.uid).toEqual('uid-1');
+  expect(ui.status).toEqual('RUNNING');
+});
+
+test('expect controller from spec.controllerName', async () => {
+  const obj = {
+    metadata: { name: 'nginx' },
+    spec: {
+      controllerName: 'nginx.org/gateway-controller',
+    },
+  } as unknown as KubernetesObject;
+
+  const ui = helper.getGatewayClassUI(obj);
+  expect(ui.controller).toEqual('nginx.org/gateway-controller');
+});
+
+test('expect controller empty when spec has no controllerName', async () => {
+  const obj = {
+    metadata: { name: 'empty' },
+    spec: {},
+  } as unknown as KubernetesObject;
+
+  const ui = helper.getGatewayClassUI(obj);
+  expect(ui.controller).toEqual('');
+});

--- a/packages/webview/src/component/gatewayclasses/gatewayclass-helper.ts
+++ b/packages/webview/src/component/gatewayclasses/gatewayclass-helper.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+
+import type { GatewayClassUI } from './GatewayClassUI';
+
+interface GatewayClassSpec {
+  controllerName?: string;
+}
+
+export class GatewayClassHelper {
+  getGatewayClassUI(o: KubernetesObject): GatewayClassUI {
+    const spec = (o as unknown as { spec?: GatewayClassSpec }).spec;
+
+    return {
+      kind: 'GatewayClass',
+      uid: o.metadata?.uid ?? '',
+      name: o.metadata?.name ?? '',
+      status: 'RUNNING',
+      created: o.metadata?.creationTimestamp,
+      controller: spec?.controllerName ?? '',
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -54,6 +54,7 @@ import { endpointSlicesModule } from '/@/component/endpoint-slices/_endpoint-sli
 import { networkPoliciesModule } from '/@/component/network-policies/_network-policies-module';
 import { ingressClassesModule } from '/@/component/ingress-classes/_ingress-classes-module';
 import { httpRoutesModule } from '/@/component/httproutes/_httproutes-module';
+import { gatewayClassesModule } from '/@/component/gatewayclasses/_gatewayclasses-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -102,6 +103,7 @@ export class InversifyBinding {
     await this.#container.load(networkPoliciesModule);
     await this.#container.load(ingressClassesModule);
     await this.#container.load(httpRoutesModule);
+    await this.#container.load(gatewayClassesModule);
 
     return this.#container;
   }

--- a/packages/webview/src/navigation/navigator.ts
+++ b/packages/webview/src/navigation/navigator.ts
@@ -87,6 +87,8 @@ export class Navigator {
       return 'ingressclasses';
     } else if (kind === 'HTTPRoute') {
       return 'httproutes';
+    } else if (kind === 'GatewayClass') {
+      return 'gatewayclasses';
     }
     // otherwise do the simple conversion
     return kind.toLowerCase() + 's';

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -629,6 +629,7 @@ test.describe('With resources', { tag: '@integration' }, () => {
   test('go to gateway-class1 page', async () => {
     const gatewayClassesPage = await navigation.openTabPage(KubernetesResources.GatewayClasses);
     await playExpect(gatewayClassesPage.heading).toBeVisible();
+    await playExpect.poll(async () => gatewayClassesPage.rowsAreVisible()).toBeTruthy();
 
     const kubernetesResourceDetails = await gatewayClassesPage.openResourceDetails(
       'gateway-class1',

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -225,6 +225,14 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     await playExpect.poll(async () => httpRoutesPage.isEmpty('No httproutes'), { timeout: 15_000 }).toBeTruthy();
   });
 
+  test('go to gateway classes page', async () => {
+    const gatewayClassesPage = await navigation.openTabPage(KubernetesResources.GatewayClasses);
+    await playExpect(gatewayClassesPage.heading).toBeVisible();
+    await playExpect
+      .poll(async () => gatewayClassesPage.isEmpty('No gatewayclasses'), { timeout: 15_000 })
+      .toBeTruthy();
+  });
+
   test('go to pvc page', async () => {
     const pvcPage = await navigation.openTabPage(KubernetesResources.PVCs);
     await playExpect(pvcPage.heading).toBeVisible();
@@ -613,6 +621,18 @@ test.describe('With resources', { tag: '@integration' }, () => {
     const kubernetesResourceDetails = await httpRoutesPage.openResourceDetails(
       'httproute1',
       KubernetesResources.HTTPRoutes,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to gateway-class1 page', async () => {
+    const gatewayClassesPage = await navigation.openTabPage(KubernetesResources.GatewayClasses);
+    await playExpect(gatewayClassesPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await gatewayClassesPage.openResourceDetails(
+      'gateway-class1',
+      KubernetesResources.GatewayClasses,
     );
     await playExpect(kubernetesResourceDetails.heading).toBeVisible();
     await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -37,6 +37,7 @@ export enum KubernetesResources {
   EndpointSlices = 'Endpoint Slices',
   NetworkPolicies = 'Network Policies',
   IngressClasses = 'Ingress Classes',
+  GatewayClasses = 'Gateway Classes',
   HTTPRoutes = 'HTTPRoutes',
   PVCs = 'Persistent Volume Claims',
   PersistentVolumes = 'Persistent Volumes',
@@ -84,6 +85,7 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
     'Actions',
   ],
   [KubernetesResources.IngressClasses]: ['Status', 'Name', 'Controller', 'Default', 'Age'],
+  [KubernetesResources.GatewayClasses]: ['Status', 'Name', 'Controller', 'Age'],
   [KubernetesResources.HTTPRoutes]: [
     'Selected',
     'Status',

--- a/tests/playwright/src/model/pages/kubernetes-resource-page.ts
+++ b/tests/playwright/src/model/pages/kubernetes-resource-page.ts
@@ -72,7 +72,11 @@ export class KubernetesResourcePage extends MainPage {
       const resourceRow = await this.fetchKubernetesResource(resourceName, timeout);
 
       let resourceRowName: Locator;
-      if (resourceType === KubernetesResources.Nodes || resourceType === KubernetesResources.StorageClasses) {
+      if (
+        resourceType === KubernetesResources.Nodes ||
+        resourceType === KubernetesResources.StorageClasses ||
+        resourceType === KubernetesResources.GatewayClasses
+      ) {
         resourceRowName = resourceRow.getByRole('cell').nth(2);
       } else {
         resourceRowName = resourceRow.getByRole('cell').nth(3);

--- a/tests/playwright/src/model/pages/kubernetes-resource-page.ts
+++ b/tests/playwright/src/model/pages/kubernetes-resource-page.ts
@@ -72,11 +72,7 @@ export class KubernetesResourcePage extends MainPage {
       const resourceRow = await this.fetchKubernetesResource(resourceName, timeout);
 
       let resourceRowName: Locator;
-      if (
-        resourceType === KubernetesResources.Nodes ||
-        resourceType === KubernetesResources.StorageClasses ||
-        resourceType === KubernetesResources.GatewayClasses
-      ) {
+      if (resourceType === KubernetesResources.Nodes || resourceType === KubernetesResources.StorageClasses) {
         resourceRowName = resourceRow.getByRole('cell').nth(2);
       } else {
         resourceRowName = resourceRow.getByRole('cell').nth(3);

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -38,6 +38,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.EndpointSlices]: NavSection.Network,
   [KubernetesResources.NetworkPolicies]: NavSection.Network,
   [KubernetesResources.IngressClasses]: NavSection.Network,
+  [KubernetesResources.GatewayClasses]: NavSection.Network,
   [KubernetesResources.HTTPRoutes]: NavSection.Network,
   [KubernetesResources.PortForwarding]: NavSection.Network,
   [KubernetesResources.PVCs]: NavSection.Storage,
@@ -102,6 +103,8 @@ export class KubernetesBar {
         return new KubernetesResourcePage(this.page, 'network policies');
       case 'Ingress Classes':
         return new KubernetesResourcePage(this.page, 'ingress classes');
+      case 'Gateway Classes':
+        return new KubernetesResourcePage(this.page, 'gateway classes');
       default:
         return new KubernetesResourcePage(this.page, kubernetesResource);
     }

--- a/tests/resources/cluster-resources.yaml
+++ b/tests/resources/cluster-resources.yaml
@@ -954,6 +954,15 @@ spec:
   controller: example.com/ingress-controller
 ---
 apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  creationTimestamp: '2026-02-09T10:18:00Z'
+  name: gateway-class1
+  uid: d4e5f6a7-b8c9-0123-def0-234567890123
+spec:
+  controllerName: example.com/gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   creationTimestamp: '2026-02-09T10:20:00Z'


### PR DESCRIPTION
feat(networking): adds Gateway Classes resource view

### What does this PR do?

Adds Gateway Classes resource view under the Network navigation section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/e51d953b-7c37-4b89-b65f-733da148ae2c

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/980

### How to test this PR?

1. Build extension
2. Go to Gateway Classes section and confirm that artifacts appear there

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
