### PR TITLE
feat(config): add HorizontalPodAutoscaler resource

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -96,6 +96,7 @@ import { PriorityClassesResourceFactory } from '/@/resources/priority-classes-re
 import { RuntimeClassesResourceFactory } from '/@/resources/runtime-classes-resource-factory.js';
 import { LeasesResourceFactory } from '/@/resources/leases-resource-factory.js';
 import { MutatingWebhooksResourceFactory } from '/@/resources/mutating-webhooks-resource-factory.js';
+import { HpasResourceFactory } from '/@/resources/hpas-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -227,6 +228,7 @@ export class ContextsManager implements ContextsApi {
       new RuntimeClassesResourceFactory(),
       new LeasesResourceFactory(),
       new MutatingWebhooksResourceFactory(),
+      new HpasResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/hpas-resource-factory.spec.ts
+++ b/packages/extension/src/resources/hpas-resource-factory.spec.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { HpasResourceFactory } from './hpas-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new HpasResourceFactory();
+  expect(factory.resource).toBe('horizontalpodautoscalers');
+  expect(factory.kind).toBe('HorizontalPodAutoscaler');
+});

--- a/packages/extension/src/resources/hpas-resource-factory.ts
+++ b/packages/extension/src/resources/hpas-resource-factory.ts
@@ -1,0 +1,83 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  KubernetesObject,
+  V1Status,
+  V2HorizontalPodAutoscaler,
+  V2HorizontalPodAutoscalerList,
+} from '@kubernetes/client-node';
+import { AutoscalingV2Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class HpasResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'horizontalpodautoscalers',
+      kind: 'HorizontalPodAutoscaler',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          group: 'autoscaling',
+          verb: 'watch',
+          resource: 'horizontalpodautoscalers',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteHorizontalPodAutoscaler);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V2HorizontalPodAutoscaler> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AutoscalingV2Api);
+    const listFn = (): Promise<V2HorizontalPodAutoscalerList> =>
+      apiClient.listNamespacedHorizontalPodAutoscaler({ namespace });
+    const path = `/apis/autoscaling/v2/namespaces/${namespace}/horizontalpodautoscalers`;
+    return new ResourceInformer<V2HorizontalPodAutoscaler>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'horizontalpodautoscalers',
+    });
+  }
+
+  deleteHorizontalPodAutoscaler(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AutoscalingV2Api);
+    return apiClient.deleteNamespacedHorizontalPodAutoscaler({ name, namespace });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -241,6 +241,8 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
   <Route path="/horizontalpodautoscalers">
     <HpasList />
   </Route>

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -75,6 +75,8 @@ import LeasesList from './component/leases/LeasesList.svelte';
 import LeaseDetails from './component/leases/LeaseDetails.svelte';
 import MutatingWebhooksList from './component/mutating-webhooks/MutatingWebhooksList.svelte';
 import MutatingWebhookDetails from './component/mutating-webhooks/MutatingWebhookDetails.svelte';
+import HpasList from './component/hpas/HpasList.svelte';
+import HpaDetails from './component/hpas/HpaDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -239,6 +241,12 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  <Route path="/horizontalpodautoscalers">
+    <HpasList />
+  </Route>
+
+  <Route path="/horizontalpodautoscalers/:name/:namespace/*" let:meta>
+    <HpaDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
   </Route>
 
   <Route path="/mutatingwebhookconfigurations">

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -53,6 +53,7 @@ const configUrls = [
   navigator.kubernetesResourcesURL('RuntimeClass'),
   navigator.kubernetesResourcesURL('Lease'),
   navigator.kubernetesResourcesURL('MutatingWebhookConfiguration'),
+  navigator.kubernetesResourcesURL('HorizontalPodAutoscaler'),
 ];
 
 const networkUrls = [
@@ -180,6 +181,10 @@ $effect(() => {
         title="Mutating Webhook Configs"
         child={true}
         href={navigator.kubernetesResourcesURL('MutatingWebhookConfiguration')} />
+      <NavItem
+        title="Horizontal Pod Autoscalers"
+        child={true}
+        href={navigator.kubernetesResourcesURL('HorizontalPodAutoscaler')} />
     {/if}
 
     <!-- Network section -->

--- a/packages/webview/src/component/hpas/HpaDetails.svelte
+++ b/packages/webview/src/component/hpas/HpaDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { HpaHelper } from './hpa-helper';
+import type { HpaUI } from './HpaUI';
+import type { V2HorizontalPodAutoscaler } from '@kubernetes/client-node';
+import HpaDetailsSummary from './HpaDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const hpaHelper = dependencyAccessor.get<HpaHelper>(HpaHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V2HorizontalPodAutoscaler}
+  typedUI={{} as HpaUI}
+  kind="HorizontalPodAutoscaler"
+  resourceName="horizontalpodautoscalers"
+  listName="Horizontal Pod Autoscalers"
+  name={name}
+  namespace={namespace}
+  transformer={hpaHelper.getHpaUI.bind(hpaHelper)}
+  SummaryComponent={HpaDetailsSummary} />

--- a/packages/webview/src/component/hpas/HpaDetails.svelte
+++ b/packages/webview/src/component/hpas/HpaDetails.svelte
@@ -6,6 +6,7 @@ import { HpaHelper } from './hpa-helper';
 import type { HpaUI } from './HpaUI';
 import type { V2HorizontalPodAutoscaler } from '@kubernetes/client-node';
 import HpaDetailsSummary from './HpaDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -26,4 +27,5 @@ const hpaHelper = dependencyAccessor.get<HpaHelper>(HpaHelper);
   name={name}
   namespace={namespace}
   transformer={hpaHelper.getHpaUI.bind(hpaHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={HpaDetailsSummary} />

--- a/packages/webview/src/component/hpas/HpaDetailsSummary.svelte
+++ b/packages/webview/src/component/hpas/HpaDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V2HorizontalPodAutoscaler } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V2HorizontalPodAutoscaler;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/hpas/HpaUI.ts
+++ b/packages/webview/src/component/hpas/HpaUI.ts
@@ -1,0 +1,29 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface HpaUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  metrics: string;
+  minReplicas: number;
+  maxReplicas: number;
+  currentReplicas: number;
+  desiredReplicas: number;
+}

--- a/packages/webview/src/component/hpas/HpasList.svelte
+++ b/packages/webview/src/component/hpas/HpasList.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import ActionsColumn from './columns/Actions.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { HpaUI } from './HpaUI';
+import { HpaHelper } from './hpa-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const hpaHelper = dependencyAccessor.get<HpaHelper>(HpaHelper);
+
+let statusColumn = new TableColumn<HpaUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<HpaUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let metricsColumn = new TableColumn<HpaUI, string>('Metrics', {
+  renderMapping: (obj): string => obj.metrics,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.metrics.localeCompare(b.metrics),
+});
+
+let minPodsColumn = new TableColumn<HpaUI, string>('Min Pods', {
+  renderMapping: (obj): string => String(obj.minReplicas),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.minReplicas - b.minReplicas,
+});
+
+let maxPodsColumn = new TableColumn<HpaUI, string>('Max Pods', {
+  renderMapping: (obj): string => String(obj.maxReplicas),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.maxReplicas - b.maxReplicas,
+});
+
+let replicasColumn = new TableColumn<HpaUI, string>('Replicas', {
+  renderMapping: (obj): string => String(obj.currentReplicas),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.currentReplicas - b.currentReplicas,
+});
+
+let desiredReplicasColumn = new TableColumn<HpaUI, string>('Desired', {
+  renderMapping: (obj): string => String(obj.desiredReplicas),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.desiredReplicas - b.desiredReplicas,
+});
+
+let ageColumn = new TableColumn<HpaUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  metricsColumn,
+  minPodsColumn,
+  maxPodsColumn,
+  replicasColumn,
+  desiredReplicasColumn,
+  ageColumn,
+  new TableColumn<HpaUI>('Actions', { align: 'right', width: '150px', renderer: ActionsColumn, overflow: true }),
+];
+
+const row = new TableRow<HpaUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'horizontalpodautoscalers',
+      transformer: hpaHelper.getHpaUI,
+    },
+  ]}
+  singular="horizontal pod autoscaler"
+  plural="horizontal pod autoscalers"
+  isNamespaced={true}
+  icon={icon['HorizontalPodAutoscaler']}
+  columns={columns}
+  row={row}>
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['HorizontalPodAutoscaler']} resources={['horizontalpodautoscalers']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/hpas/HpasList.svelte
+++ b/packages/webview/src/component/hpas/HpasList.svelte
@@ -1,17 +1,24 @@
 <script lang="ts">
+import type { KubernetesObject, V2HorizontalPodAutoscaler } from '@kubernetes/client-node';
 import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
 import moment from 'moment';
+import { getContext } from 'svelte';
 
+import { icon } from '/@/component/icons/icon';
 import NameColumn from '/@/component/objects/columns/Name.svelte';
 import StatusColumn from '/@/component/objects/columns/Status.svelte';
-import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
-import ActionsColumn from './columns/Actions.svelte';
-import { getContext } from 'svelte';
-import { DependencyAccessor } from '/@/inject/dependency-accessor';
 import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
-import { icon } from '/@/component/icons/icon';
-import type { HpaUI } from './HpaUI';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+
+import ActionsColumn from './columns/Actions.svelte';
 import { HpaHelper } from './hpa-helper';
+import type { HpaUI } from './HpaUI';
+
+function isV2HorizontalPodAutoscaler(o: KubernetesObject): o is V2HorizontalPodAutoscaler {
+  return 'spec' in o && o.spec !== undefined;
+}
 
 const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
 const hpaHelper = dependencyAccessor.get<HpaHelper>(HpaHelper);
@@ -84,7 +91,12 @@ const row = new TableRow<HpaUI>({ selectable: (_obj): boolean => true });
   kinds={[
     {
       resource: 'horizontalpodautoscalers',
-      transformer: hpaHelper.getHpaUI.bind(hpaHelper),
+      transformer: (o: KubernetesObject): KubernetesObjectUI => {
+        if (!isV2HorizontalPodAutoscaler(o)) {
+          throw new Error(`HorizontalPodAutoscaler ${o.metadata?.name} is missing spec`);
+        }
+        return hpaHelper.getHpaUI.bind(hpaHelper)(o);
+      },
     },
   ]}
   singular="horizontal pod autoscaler"

--- a/packages/webview/src/component/hpas/HpasList.svelte
+++ b/packages/webview/src/component/hpas/HpasList.svelte
@@ -84,7 +84,7 @@ const row = new TableRow<HpaUI>({ selectable: (_obj): boolean => true });
   kinds={[
     {
       resource: 'horizontalpodautoscalers',
-      transformer: hpaHelper.getHpaUI,
+      transformer: hpaHelper.getHpaUI.bind(hpaHelper),
     },
   ]}
   singular="horizontal pod autoscaler"

--- a/packages/webview/src/component/hpas/_hpas-module.ts
+++ b/packages/webview/src/component/hpas/_hpas-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { HpaHelper } from './hpa-helper';
+
+const hpasModule = new ContainerModule(options => {
+  options.bind<HpaHelper>(HpaHelper).toSelf().inSingletonScope();
+});
+
+export { hpasModule };

--- a/packages/webview/src/component/hpas/columns/Actions.svelte
+++ b/packages/webview/src/component/hpas/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/hpas/columns/props.ts
+++ b/packages/webview/src/component/hpas/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { HpaUI } from '/@/component/hpas/HpaUI';
+
+export interface Props {
+  object: HpaUI;
+}

--- a/packages/webview/src/component/hpas/hpa-helper.spec.ts
+++ b/packages/webview/src/component/hpas/hpa-helper.spec.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V2HorizontalPodAutoscaler } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { HpaHelper } from './hpa-helper';
+
+let helper: HpaHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new HpaHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const hpa = {
+    metadata: {
+      name: 'my-hpa',
+      namespace: 'default',
+      uid: 'uid-789',
+    },
+    spec: { maxReplicas: 10 },
+    status: {},
+  } as V2HorizontalPodAutoscaler;
+  const ui = helper.getHpaUI(hpa);
+  expect(ui.kind).toEqual('HorizontalPodAutoscaler');
+  expect(ui.name).toEqual('my-hpa');
+  expect(ui.namespace).toEqual('default');
+});
+
+test('expect Resource metrics formatting "name: current%/target%"', async () => {
+  const hpa = {
+    metadata: { name: 'hpa1' },
+    spec: {
+      maxReplicas: 5,
+      metrics: [
+        {
+          type: 'Resource',
+          resource: { name: 'cpu', target: { averageUtilization: 80 } },
+        },
+      ],
+    },
+    status: {
+      currentMetrics: [
+        {
+          type: 'Resource',
+          resource: { name: 'cpu', current: { averageUtilization: 45 } },
+        },
+      ],
+    },
+  } as V2HorizontalPodAutoscaler;
+  const ui = helper.getHpaUI(hpa);
+  expect(ui.metrics).toEqual('cpu: 45%/80%');
+});
+
+test('expect minReplicas and maxReplicas defaults', async () => {
+  const hpa = {
+    metadata: { name: 'hpa2' },
+    spec: { maxReplicas: 10, minReplicas: 2 },
+    status: {},
+  } as V2HorizontalPodAutoscaler;
+  const ui = helper.getHpaUI(hpa);
+  expect(ui.minReplicas).toEqual(2);
+  expect(ui.maxReplicas).toEqual(10);
+});

--- a/packages/webview/src/component/hpas/hpa-helper.ts
+++ b/packages/webview/src/component/hpas/hpa-helper.ts
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V2HorizontalPodAutoscaler } from '@kubernetes/client-node';
+
+import type { HpaUI } from './HpaUI';
+
+export class HpaHelper {
+  getHpaUI(hpa: V2HorizontalPodAutoscaler): HpaUI {
+    const specMetrics = hpa.spec?.metrics ?? [];
+    const currentMetrics = hpa.status?.currentMetrics ?? [];
+
+    const metrics = specMetrics
+      .map(metric => {
+        if (metric.type === 'Resource') {
+          const name = metric.resource?.name ?? '';
+          const targetUtil = metric.resource?.target?.averageUtilization;
+          const currentMetric = currentMetrics.find(cm => cm.type === 'Resource' && cm.resource?.name === name);
+          const currentUtil = currentMetric?.resource?.current?.averageUtilization;
+          const currentStr = currentUtil !== undefined ? `${String(currentUtil)}%` : '<unknown>';
+          const targetStr = targetUtil !== undefined ? `${String(targetUtil)}%` : '<unknown>';
+          return `${name}: ${currentStr}/${targetStr}`;
+        }
+        if (metric.type === 'Pods') {
+          return metric.pods?.metric?.name ?? 'Pods';
+        }
+        if (metric.type === 'Object') {
+          return metric.object?.metric?.name ?? 'Object';
+        }
+        if (metric.type === 'External') {
+          return metric.external?.metric?.name ?? 'External';
+        }
+        return '';
+      })
+      .filter(name => name !== '')
+      .join(', ');
+
+    return {
+      kind: 'HorizontalPodAutoscaler',
+      uid: hpa.metadata?.uid ?? '',
+      name: hpa.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: hpa.metadata?.namespace ?? '',
+      created: hpa.metadata?.creationTimestamp,
+      selected: false,
+      metrics: metrics || 'N/A',
+      minReplicas: hpa.spec?.minReplicas ?? 1,
+      maxReplicas: hpa.spec?.maxReplicas ?? 0,
+      currentReplicas: hpa.status?.currentReplicas ?? 0,
+      desiredReplicas: hpa.status?.desiredReplicas ?? 0,
+    };
+  }
+}

--- a/packages/webview/src/component/hpas/hpa-helper.ts
+++ b/packages/webview/src/component/hpas/hpa-helper.ts
@@ -22,7 +22,7 @@ import type { HpaUI } from './HpaUI';
 
 export class HpaHelper {
   getHpaUI(hpa: V2HorizontalPodAutoscaler): HpaUI {
-    const specMetrics = hpa.spec?.metrics ?? [];
+    const specMetrics = hpa.spec.metrics ?? [];
     const currentMetrics = hpa.status?.currentMetrics ?? [];
 
     const metrics = specMetrics
@@ -59,8 +59,8 @@ export class HpaHelper {
       created: hpa.metadata?.creationTimestamp,
       selected: false,
       metrics: metrics || 'N/A',
-      minReplicas: hpa.spec?.minReplicas ?? 1,
-      maxReplicas: hpa.spec?.maxReplicas ?? 0,
+      minReplicas: hpa.spec.minReplicas ?? 1,
+      maxReplicas: hpa.spec.maxReplicas ?? 0,
       currentReplicas: hpa.status?.currentReplicas ?? 0,
       desiredReplicas: hpa.status?.desiredReplicas ?? 0,
     };

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -63,6 +63,7 @@ import { priorityClassesModule } from '/@/component/priority-classes/_priority-c
 import { runtimeClassesModule } from '/@/component/runtime-classes/_runtime-classes-module';
 import { leasesModule } from '/@/component/leases/_leases-module';
 import { mutatingWebhooksModule } from '/@/component/mutating-webhooks/_mutating-webhooks-module';
+import { hpasModule } from '/@/component/hpas/_hpas-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -120,6 +121,7 @@ export class InversifyBinding {
     await this.#container.load(runtimeClassesModule);
     await this.#container.load(leasesModule);
     await this.#container.load(mutatingWebhooksModule);
+    await this.#container.load(hpasModule);
 
     return this.#container;
   }

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -262,6 +262,10 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  test('go to hpas page', async () => {
+    const hpasPage = await navigation.openTabPage(KubernetesResources.HorizontalPodAutoscalers);
+    await playExpect(hpasPage.heading).toBeVisible();
+    await playExpect.poll(async () => hpasPage.isEmpty('No horizontalpodautoscalers')).toBeTruthy();
   });
   test('go to mutatingWebhooks page', async () => {
     const mutatingWebhooksPage = await navigation.openTabPage(KubernetesResources.MutatingWebhookConfigs);

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -262,6 +262,7 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  });
   test('go to hpas page', async () => {
     const hpasPage = await navigation.openTabPage(KubernetesResources.HorizontalPodAutoscalers);
     await playExpect(hpasPage.heading).toBeVisible();

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -60,6 +60,7 @@ export enum KubernetesResources {
   RuntimeClasses = 'Runtime Classes',
   Leases = 'Leases',
   MutatingWebhookConfigs = 'Mutating Webhook Configs',
+  HorizontalPodAutoscalers = 'Horizontal Pod Autoscalers',
 }
 
 export const KubernetesResourceAttributes: Record<KubernetesResources, string[]> = {
@@ -193,4 +194,5 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
     'Age',
     'Actions',
   ],
+  [KubernetesResources.HorizontalPodAutoscalers]: ['Selected', 'Status', 'Name', 'Metrics', 'Min Pods', 'Max Pods', 'Replicas', 'Desired', 'Age', 'Actions'],
 };

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -195,4 +195,16 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
     'Actions',
   ],
   [KubernetesResources.HorizontalPodAutoscalers]: ['Selected', 'Status', 'Name', 'Metrics', 'Min Pods', 'Max Pods', 'Replicas', 'Desired', 'Age', 'Actions'],
+  [KubernetesResources.HorizontalPodAutoscalers]: [
+    'Selected',
+    'Status',
+    'Name',
+    'Metrics',
+    'Min Pods',
+    'Max Pods',
+    'Replicas',
+    'Desired',
+    'Age',
+    'Actions',
+  ],
 };

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -194,7 +194,6 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
     'Age',
     'Actions',
   ],
-  [KubernetesResources.HorizontalPodAutoscalers]: ['Selected', 'Status', 'Name', 'Metrics', 'Min Pods', 'Max Pods', 'Replicas', 'Desired', 'Age', 'Actions'],
   [KubernetesResources.HorizontalPodAutoscalers]: [
     'Selected',
     'Status',

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -57,6 +57,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.RuntimeClasses]: NavSection.Config,
   [KubernetesResources.Leases]: NavSection.Config,
   [KubernetesResources.MutatingWebhookConfigs]: NavSection.Config,
+  [KubernetesResources.HorizontalPodAutoscalers]: NavSection.Config,
 };
 
 export class KubernetesBar {
@@ -125,6 +126,8 @@ export class KubernetesBar {
         return new KubernetesResourcePage(this.page, 'runtime classes');
       case 'Mutating Webhook Configs':
         return new KubernetesResourcePage(this.page, 'mutating webhook configurations');
+      case 'Horizontal Pod Autoscalers':
+        return new KubernetesResourcePage(this.page, 'horizontal pod autoscalers');
       default:
         return new KubernetesResourcePage(this.page, kubernetesResource);
     }


### PR DESCRIPTION
feat(config): add HorizontalPodAutoscaler resource

### What does this PR do?

Adds resource views for HorizontalPodAutoscaler under the Config section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/598726d9-d5e9-4491-ab9a-a272f1381064

### What issues does this PR fix or reference?

Part of  https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Connect to a cluster with example an HorizontalPodAutoscaler resource
2. Confirm you are able to view the new section

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
