### PR TITLE
feat(config): add PodDisruptionBudget resource

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -91,6 +91,7 @@ import { GatewayClassesResourceFactory } from '/@/resources/gatewayclasses-resou
 import { ResourceQuotasResourceFactory } from '/@/resources/resource-quotas-resource-factory.js';
 import { GatewaysResourceFactory } from '/@/resources/gateways-resource-factory.js';
 import { LimitRangesResourceFactory } from '/@/resources/limit-ranges-resource-factory.js';
+import { PdbsResourceFactory } from '/@/resources/pdbs-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -217,6 +218,7 @@ export class ContextsManager implements ContextsApi {
       new ResourceQuotasResourceFactory(),
       new GatewaysResourceFactory(),
       new LimitRangesResourceFactory(),
+      new PdbsResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/pdbs-resource-factory.spec.ts
+++ b/packages/extension/src/resources/pdbs-resource-factory.spec.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { PdbsResourceFactory } from './pdbs-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new PdbsResourceFactory();
+  expect(factory.resource).toBe('poddisruptionbudgets');
+  expect(factory.kind).toBe('PodDisruptionBudget');
+});

--- a/packages/extension/src/resources/pdbs-resource-factory.ts
+++ b/packages/extension/src/resources/pdbs-resource-factory.ts
@@ -1,0 +1,82 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  KubernetesObject,
+  V1PodDisruptionBudget,
+  V1PodDisruptionBudgetList,
+  V1Status,
+} from '@kubernetes/client-node';
+import { PolicyV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class PdbsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'poddisruptionbudgets',
+      kind: 'PodDisruptionBudget',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          group: 'policy',
+          verb: 'watch',
+          resource: 'poddisruptionbudgets',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deletePodDisruptionBudget);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1PodDisruptionBudget> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(PolicyV1Api);
+    const listFn = (): Promise<V1PodDisruptionBudgetList> => apiClient.listNamespacedPodDisruptionBudget({ namespace });
+    const path = `/apis/policy/v1/namespaces/${namespace}/poddisruptionbudgets`;
+    return new ResourceInformer<V1PodDisruptionBudget>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'poddisruptionbudgets',
+    });
+  }
+
+  deletePodDisruptionBudget(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(PolicyV1Api);
+    return apiClient.deleteNamespacedPodDisruptionBudget({ name, namespace });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -65,6 +65,8 @@ import GatewaysList from './component/gateways/GatewaysList.svelte';
 import GatewayDetails from './component/gateways/GatewayDetails.svelte';
 import LimitRangesList from './component/limit-ranges/LimitRangesList.svelte';
 import LimitRangeDetails from './component/limit-ranges/LimitRangeDetails.svelte';
+import PdbsList from './component/pdbs/PdbsList.svelte';
+import PdbDetails from './component/pdbs/PdbDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -229,6 +231,12 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  <Route path="/poddisruptionbudgets">
+    <PdbsList />
+  </Route>
+
+  <Route path="/poddisruptionbudgets/:name/:namespace/*" let:meta>
+    <PdbDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
   </Route>
 
   <Route path="/limitranges">

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -231,6 +231,8 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
   <Route path="/poddisruptionbudgets">
     <PdbsList />
   </Route>

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -165,11 +165,6 @@ $effect(() => {
       <NavItem title="Service Accounts" child={true} href={navigator.kubernetesResourcesURL('ServiceAccount')} />
       <NavItem title="Resource Quotas" child={true} href={navigator.kubernetesResourcesURL('ResourceQuota')} />
       <NavItem title="Limit Ranges" child={true} href={navigator.kubernetesResourcesURL('LimitRange')} />
-      <NavItem title="Pod Disruption Budgets" child={true} href={navigator.kubernetesResourcesURL('PodDisruptionBudget')} />
-      <NavItem
-        title="Pod Disruption Budgets"
-        child={true}
-        href={navigator.kubernetesResourcesURL('PodDisruptionBudget')} />
       <NavItem
         title="Pod Disruption Budgets"
         child={true}

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -170,6 +170,10 @@ $effect(() => {
         title="Pod Disruption Budgets"
         child={true}
         href={navigator.kubernetesResourcesURL('PodDisruptionBudget')} />
+      <NavItem
+        title="Pod Disruption Budgets"
+        child={true}
+        href={navigator.kubernetesResourcesURL('PodDisruptionBudget')} />
     {/if}
 
     <!-- Network section -->

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -166,6 +166,10 @@ $effect(() => {
       <NavItem title="Resource Quotas" child={true} href={navigator.kubernetesResourcesURL('ResourceQuota')} />
       <NavItem title="Limit Ranges" child={true} href={navigator.kubernetesResourcesURL('LimitRange')} />
       <NavItem title="Pod Disruption Budgets" child={true} href={navigator.kubernetesResourcesURL('PodDisruptionBudget')} />
+      <NavItem
+        title="Pod Disruption Budgets"
+        child={true}
+        href={navigator.kubernetesResourcesURL('PodDisruptionBudget')} />
     {/if}
 
     <!-- Network section -->

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -48,6 +48,7 @@ const configUrls = [
   navigator.kubernetesResourcesURL('ServiceAccount'),
   navigator.kubernetesResourcesURL('ResourceQuota'),
   navigator.kubernetesResourcesURL('LimitRange'),
+  navigator.kubernetesResourcesURL('PodDisruptionBudget'),
 ];
 
 const networkUrls = [
@@ -164,6 +165,7 @@ $effect(() => {
       <NavItem title="Service Accounts" child={true} href={navigator.kubernetesResourcesURL('ServiceAccount')} />
       <NavItem title="Resource Quotas" child={true} href={navigator.kubernetesResourcesURL('ResourceQuota')} />
       <NavItem title="Limit Ranges" child={true} href={navigator.kubernetesResourcesURL('LimitRange')} />
+      <NavItem title="Pod Disruption Budgets" child={true} href={navigator.kubernetesResourcesURL('PodDisruptionBudget')} />
     {/if}
 
     <!-- Network section -->

--- a/packages/webview/src/component/pdbs/PdbDetails.svelte
+++ b/packages/webview/src/component/pdbs/PdbDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { PdbHelper } from './pdb-helper';
+import type { PdbUI } from './PdbUI';
+import type { V1PodDisruptionBudget } from '@kubernetes/client-node';
+import PdbDetailsSummary from './PdbDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const pdbHelper = dependencyAccessor.get<PdbHelper>(PdbHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1PodDisruptionBudget}
+  typedUI={{} as PdbUI}
+  kind="PodDisruptionBudget"
+  resourceName="poddisruptionbudgets"
+  listName="Pod Disruption Budgets"
+  name={name}
+  namespace={namespace}
+  transformer={pdbHelper.getPdbUI.bind(pdbHelper)}
+  SummaryComponent={PdbDetailsSummary} />

--- a/packages/webview/src/component/pdbs/PdbDetails.svelte
+++ b/packages/webview/src/component/pdbs/PdbDetails.svelte
@@ -6,6 +6,7 @@ import { PdbHelper } from './pdb-helper';
 import type { PdbUI } from './PdbUI';
 import type { V1PodDisruptionBudget } from '@kubernetes/client-node';
 import PdbDetailsSummary from './PdbDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -26,4 +27,5 @@ const pdbHelper = dependencyAccessor.get<PdbHelper>(PdbHelper);
   name={name}
   namespace={namespace}
   transformer={pdbHelper.getPdbUI.bind(pdbHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={PdbDetailsSummary} />

--- a/packages/webview/src/component/pdbs/PdbDetailsSummary.svelte
+++ b/packages/webview/src/component/pdbs/PdbDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1PodDisruptionBudget } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1PodDisruptionBudget;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/pdbs/PdbUI.ts
+++ b/packages/webview/src/component/pdbs/PdbUI.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface PdbUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  minAvailable: string;
+  maxUnavailable: string;
+  currentHealthy: number;
+  desiredHealthy: number;
+  allowedDisruptions: number;
+  expectedPods: number;
+}

--- a/packages/webview/src/component/pdbs/PdbsList.svelte
+++ b/packages/webview/src/component/pdbs/PdbsList.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import ActionsColumn from './columns/Actions.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { PdbUI } from './PdbUI';
+import { PdbHelper } from './pdb-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const pdbHelper = dependencyAccessor.get<PdbHelper>(PdbHelper);
+
+let statusColumn = new TableColumn<PdbUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<PdbUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let minAvailableColumn = new TableColumn<PdbUI, string>('Min Available', {
+  renderMapping: (obj): string => obj.minAvailable,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.minAvailable.localeCompare(b.minAvailable),
+});
+
+let maxUnavailableColumn = new TableColumn<PdbUI, string>('Max Unavailable', {
+  renderMapping: (obj): string => obj.maxUnavailable,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.maxUnavailable.localeCompare(b.maxUnavailable),
+});
+
+let currentHealthyColumn = new TableColumn<PdbUI, string>('Current Healthy', {
+  renderMapping: (obj): string => String(obj.currentHealthy),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.currentHealthy - b.currentHealthy,
+});
+
+let desiredHealthyColumn = new TableColumn<PdbUI, string>('Desired Healthy', {
+  renderMapping: (obj): string => String(obj.desiredHealthy),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.desiredHealthy - b.desiredHealthy,
+});
+
+let allowedDisruptionsColumn = new TableColumn<PdbUI, string>('Allowed Disruptions', {
+  renderMapping: (obj): string => String(obj.allowedDisruptions),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.allowedDisruptions - b.allowedDisruptions,
+});
+
+let expectedPodsColumn = new TableColumn<PdbUI, string>('Expected Pods', {
+  renderMapping: (obj): string => String(obj.expectedPods),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.expectedPods - b.expectedPods,
+});
+
+let ageColumn = new TableColumn<PdbUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  minAvailableColumn,
+  maxUnavailableColumn,
+  currentHealthyColumn,
+  desiredHealthyColumn,
+  allowedDisruptionsColumn,
+  expectedPodsColumn,
+  ageColumn,
+  new TableColumn<PdbUI>('Actions', { align: 'right', width: '150px', renderer: ActionsColumn, overflow: true }),
+];
+
+const row = new TableRow<PdbUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'poddisruptionbudgets',
+      transformer: pdbHelper.getPdbUI,
+    },
+  ]}
+  singular="pod disruption budget"
+  plural="pod disruption budgets"
+  isNamespaced={true}
+  icon={icon['PodDisruptionBudget']}
+  columns={columns}
+  row={row}>
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['PodDisruptionBudget']} resources={['poddisruptionbudgets']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/pdbs/PdbsList.svelte
+++ b/packages/webview/src/component/pdbs/PdbsList.svelte
@@ -91,7 +91,7 @@ const row = new TableRow<PdbUI>({ selectable: (_obj): boolean => true });
   kinds={[
     {
       resource: 'poddisruptionbudgets',
-      transformer: pdbHelper.getPdbUI,
+      transformer: pdbHelper.getPdbUI.bind(pdbHelper),
     },
   ]}
   singular="pod disruption budget"

--- a/packages/webview/src/component/pdbs/_pdbs-module.ts
+++ b/packages/webview/src/component/pdbs/_pdbs-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { PdbHelper } from './pdb-helper';
+
+const pdbsModule = new ContainerModule(options => {
+  options.bind<PdbHelper>(PdbHelper).toSelf().inSingletonScope();
+});
+
+export { pdbsModule };

--- a/packages/webview/src/component/pdbs/columns/Actions.svelte
+++ b/packages/webview/src/component/pdbs/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/pdbs/columns/props.ts
+++ b/packages/webview/src/component/pdbs/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { PdbUI } from '/@/component/pdbs/PdbUI';
+
+export interface Props {
+  object: PdbUI;
+}

--- a/packages/webview/src/component/pdbs/pdb-helper.spec.ts
+++ b/packages/webview/src/component/pdbs/pdb-helper.spec.ts
@@ -1,0 +1,74 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1PodDisruptionBudget } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { PdbHelper } from './pdb-helper';
+
+let helper: PdbHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new PdbHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const pdb = {
+    metadata: {
+      name: 'my-pdb',
+      namespace: 'default',
+      uid: 'uid-pdb',
+    },
+    spec: { minAvailable: 1 },
+    status: {},
+  } as V1PodDisruptionBudget;
+  const ui = helper.getPdbUI(pdb);
+  expect(ui.kind).toEqual('PodDisruptionBudget');
+  expect(ui.name).toEqual('my-pdb');
+  expect(ui.namespace).toEqual('default');
+});
+
+test('expect minAvailable and maxUnavailable as strings', async () => {
+  const pdb = {
+    metadata: { name: 'pdb1' },
+    spec: { minAvailable: 2, maxUnavailable: 1 },
+    status: {},
+  } as V1PodDisruptionBudget;
+  const ui = helper.getPdbUI(pdb);
+  expect(ui.minAvailable).toEqual('2');
+  expect(ui.maxUnavailable).toEqual('1');
+});
+
+test('expect status fields with defaults', async () => {
+  const pdb = {
+    metadata: { name: 'pdb2' },
+    spec: {},
+    status: {
+      currentHealthy: 3,
+      desiredHealthy: 2,
+      disruptionsAllowed: 1,
+      expectedPods: 4,
+    },
+  } as V1PodDisruptionBudget;
+  const ui = helper.getPdbUI(pdb);
+  expect(ui.currentHealthy).toEqual(3);
+  expect(ui.desiredHealthy).toEqual(2);
+  expect(ui.allowedDisruptions).toEqual(1);
+  expect(ui.expectedPods).toEqual(4);
+});

--- a/packages/webview/src/component/pdbs/pdb-helper.ts
+++ b/packages/webview/src/component/pdbs/pdb-helper.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1PodDisruptionBudget } from '@kubernetes/client-node';
+
+import type { PdbUI } from './PdbUI';
+
+export class PdbHelper {
+  getPdbUI(pdb: V1PodDisruptionBudget): PdbUI {
+    return {
+      kind: 'PodDisruptionBudget',
+      uid: pdb.metadata?.uid ?? '',
+      name: pdb.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: pdb.metadata?.namespace ?? '',
+      created: pdb.metadata?.creationTimestamp,
+      selected: false,
+      minAvailable: String(pdb.spec?.minAvailable ?? 'N/A'),
+      maxUnavailable: String(pdb.spec?.maxUnavailable ?? 'N/A'),
+      currentHealthy: pdb.status?.currentHealthy ?? 0,
+      desiredHealthy: pdb.status?.desiredHealthy ?? 0,
+      allowedDisruptions: pdb.status?.disruptionsAllowed ?? 0,
+      expectedPods: pdb.status?.expectedPods ?? 0,
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -58,6 +58,7 @@ import { gatewayClassesModule } from '/@/component/gatewayclasses/_gatewayclasse
 import { resourceQuotasModule } from '/@/component/resource-quotas/_resource-quotas-module';
 import { gatewaysModule } from '/@/component/gateways/_gateways-module';
 import { limitRangesModule } from '/@/component/limit-ranges/_limit-ranges-module';
+import { pdbsModule } from '/@/component/pdbs/_pdbs-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -110,6 +111,7 @@ export class InversifyBinding {
     await this.#container.load(resourceQuotasModule);
     await this.#container.load(gatewaysModule);
     await this.#container.load(limitRangesModule);
+    await this.#container.load(pdbsModule);
 
     return this.#container;
   }

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -262,6 +262,7 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  });
   test('go to pdbs page', async () => {
     const pdbsPage = await navigation.openTabPage(KubernetesResources.PodDisruptionBudgets);
     await playExpect(pdbsPage.heading).toBeVisible();

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -262,6 +262,10 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  test('go to pdbs page', async () => {
+    const pdbsPage = await navigation.openTabPage(KubernetesResources.PodDisruptionBudgets);
+    await playExpect(pdbsPage.heading).toBeVisible();
+    await playExpect.poll(async () => pdbsPage.isEmpty('No poddisruptionbudgets')).toBeTruthy();
   });
   test('go to limitRanges page', async () => {
     const limitRangesPage = await navigation.openTabPage(KubernetesResources.LimitRanges);

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -155,7 +155,6 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   [KubernetesResources.ClusterRoleBindings]: ['Selected', 'Status', 'Name', 'Bindings', 'Role', 'Age', 'Actions'],
   [KubernetesResources.ResourceQuotas]: ['Selected', 'Status', 'Name', 'Request Count', 'Age', 'Actions'],
   [KubernetesResources.LimitRanges]: ['Selected', 'Status', 'Name', 'Type', 'Count', 'Age', 'Actions'],
-  [KubernetesResources.PodDisruptionBudgets]: ['Selected', 'Status', 'Name', 'Min Available', 'Max Unavailable', 'Current Healthy', 'Desired Healthy', 'Allowed Disruptions', 'Expected Pods', 'Age', 'Actions'],
   [KubernetesResources.PodDisruptionBudgets]: [
     'Selected',
     'Status',

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -55,6 +55,7 @@ export enum KubernetesResources {
   ClusterRoleBindings = 'Cluster Role Bindings',
   ResourceQuotas = 'Resource Quotas',
   LimitRanges = 'Limit Ranges',
+  PodDisruptionBudgets = 'Pod Disruption Budgets',
 }
 
 export const KubernetesResourceAttributes: Record<KubernetesResources, string[]> = {
@@ -154,4 +155,5 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   [KubernetesResources.ClusterRoleBindings]: ['Selected', 'Status', 'Name', 'Bindings', 'Role', 'Age', 'Actions'],
   [KubernetesResources.ResourceQuotas]: ['Selected', 'Status', 'Name', 'Request Count', 'Age', 'Actions'],
   [KubernetesResources.LimitRanges]: ['Selected', 'Status', 'Name', 'Type', 'Count', 'Age', 'Actions'],
+  [KubernetesResources.PodDisruptionBudgets]: ['Selected', 'Status', 'Name', 'Min Available', 'Max Unavailable', 'Current Healthy', 'Desired Healthy', 'Allowed Disruptions', 'Expected Pods', 'Age', 'Actions'],
 };

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -156,4 +156,17 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   [KubernetesResources.ResourceQuotas]: ['Selected', 'Status', 'Name', 'Request Count', 'Age', 'Actions'],
   [KubernetesResources.LimitRanges]: ['Selected', 'Status', 'Name', 'Type', 'Count', 'Age', 'Actions'],
   [KubernetesResources.PodDisruptionBudgets]: ['Selected', 'Status', 'Name', 'Min Available', 'Max Unavailable', 'Current Healthy', 'Desired Healthy', 'Allowed Disruptions', 'Expected Pods', 'Age', 'Actions'],
+  [KubernetesResources.PodDisruptionBudgets]: [
+    'Selected',
+    'Status',
+    'Name',
+    'Min Available',
+    'Max Unavailable',
+    'Current Healthy',
+    'Desired Healthy',
+    'Allowed Disruptions',
+    'Expected Pods',
+    'Age',
+    'Actions',
+  ],
 };

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -52,6 +52,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.ClusterRoleBindings]: NavSection.AccessControl,
   [KubernetesResources.ResourceQuotas]: NavSection.Config,
   [KubernetesResources.LimitRanges]: NavSection.Config,
+  [KubernetesResources.PodDisruptionBudgets]: NavSection.Config,
 };
 
 export class KubernetesBar {
@@ -112,6 +113,8 @@ export class KubernetesBar {
         return new KubernetesResourcePage(this.page, 'resource quotas');
       case 'Limit Ranges':
         return new KubernetesResourcePage(this.page, 'limit ranges');
+      case 'Pod Disruption Budgets':
+        return new KubernetesResourcePage(this.page, 'pod disruption budgets');
       default:
         return new KubernetesResourcePage(this.page, kubernetesResource);
     }


### PR DESCRIPTION
feat(config): add PodDisruptionBudget resource

### What does this PR do?

Adds resource views for PodDisruptionBudget under the Config section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/598726d9-d5e9-4491-ab9a-a272f1381064

### What issues does this PR fix or reference?

Part of  https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Connect to a cluster with example a PodDisruptionBudget resource
2. Confirm you are able to view the new section

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
