### PR TITLE
build(deps): update Containerfile.builder for pnpm v11

### DIFF
--- a/build/Containerfile.builder
+++ b/build/Containerfile.builder
@@ -27,12 +27,11 @@ ENV HOME=/opt/app-root
 # copy the application files to the /opt/app-root/extension-source directory
 WORKDIR /opt/app-root/extension-source
 RUN mkdir -p /opt/app-root/extension-source
-COPY --chown=1001:root .npmrc /opt/app-root/extension-source/
 COPY --chown=1001:root package.json /opt/app-root/extension-source/
 COPY --chown=1001:root pnpm-lock.yaml /opt/app-root/extension-source/
 COPY --chown=1001:root pnpm-workspace.yaml /opt/app-root/extension-source/
 COPY --chown=1001:root packages/webview/package.json /opt/app-root/extension-source/packages/webview/package.json
 COPY --chown=1001:root packages/extension/package.json /opt/app-root/extension-source/packages/extension/package.json
 
-RUN npm install --global pnpm@10 && \
-    pnpm --frozen-lockfile install
+RUN corepack enable && corepack install && \
+    CI=true pnpm --frozen-lockfile install

--- a/build/Containerfile.builder
+++ b/build/Containerfile.builder
@@ -18,7 +18,7 @@
 # v10.1-1766363988
 FROM registry.access.redhat.com/ubi10/nodejs-24@sha256:5a3cea874f0555bcde27d979bbc8a067f1d75b4b324ef3274112c8270e951f5b
 USER root
-RUN dnf install -y jq
+RUN dnf install -y jq && npm i -g corepack && corepack enable
 USER default
 
 # change home directory to be at /opt/app-root


### PR DESCRIPTION
### What does this PR do?

- Remove .npmrc COPY (file deleted after pnpm v10→v11 migration)
- Replace npm install --global pnpm@10 with corepack enable && corepack install
- Add CI=true to suppress non-TTY modules-purge prompt

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #1212 

### How to test this PR?

<!-- Please explain steps to reproduce -->
