### PR TITLE
feat(config): add LimitRange resource

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -90,6 +90,7 @@ import { HttpRoutesResourceFactory } from '/@/resources/httproutes-resource-fact
 import { GatewayClassesResourceFactory } from '/@/resources/gatewayclasses-resource-factory.js';
 import { ResourceQuotasResourceFactory } from '/@/resources/resource-quotas-resource-factory.js';
 import { GatewaysResourceFactory } from '/@/resources/gateways-resource-factory.js';
+import { LimitRangesResourceFactory } from '/@/resources/limit-ranges-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -215,6 +216,7 @@ export class ContextsManager implements ContextsApi {
       new GatewayClassesResourceFactory(),
       new ResourceQuotasResourceFactory(),
       new GatewaysResourceFactory(),
+      new LimitRangesResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/limit-ranges-resource-factory.spec.ts
+++ b/packages/extension/src/resources/limit-ranges-resource-factory.spec.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { LimitRangesResourceFactory } from './limit-ranges-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new LimitRangesResourceFactory();
+  expect(factory.resource).toBe('limitranges');
+  expect(factory.kind).toBe('LimitRange');
+});

--- a/packages/extension/src/resources/limit-ranges-resource-factory.ts
+++ b/packages/extension/src/resources/limit-ranges-resource-factory.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1LimitRange, V1LimitRangeList, V1Status } from '@kubernetes/client-node';
+import { CoreV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class LimitRangesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'limitranges',
+      kind: 'LimitRange',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'limitranges',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteLimitRange);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1LimitRange> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    const listFn = (): Promise<V1LimitRangeList> => apiClient.listNamespacedLimitRange({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/limitranges`;
+    return new ResourceInformer<V1LimitRange>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'limitranges',
+    });
+  }
+
+  deleteLimitRange(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    return apiClient.deleteNamespacedLimitRange({ name, namespace });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -63,6 +63,8 @@ import ResourceQuotasList from './component/resource-quotas/ResourceQuotasList.s
 import ResourceQuotaDetails from './component/resource-quotas/ResourceQuotaDetails.svelte';
 import GatewaysList from './component/gateways/GatewaysList.svelte';
 import GatewayDetails from './component/gateways/GatewayDetails.svelte';
+import LimitRangesList from './component/limit-ranges/LimitRangesList.svelte';
+import LimitRangeDetails from './component/limit-ranges/LimitRangeDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -227,6 +229,12 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  <Route path="/limitranges">
+    <LimitRangesList />
+  </Route>
+
+  <Route path="/limitranges/:name/:namespace/*" let:meta>
+    <LimitRangeDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
   </Route>
 
   <Route path="/resourcequotas">

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -229,6 +229,8 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
   <Route path="/limitranges">
     <LimitRangesList />
   </Route>

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -48,6 +48,7 @@ const configUrls = [
   navigator.kubernetesResourcesURL('ServiceAccount'),
   navigator.kubernetesResourcesURL('ResourceQuota'),
   navigator.kubernetesResourcesURL('LimitRange'),
+];
 
 const networkUrls = [
   navigator.kubernetesResourcesURL('Service'),

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -47,7 +47,7 @@ const configUrls = [
   navigator.kubernetesResourcesURL('ConfigMap'),
   navigator.kubernetesResourcesURL('ServiceAccount'),
   navigator.kubernetesResourcesURL('ResourceQuota'),
-];
+  navigator.kubernetesResourcesURL('LimitRange'),
 
 const networkUrls = [
   navigator.kubernetesResourcesURL('Service'),
@@ -162,6 +162,7 @@ $effect(() => {
       <NavItem title="ConfigMaps &amp; Secrets" child={true} href={navigator.kubernetesResourcesURL('ConfigMap')} />
       <NavItem title="Service Accounts" child={true} href={navigator.kubernetesResourcesURL('ServiceAccount')} />
       <NavItem title="Resource Quotas" child={true} href={navigator.kubernetesResourcesURL('ResourceQuota')} />
+      <NavItem title="Limit Ranges" child={true} href={navigator.kubernetesResourcesURL('LimitRange')} />
     {/if}
 
     <!-- Network section -->

--- a/packages/webview/src/component/limit-ranges/LimitRangeDetails.svelte
+++ b/packages/webview/src/component/limit-ranges/LimitRangeDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { LimitRangeHelper } from './limit-range-helper';
+import type { LimitRangeUI } from './LimitRangeUI';
+import type { V1LimitRange } from '@kubernetes/client-node';
+import LimitRangeDetailsSummary from './LimitRangeDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const limitRangeHelper = dependencyAccessor.get<LimitRangeHelper>(LimitRangeHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1LimitRange}
+  typedUI={{} as LimitRangeUI}
+  kind="LimitRange"
+  resourceName="limitranges"
+  listName="Limit Ranges"
+  name={name}
+  namespace={namespace}
+  transformer={limitRangeHelper.getLimitRangeUI.bind(limitRangeHelper)}
+  SummaryComponent={LimitRangeDetailsSummary} />

--- a/packages/webview/src/component/limit-ranges/LimitRangeDetails.svelte
+++ b/packages/webview/src/component/limit-ranges/LimitRangeDetails.svelte
@@ -6,6 +6,7 @@ import { LimitRangeHelper } from './limit-range-helper';
 import type { LimitRangeUI } from './LimitRangeUI';
 import type { V1LimitRange } from '@kubernetes/client-node';
 import LimitRangeDetailsSummary from './LimitRangeDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -26,4 +27,5 @@ const limitRangeHelper = dependencyAccessor.get<LimitRangeHelper>(LimitRangeHelp
   name={name}
   namespace={namespace}
   transformer={limitRangeHelper.getLimitRangeUI.bind(limitRangeHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={LimitRangeDetailsSummary} />

--- a/packages/webview/src/component/limit-ranges/LimitRangeDetailsSummary.svelte
+++ b/packages/webview/src/component/limit-ranges/LimitRangeDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1LimitRange } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1LimitRange;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/limit-ranges/LimitRangeUI.ts
+++ b/packages/webview/src/component/limit-ranges/LimitRangeUI.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface LimitRangeUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  limitTypes: string;
+  limitCount: number;
+}

--- a/packages/webview/src/component/limit-ranges/LimitRangesList.svelte
+++ b/packages/webview/src/component/limit-ranges/LimitRangesList.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import ActionsColumn from './columns/Actions.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { LimitRangeUI } from './LimitRangeUI';
+import { LimitRangeHelper } from './limit-range-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const limitRangeHelper = dependencyAccessor.get<LimitRangeHelper>(LimitRangeHelper);
+
+let statusColumn = new TableColumn<LimitRangeUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<LimitRangeUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let typeColumn = new TableColumn<LimitRangeUI, string>('Type', {
+  renderMapping: (obj): string => obj.limitTypes,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.limitTypes.localeCompare(b.limitTypes),
+});
+
+let countColumn = new TableColumn<LimitRangeUI, string>('Count', {
+  renderMapping: (obj): string => String(obj.limitCount),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.limitCount - b.limitCount,
+});
+
+let ageColumn = new TableColumn<LimitRangeUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  typeColumn,
+  countColumn,
+  ageColumn,
+  new TableColumn<LimitRangeUI>('Actions', { align: 'right', width: '150px', renderer: ActionsColumn, overflow: true }),
+];
+
+const row = new TableRow<LimitRangeUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'limitranges',
+      transformer: limitRangeHelper.getLimitRangeUI,
+    },
+  ]}
+  singular="limit range"
+  plural="limit ranges"
+  isNamespaced={true}
+  icon={icon['LimitRange']}
+  columns={columns}
+  row={row}>
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['LimitRange']} resources={['limitranges']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/limit-ranges/LimitRangesList.svelte
+++ b/packages/webview/src/component/limit-ranges/LimitRangesList.svelte
@@ -63,7 +63,7 @@ const row = new TableRow<LimitRangeUI>({ selectable: (_obj): boolean => true });
   kinds={[
     {
       resource: 'limitranges',
-      transformer: limitRangeHelper.getLimitRangeUI,
+      transformer: limitRangeHelper.getLimitRangeUI.bind(limitRangeHelper),
     },
   ]}
   singular="limit range"

--- a/packages/webview/src/component/limit-ranges/_limit-ranges-module.ts
+++ b/packages/webview/src/component/limit-ranges/_limit-ranges-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { LimitRangeHelper } from './limit-range-helper';
+
+const limitRangesModule = new ContainerModule(options => {
+  options.bind<LimitRangeHelper>(LimitRangeHelper).toSelf().inSingletonScope();
+});
+
+export { limitRangesModule };

--- a/packages/webview/src/component/limit-ranges/columns/Actions.svelte
+++ b/packages/webview/src/component/limit-ranges/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/limit-ranges/columns/props.ts
+++ b/packages/webview/src/component/limit-ranges/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { LimitRangeUI } from '/@/component/limit-ranges/LimitRangeUI';
+
+export interface Props {
+  object: LimitRangeUI;
+}

--- a/packages/webview/src/component/limit-ranges/limit-range-helper.spec.ts
+++ b/packages/webview/src/component/limit-ranges/limit-range-helper.spec.ts
@@ -1,0 +1,84 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1LimitRange } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { LimitRangeHelper } from './limit-range-helper';
+
+let helper: LimitRangeHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new LimitRangeHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const lr = {
+    metadata: {
+      name: 'my-limit',
+      namespace: 'default',
+      uid: 'uid-456',
+    },
+    spec: { limits: [] },
+  } as V1LimitRange;
+  const ui = helper.getLimitRangeUI(lr);
+  expect(ui.kind).toEqual('LimitRange');
+  expect(ui.name).toEqual('my-limit');
+  expect(ui.namespace).toEqual('default');
+  expect(ui.uid).toEqual('uid-456');
+});
+
+test('expect limitTypes and limitCount with type', async () => {
+  const lr = {
+    metadata: { name: 'lr1' },
+    spec: {
+      limits: [
+        {
+          type: 'Container',
+          _default: { cpu: '500m', memory: '128Mi' },
+          defaultRequest: { cpu: '250m' },
+        },
+      ],
+    },
+  } as V1LimitRange;
+  const ui = helper.getLimitRangeUI(lr);
+  expect(ui.limitTypes).toEqual('Container');
+  expect(ui.limitCount).toEqual(1);
+});
+
+test('expect multiple limit types', async () => {
+  const lr = {
+    metadata: { name: 'lr2' },
+    spec: {
+      limits: [{ type: 'Container', _default: { cpu: '500m' } }, { type: 'Pod' }],
+    },
+  } as V1LimitRange;
+  const ui = helper.getLimitRangeUI(lr);
+  expect(ui.limitTypes).toEqual('Container, Pod');
+  expect(ui.limitCount).toEqual(2);
+});
+
+test('expect empty limitTypes when no spec', async () => {
+  const lr = {
+    metadata: { name: 'empty' },
+  } as V1LimitRange;
+  const ui = helper.getLimitRangeUI(lr);
+  expect(ui.limitTypes).toEqual('');
+  expect(ui.limitCount).toEqual(0);
+});

--- a/packages/webview/src/component/limit-ranges/limit-range-helper.ts
+++ b/packages/webview/src/component/limit-ranges/limit-range-helper.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1LimitRange } from '@kubernetes/client-node';
+
+import type { LimitRangeUI } from './LimitRangeUI';
+
+export class LimitRangeHelper {
+  getLimitRangeUI(o: KubernetesObject): LimitRangeUI {
+    const obj = o as V1LimitRange;
+    const items = obj.spec?.limits ?? [];
+    const types = items.map(item => item.type).filter((t): t is string => !!t);
+    const limitCount = items.length;
+
+    return {
+      kind: 'LimitRange',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: obj.metadata?.namespace ?? '',
+      created: obj.metadata?.creationTimestamp,
+      selected: false,
+      limitTypes: types.join(', '),
+      limitCount,
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -57,6 +57,7 @@ import { httpRoutesModule } from '/@/component/httproutes/_httproutes-module';
 import { gatewayClassesModule } from '/@/component/gatewayclasses/_gatewayclasses-module';
 import { resourceQuotasModule } from '/@/component/resource-quotas/_resource-quotas-module';
 import { gatewaysModule } from '/@/component/gateways/_gateways-module';
+import { limitRangesModule } from '/@/component/limit-ranges/_limit-ranges-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -108,6 +109,7 @@ export class InversifyBinding {
     await this.#container.load(gatewayClassesModule);
     await this.#container.load(resourceQuotasModule);
     await this.#container.load(gatewaysModule);
+    await this.#container.load(limitRangesModule);
 
     return this.#container;
   }

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -262,6 +262,7 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  });
   test('go to limitRanges page', async () => {
     const limitRangesPage = await navigation.openTabPage(KubernetesResources.LimitRanges);
     await playExpect(limitRangesPage.heading).toBeVisible();

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -262,6 +262,10 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  test('go to limitRanges page', async () => {
+    const limitRangesPage = await navigation.openTabPage(KubernetesResources.LimitRanges);
+    await playExpect(limitRangesPage.heading).toBeVisible();
+    await playExpect.poll(async () => limitRangesPage.isEmpty('No limitranges')).toBeTruthy();
   });
   test('go to resourceQuotas page', async () => {
     const resourceQuotasPage = await navigation.openTabPage(KubernetesResources.ResourceQuotas);

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -54,6 +54,7 @@ export enum KubernetesResources {
   ClusterRoles = 'Cluster Roles',
   ClusterRoleBindings = 'Cluster Role Bindings',
   ResourceQuotas = 'Resource Quotas',
+  LimitRanges = 'Limit Ranges',
 }
 
 export const KubernetesResourceAttributes: Record<KubernetesResources, string[]> = {
@@ -152,4 +153,5 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   [KubernetesResources.ClusterRoles]: ['Selected', 'Status', 'Name', 'Rules', 'Age', 'Actions'],
   [KubernetesResources.ClusterRoleBindings]: ['Selected', 'Status', 'Name', 'Bindings', 'Role', 'Age', 'Actions'],
   [KubernetesResources.ResourceQuotas]: ['Selected', 'Status', 'Name', 'Request Count', 'Age', 'Actions'],
+  [KubernetesResources.LimitRanges]: ['Selected', 'Status', 'Name', 'Type', 'Count', 'Age', 'Actions'],
 };

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -51,6 +51,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.ClusterRoles]: NavSection.AccessControl,
   [KubernetesResources.ClusterRoleBindings]: NavSection.AccessControl,
   [KubernetesResources.ResourceQuotas]: NavSection.Config,
+  [KubernetesResources.LimitRanges]: NavSection.Config,
 };
 
 export class KubernetesBar {
@@ -109,6 +110,8 @@ export class KubernetesBar {
         return new KubernetesResourcePage(this.page, 'gateway classes');
       case 'Resource Quotas':
         return new KubernetesResourcePage(this.page, 'resource quotas');
+      case 'Limit Ranges':
+        return new KubernetesResourcePage(this.page, 'limit ranges');
       default:
         return new KubernetesResourcePage(this.page, kubernetesResource);
     }


### PR DESCRIPTION
feat(config): add LimitRange resource

### What does this PR do?

Adds resource views for LimitRange under the Config section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/598726d9-d5e9-4491-ab9a-a272f1381064

### What issues does this PR fix or reference?

Part of  https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Connect to a cluster with example a LimitRange resource
2. Confirm you are able to view the new section

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
