### PR TITLE
feat(config): add ResourceQuota resource

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -88,6 +88,7 @@ import { NetworkPoliciesResourceFactory } from '/@/resources/network-policies-re
 import { IngressClassesResourceFactory } from '/@/resources/ingress-classes-resource-factory.js';
 import { HttpRoutesResourceFactory } from '/@/resources/httproutes-resource-factory.js';
 import { GatewayClassesResourceFactory } from '/@/resources/gatewayclasses-resource-factory.js';
+import { ResourceQuotasResourceFactory } from '/@/resources/resource-quotas-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -211,6 +212,7 @@ export class ContextsManager implements ContextsApi {
       new IngressClassesResourceFactory(),
       new HttpRoutesResourceFactory(),
       new GatewayClassesResourceFactory(),
+      new ResourceQuotasResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/resource-quotas-resource-factory.spec.ts
+++ b/packages/extension/src/resources/resource-quotas-resource-factory.spec.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { ResourceQuotasResourceFactory } from './resource-quotas-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new ResourceQuotasResourceFactory();
+  expect(factory.resource).toBe('resourcequotas');
+  expect(factory.kind).toBe('ResourceQuota');
+});

--- a/packages/extension/src/resources/resource-quotas-resource-factory.ts
+++ b/packages/extension/src/resources/resource-quotas-resource-factory.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1ResourceQuota, V1ResourceQuotaList, V1Status } from '@kubernetes/client-node';
+import { CoreV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class ResourceQuotasResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'resourcequotas',
+      kind: 'ResourceQuota',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'resourcequotas',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteResourceQuota);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1ResourceQuota> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    const listFn = (): Promise<V1ResourceQuotaList> => apiClient.listNamespacedResourceQuota({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/resourcequotas`;
+    return new ResourceInformer<V1ResourceQuota>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'resourcequotas',
+    });
+  }
+
+  deleteResourceQuota(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    return apiClient.deleteNamespacedResourceQuota({ name, namespace });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -59,6 +59,8 @@ import HttpRoutesList from './component/httproutes/HttpRoutesList.svelte';
 import HttpRouteDetails from './component/httproutes/HttpRouteDetails.svelte';
 import GatewayClassesList from './component/gatewayclasses/GatewayClassesList.svelte';
 import GatewayClassDetails from './component/gatewayclasses/GatewayClassDetails.svelte';
+import ResourceQuotasList from './component/resource-quotas/ResourceQuotasList.svelte';
+import ResourceQuotaDetails from './component/resource-quotas/ResourceQuotaDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -223,6 +225,12 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  <Route path="/resourcequotas">
+    <ResourceQuotasList />
+  </Route>
+
+  <Route path="/resourcequotas/:name/:namespace/*" let:meta>
+    <ResourceQuotaDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
   </Route>
 
   <Route path="/gatewayclasses">

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -225,6 +225,8 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
   <Route path="/resourcequotas">
     <ResourceQuotasList />
   </Route>

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -43,7 +43,11 @@ const workloadUrls = [
   navigator.kubernetesResourcesURL('CronJob'),
 ];
 
-const configUrls = [navigator.kubernetesResourcesURL('ConfigMap'), navigator.kubernetesResourcesURL('ServiceAccount'), navigator.kubernetesResourcesURL('ResourceQuota')];
+const configUrls = [
+  navigator.kubernetesResourcesURL('ConfigMap'),
+  navigator.kubernetesResourcesURL('ServiceAccount'),
+  navigator.kubernetesResourcesURL('ResourceQuota'),
+];
 
 const networkUrls = [
   navigator.kubernetesResourcesURL('Service'),

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -44,6 +44,10 @@ const workloadUrls = [
 ];
 
 const configUrls = [navigator.kubernetesResourcesURL('ConfigMap'), navigator.kubernetesResourcesURL('ServiceAccount')];
+const configUrls = [
+  navigator.kubernetesResourcesURL('ConfigMap'),
+  navigator.kubernetesResourcesURL('ResourceQuota'),
+];
 
 const networkUrls = [
   navigator.kubernetesResourcesURL('Service'),
@@ -156,6 +160,7 @@ $effect(() => {
     {#if configExpanded}
       <NavItem title="ConfigMaps &amp; Secrets" child={true} href={navigator.kubernetesResourcesURL('ConfigMap')} />
       <NavItem title="Service Accounts" child={true} href={navigator.kubernetesResourcesURL('ServiceAccount')} />
+      <NavItem title="Resource Quotas" child={true} href={navigator.kubernetesResourcesURL('ResourceQuota')} />
     {/if}
 
     <!-- Network section -->

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -43,12 +43,7 @@ const workloadUrls = [
   navigator.kubernetesResourcesURL('CronJob'),
 ];
 
-const configUrls = [navigator.kubernetesResourcesURL('ConfigMap'), navigator.kubernetesResourcesURL('ServiceAccount')];
-const configUrls = [
-  navigator.kubernetesResourcesURL('ConfigMap'),
-  navigator.kubernetesResourcesURL('ResourceQuota'),
-];
-const configUrls = [navigator.kubernetesResourcesURL('ConfigMap'), navigator.kubernetesResourcesURL('ResourceQuota')];
+const configUrls = [navigator.kubernetesResourcesURL('ConfigMap'), navigator.kubernetesResourcesURL('ServiceAccount'), navigator.kubernetesResourcesURL('ResourceQuota')];
 
 const networkUrls = [
   navigator.kubernetesResourcesURL('Service'),

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -48,6 +48,7 @@ const configUrls = [
   navigator.kubernetesResourcesURL('ConfigMap'),
   navigator.kubernetesResourcesURL('ResourceQuota'),
 ];
+const configUrls = [navigator.kubernetesResourcesURL('ConfigMap'), navigator.kubernetesResourcesURL('ResourceQuota')];
 
 const networkUrls = [
   navigator.kubernetesResourcesURL('Service'),

--- a/packages/webview/src/component/resource-quotas/ResourceQuotaDetails.svelte
+++ b/packages/webview/src/component/resource-quotas/ResourceQuotaDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { ResourceQuotaHelper } from './resource-quota-helper';
+import type { ResourceQuotaUI } from './ResourceQuotaUI';
+import type { V1ResourceQuota } from '@kubernetes/client-node';
+import ResourceQuotaDetailsSummary from './ResourceQuotaDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const resourceQuotaHelper = dependencyAccessor.get<ResourceQuotaHelper>(ResourceQuotaHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1ResourceQuota}
+  typedUI={{} as ResourceQuotaUI}
+  kind="ResourceQuota"
+  resourceName="resourcequotas"
+  listName="Resource Quotas"
+  name={name}
+  namespace={namespace}
+  transformer={resourceQuotaHelper.getResourceQuotaUI.bind(resourceQuotaHelper)}
+  SummaryComponent={ResourceQuotaDetailsSummary} />

--- a/packages/webview/src/component/resource-quotas/ResourceQuotaDetails.svelte
+++ b/packages/webview/src/component/resource-quotas/ResourceQuotaDetails.svelte
@@ -6,6 +6,7 @@ import { ResourceQuotaHelper } from './resource-quota-helper';
 import type { ResourceQuotaUI } from './ResourceQuotaUI';
 import type { V1ResourceQuota } from '@kubernetes/client-node';
 import ResourceQuotaDetailsSummary from './ResourceQuotaDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -26,4 +27,5 @@ const resourceQuotaHelper = dependencyAccessor.get<ResourceQuotaHelper>(Resource
   name={name}
   namespace={namespace}
   transformer={resourceQuotaHelper.getResourceQuotaUI.bind(resourceQuotaHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={ResourceQuotaDetailsSummary} />

--- a/packages/webview/src/component/resource-quotas/ResourceQuotaDetailsSummary.svelte
+++ b/packages/webview/src/component/resource-quotas/ResourceQuotaDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1ResourceQuota } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1ResourceQuota;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/resource-quotas/ResourceQuotaUI.ts
+++ b/packages/webview/src/component/resource-quotas/ResourceQuotaUI.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface ResourceQuotaUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  requestCount: number;
+}

--- a/packages/webview/src/component/resource-quotas/ResourceQuotasList.svelte
+++ b/packages/webview/src/component/resource-quotas/ResourceQuotasList.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import ActionsColumn from './columns/Actions.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { ResourceQuotaUI } from './ResourceQuotaUI';
+import { ResourceQuotaHelper } from './resource-quota-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const resourceQuotaHelper = dependencyAccessor.get<ResourceQuotaHelper>(ResourceQuotaHelper);
+
+let statusColumn = new TableColumn<ResourceQuotaUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<ResourceQuotaUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let requestCountColumn = new TableColumn<ResourceQuotaUI, string>('Request Count', {
+  renderMapping: (obj): string => String(obj.requestCount),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.requestCount - b.requestCount,
+});
+
+let ageColumn = new TableColumn<ResourceQuotaUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  requestCountColumn,
+  ageColumn,
+  new TableColumn<ResourceQuotaUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<ResourceQuotaUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'resourcequotas',
+      transformer: resourceQuotaHelper.getResourceQuotaUI,
+    },
+  ]}
+  singular="resource quota"
+  plural="resource quotas"
+  isNamespaced={true}
+  icon={icon['ResourceQuota']}
+  columns={columns}
+  row={row}>
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['ResourceQuota']} resources={['resourcequotas']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/resource-quotas/ResourceQuotasList.svelte
+++ b/packages/webview/src/component/resource-quotas/ResourceQuotasList.svelte
@@ -61,7 +61,7 @@ const row = new TableRow<ResourceQuotaUI>({ selectable: (_obj): boolean => true 
   kinds={[
     {
       resource: 'resourcequotas',
-      transformer: resourceQuotaHelper.getResourceQuotaUI,
+      transformer: resourceQuotaHelper.getResourceQuotaUI.bind(resourceQuotaHelper),
     },
   ]}
   singular="resource quota"

--- a/packages/webview/src/component/resource-quotas/_resource-quotas-module.ts
+++ b/packages/webview/src/component/resource-quotas/_resource-quotas-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { ResourceQuotaHelper } from './resource-quota-helper';
+
+const resourceQuotasModule = new ContainerModule(options => {
+  options.bind<ResourceQuotaHelper>(ResourceQuotaHelper).toSelf().inSingletonScope();
+});
+
+export { resourceQuotasModule };

--- a/packages/webview/src/component/resource-quotas/columns/Actions.svelte
+++ b/packages/webview/src/component/resource-quotas/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/resource-quotas/columns/props.ts
+++ b/packages/webview/src/component/resource-quotas/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ResourceQuotaUI } from '/@/component/resource-quotas/ResourceQuotaUI';
+
+export interface Props {
+  object: ResourceQuotaUI;
+}

--- a/packages/webview/src/component/resource-quotas/resource-quota-helper.spec.ts
+++ b/packages/webview/src/component/resource-quotas/resource-quota-helper.spec.ts
@@ -1,0 +1,66 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ResourceQuota } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { ResourceQuotaHelper } from './resource-quota-helper';
+
+let helper: ResourceQuotaHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new ResourceQuotaHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const rq = {
+    metadata: {
+      name: 'my-quota',
+      namespace: 'default',
+      uid: 'uid-123',
+    },
+    spec: { hard: { cpu: '4' } },
+    status: { hard: { cpu: '4' }, used: { cpu: '2' } },
+  } as V1ResourceQuota;
+  const ui = helper.getResourceQuotaUI(rq);
+  expect(ui.kind).toEqual('ResourceQuota');
+  expect(ui.name).toEqual('my-quota');
+  expect(ui.namespace).toEqual('default');
+  expect(ui.uid).toEqual('uid-123');
+});
+
+test('expect requestCount from status hard', async () => {
+  const rq = {
+    metadata: { name: 'q1' },
+    status: {
+      hard: { cpu: '4', memory: '8Gi' },
+      used: { cpu: '1', memory: '2Gi' },
+    },
+  } as V1ResourceQuota;
+  const ui = helper.getResourceQuotaUI(rq);
+  expect(ui.requestCount).toEqual(2);
+});
+
+test('expect zero requestCount when no spec or status', async () => {
+  const rq = {
+    metadata: { name: 'empty' },
+  } as V1ResourceQuota;
+  const ui = helper.getResourceQuotaUI(rq);
+  expect(ui.requestCount).toEqual(0);
+});

--- a/packages/webview/src/component/resource-quotas/resource-quota-helper.ts
+++ b/packages/webview/src/component/resource-quotas/resource-quota-helper.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1ResourceQuota } from '@kubernetes/client-node';
+
+import type { ResourceQuotaUI } from './ResourceQuotaUI';
+
+export class ResourceQuotaHelper {
+  getResourceQuotaUI(o: KubernetesObject): ResourceQuotaUI {
+    const obj = o as V1ResourceQuota;
+    const hard = obj.status?.hard ?? obj.spec?.hard ?? {};
+    const requestCount = Object.keys(hard).length;
+
+    return {
+      kind: 'ResourceQuota',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: obj.metadata?.namespace ?? '',
+      created: obj.metadata?.creationTimestamp,
+      selected: false,
+      requestCount,
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -55,6 +55,7 @@ import { networkPoliciesModule } from '/@/component/network-policies/_network-po
 import { ingressClassesModule } from '/@/component/ingress-classes/_ingress-classes-module';
 import { httpRoutesModule } from '/@/component/httproutes/_httproutes-module';
 import { gatewayClassesModule } from '/@/component/gatewayclasses/_gatewayclasses-module';
+import { resourceQuotasModule } from '/@/component/resource-quotas/_resource-quotas-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -104,6 +105,7 @@ export class InversifyBinding {
     await this.#container.load(ingressClassesModule);
     await this.#container.load(httpRoutesModule);
     await this.#container.load(gatewayClassesModule);
+    await this.#container.load(resourceQuotasModule);
 
     return this.#container;
   }

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -256,6 +256,7 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  });
   test('go to resourceQuotas page', async () => {
     const resourceQuotasPage = await navigation.openTabPage(KubernetesResources.ResourceQuotas);
     await playExpect(resourceQuotasPage.heading).toBeVisible();

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -256,6 +256,10 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  test('go to resourceQuotas page', async () => {
+    const resourceQuotasPage = await navigation.openTabPage(KubernetesResources.ResourceQuotas);
+    await playExpect(resourceQuotasPage.heading).toBeVisible();
+    await playExpect.poll(async () => resourceQuotasPage.isEmpty('No resourcequotas')).toBeTruthy();
   });
 
   test('go to clusterRoleBindings page', async () => {

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -52,6 +52,7 @@ export enum KubernetesResources {
   RoleBindings = 'Role Bindings',
   ClusterRoles = 'Cluster Roles',
   ClusterRoleBindings = 'Cluster Role Bindings',
+  ResourceQuotas = 'Resource Quotas',
 }
 
 export const KubernetesResourceAttributes: Record<KubernetesResources, string[]> = {
@@ -139,4 +140,5 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   [KubernetesResources.RoleBindings]: ['Selected', 'Status', 'Name', 'Bindings', 'Role', 'Age', 'Actions'],
   [KubernetesResources.ClusterRoles]: ['Selected', 'Status', 'Name', 'Rules', 'Age', 'Actions'],
   [KubernetesResources.ClusterRoleBindings]: ['Selected', 'Status', 'Name', 'Bindings', 'Role', 'Age', 'Actions'],
+  [KubernetesResources.ResourceQuotas]: ['Selected', 'Status', 'Name', 'Request Count', 'Age', 'Actions'],
 };

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -49,6 +49,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.RoleBindings]: NavSection.AccessControl,
   [KubernetesResources.ClusterRoles]: NavSection.AccessControl,
   [KubernetesResources.ClusterRoleBindings]: NavSection.AccessControl,
+  [KubernetesResources.ResourceQuotas]: NavSection.Config,
 };
 
 export class KubernetesBar {
@@ -105,6 +106,8 @@ export class KubernetesBar {
         return new KubernetesResourcePage(this.page, 'ingress classes');
       case 'Gateway Classes':
         return new KubernetesResourcePage(this.page, 'gateway classes');
+      case 'Resource Quotas':
+        return new KubernetesResourcePage(this.page, 'resource quotas');
       default:
         return new KubernetesResourcePage(this.page, kubernetesResource);
     }


### PR DESCRIPTION
feat(config): add ResourceQuota resource

### What does this PR do?

Adds resource views for ResourceQuota under the Config section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/598726d9-d5e9-4491-ab9a-a272f1381064

### What issues does this PR fix or reference?

Part of  https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Connect to a cluster with example a ResourceQuota resource
2. Confirm you are able to view the new section

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
