### PR TITLE
feat(config): add RuntimeClass resource

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -93,6 +93,7 @@ import { GatewaysResourceFactory } from '/@/resources/gateways-resource-factory.
 import { LimitRangesResourceFactory } from '/@/resources/limit-ranges-resource-factory.js';
 import { PdbsResourceFactory } from '/@/resources/pdbs-resource-factory.js';
 import { PriorityClassesResourceFactory } from '/@/resources/priority-classes-resource-factory.js';
+import { RuntimeClassesResourceFactory } from '/@/resources/runtime-classes-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -221,6 +222,7 @@ export class ContextsManager implements ContextsApi {
       new LimitRangesResourceFactory(),
       new PdbsResourceFactory(),
       new PriorityClassesResourceFactory(),
+      new RuntimeClassesResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/runtime-classes-resource-factory.spec.ts
+++ b/packages/extension/src/resources/runtime-classes-resource-factory.spec.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { RuntimeClassesResourceFactory } from './runtime-classes-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new RuntimeClassesResourceFactory();
+  expect(factory.resource).toBe('runtimeclasses');
+  expect(factory.kind).toBe('RuntimeClass');
+});

--- a/packages/extension/src/resources/runtime-classes-resource-factory.ts
+++ b/packages/extension/src/resources/runtime-classes-resource-factory.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1RuntimeClass, V1RuntimeClassList, V1Status } from '@kubernetes/client-node';
+import { NodeV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class RuntimeClassesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'runtimeclasses',
+      kind: 'RuntimeClass',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          group: 'node.k8s.io',
+          verb: 'watch',
+          resource: 'runtimeclasses',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteRuntimeClass);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1RuntimeClass> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(NodeV1Api);
+    const listFn = (): Promise<V1RuntimeClassList> => apiClient.listRuntimeClass();
+    const path = `/apis/node.k8s.io/v1/runtimeclasses`;
+    return new ResourceInformer<V1RuntimeClass>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'runtimeclasses',
+    });
+  }
+
+  deleteRuntimeClass(kubeconfig: KubeConfigSingleContext, name: string): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(NodeV1Api);
+    return apiClient.deleteRuntimeClass({ name });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -235,6 +235,8 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
   <Route path="/runtimeclasses">
     <RuntimeClassesList />
   </Route>

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -69,6 +69,8 @@ import PdbsList from './component/pdbs/PdbsList.svelte';
 import PdbDetails from './component/pdbs/PdbDetails.svelte';
 import PriorityClassesList from './component/priority-classes/PriorityClassesList.svelte';
 import PriorityClassDetails from './component/priority-classes/PriorityClassDetails.svelte';
+import RuntimeClassesList from './component/runtime-classes/RuntimeClassesList.svelte';
+import RuntimeClassDetails from './component/runtime-classes/RuntimeClassDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -233,6 +235,12 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  <Route path="/runtimeclasses">
+    <RuntimeClassesList />
+  </Route>
+
+  <Route path="/runtimeclasses/:name/*" let:meta>
+    <RuntimeClassDetails name={decodeURI(meta.params.name)} />
   </Route>
 
   <Route path="/priorityclasses">

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -50,6 +50,7 @@ const configUrls = [
   navigator.kubernetesResourcesURL('LimitRange'),
   navigator.kubernetesResourcesURL('PodDisruptionBudget'),
   navigator.kubernetesResourcesURL('PriorityClass'),
+  navigator.kubernetesResourcesURL('RuntimeClass'),
 ];
 
 const networkUrls = [
@@ -171,6 +172,7 @@ $effect(() => {
         child={true}
         href={navigator.kubernetesResourcesURL('PodDisruptionBudget')} />
       <NavItem title="Priority Classes" child={true} href={navigator.kubernetesResourcesURL('PriorityClass')} />
+      <NavItem title="Runtime Classes" child={true} href={navigator.kubernetesResourcesURL('RuntimeClass')} />
     {/if}
 
     <!-- Network section -->

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -52,7 +52,6 @@ const configUrls = [
   navigator.kubernetesResourcesURL('PriorityClass'),
   navigator.kubernetesResourcesURL('RuntimeClass'),
 ];
-const configUrls = [navigator.kubernetesResourcesURL('ConfigMap'), navigator.kubernetesResourcesURL('RuntimeClass')];
 
 const networkUrls = [
   navigator.kubernetesResourcesURL('Service'),

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -52,6 +52,7 @@ const configUrls = [
   navigator.kubernetesResourcesURL('PriorityClass'),
   navigator.kubernetesResourcesURL('RuntimeClass'),
 ];
+const configUrls = [navigator.kubernetesResourcesURL('ConfigMap'), navigator.kubernetesResourcesURL('RuntimeClass')];
 
 const networkUrls = [
   navigator.kubernetesResourcesURL('Service'),

--- a/packages/webview/src/component/runtime-classes/RuntimeClassDetails.svelte
+++ b/packages/webview/src/component/runtime-classes/RuntimeClassDetails.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { RuntimeClassHelper } from './runtime-class-helper';
+import type { RuntimeClassUI } from './RuntimeClassUI';
+import type { V1RuntimeClass } from '@kubernetes/client-node';
+import RuntimeClassDetailsSummary from './RuntimeClassDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+}
+let { name }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const runtimeClassHelper = dependencyAccessor.get<RuntimeClassHelper>(RuntimeClassHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1RuntimeClass}
+  typedUI={{} as RuntimeClassUI}
+  kind="RuntimeClass"
+  resourceName="runtimeclasses"
+  listName="Runtime Classes"
+  name={name}
+  transformer={runtimeClassHelper.getRuntimeClassUI.bind(runtimeClassHelper)}
+  SummaryComponent={RuntimeClassDetailsSummary} />

--- a/packages/webview/src/component/runtime-classes/RuntimeClassDetails.svelte
+++ b/packages/webview/src/component/runtime-classes/RuntimeClassDetails.svelte
@@ -6,6 +6,7 @@ import { RuntimeClassHelper } from './runtime-class-helper';
 import type { RuntimeClassUI } from './RuntimeClassUI';
 import type { V1RuntimeClass } from '@kubernetes/client-node';
 import RuntimeClassDetailsSummary from './RuntimeClassDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -24,4 +25,5 @@ const runtimeClassHelper = dependencyAccessor.get<RuntimeClassHelper>(RuntimeCla
   listName="Runtime Classes"
   name={name}
   transformer={runtimeClassHelper.getRuntimeClassUI.bind(runtimeClassHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={RuntimeClassDetailsSummary} />

--- a/packages/webview/src/component/runtime-classes/RuntimeClassDetailsSummary.svelte
+++ b/packages/webview/src/component/runtime-classes/RuntimeClassDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1RuntimeClass } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1RuntimeClass;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/runtime-classes/RuntimeClassUI.ts
+++ b/packages/webview/src/component/runtime-classes/RuntimeClassUI.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface RuntimeClassUI extends KubernetesObjectUI {
+  uid: string;
+  created?: Date;
+  handler: string;
+}

--- a/packages/webview/src/component/runtime-classes/RuntimeClassesList.svelte
+++ b/packages/webview/src/component/runtime-classes/RuntimeClassesList.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { RuntimeClassUI } from './RuntimeClassUI';
+import { RuntimeClassHelper } from './runtime-class-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const runtimeClassHelper = dependencyAccessor.get<RuntimeClassHelper>(RuntimeClassHelper);
+
+let statusColumn = new TableColumn<RuntimeClassUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<RuntimeClassUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let handlerColumn = new TableColumn<RuntimeClassUI, string>('Handler', {
+  renderMapping: (obj): string => obj.handler,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.handler.localeCompare(b.handler),
+});
+
+let ageColumn = new TableColumn<RuntimeClassUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [statusColumn, nameColumn, handlerColumn, ageColumn];
+
+const row = new TableRow<RuntimeClassUI>({});
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'runtimeclasses',
+      transformer: runtimeClassHelper.getRuntimeClassUI.bind(runtimeClassHelper),
+    },
+  ]}
+  singular="runtime class"
+  plural="runtime classes"
+  isNamespaced={false}
+  icon={icon['RuntimeClass']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['RuntimeClass']} resources={['runtimeclasses']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/runtime-classes/RuntimeClassesList.svelte
+++ b/packages/webview/src/component/runtime-classes/RuntimeClassesList.svelte
@@ -11,6 +11,7 @@ import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.sv
 import { icon } from '/@/component/icons/icon';
 import type { RuntimeClassUI } from './RuntimeClassUI';
 import { RuntimeClassHelper } from './runtime-class-helper';
+import ActionsColumn from './columns/Actions.svelte';
 
 const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
 const runtimeClassHelper = dependencyAccessor.get<RuntimeClassHelper>(RuntimeClassHelper);
@@ -40,9 +41,19 @@ let ageColumn = new TableColumn<RuntimeClassUI, Date | undefined>('Age', {
   comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
 });
 
-const columns = [statusColumn, nameColumn, handlerColumn, ageColumn];
+const columns = [
+  statusColumn,
+  nameColumn,
+  handlerColumn,
+  ageColumn,
+  new TableColumn<RuntimeClassUI>('Actions', {
+    align: 'right',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
 
-const row = new TableRow<RuntimeClassUI>({});
+const row = new TableRow<RuntimeClassUI>({ selectable: (_obj): boolean => true });
 </script>
 
 <KubernetesObjectsList

--- a/packages/webview/src/component/runtime-classes/_runtime-classes-module.ts
+++ b/packages/webview/src/component/runtime-classes/_runtime-classes-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { RuntimeClassHelper } from './runtime-class-helper';
+
+const runtimeClassesModule = new ContainerModule(options => {
+  options.bind<RuntimeClassHelper>(RuntimeClassHelper).toSelf().inSingletonScope();
+});
+
+export { runtimeClassesModule };

--- a/packages/webview/src/component/runtime-classes/columns/Actions.svelte
+++ b/packages/webview/src/component/runtime-classes/columns/Actions.svelte
@@ -5,12 +5,4 @@ import type { Props } from './props';
 let { object }: Props = $props();
 </script>
 
-/********************************************************************** * Copyright (C) 2026 Red Hat, Inc. * * Licensed
-under the Apache License, Version 2.0 (the "License"); * you may not use this file except in compliance with the
-License. * You may obtain a copy of the License at * * http://www.apache.org/licenses/LICENSE-2.0 * * Unless required by
-applicable law or agreed to in writing, software * distributed under the License is distributed on an "AS IS" BASIS, *
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. * See the License for the specific language
-governing permissions and * limitations under the License. * * SPDX-License-Identifier: Apache-2.0
-***********************************************************************/
-
 <DeleteAction object={object} />

--- a/packages/webview/src/component/runtime-classes/columns/Actions.svelte
+++ b/packages/webview/src/component/runtime-classes/columns/Actions.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+/********************************************************************** * Copyright (C) 2026 Red Hat, Inc. * * Licensed
+under the Apache License, Version 2.0 (the "License"); * you may not use this file except in compliance with the
+License. * You may obtain a copy of the License at * * http://www.apache.org/licenses/LICENSE-2.0 * * Unless required by
+applicable law or agreed to in writing, software * distributed under the License is distributed on an "AS IS" BASIS, *
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. * See the License for the specific language
+governing permissions and * limitations under the License. * * SPDX-License-Identifier: Apache-2.0
+***********************************************************************/
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/runtime-classes/columns/props.ts
+++ b/packages/webview/src/component/runtime-classes/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { RuntimeClassUI } from '/@/component/runtime-classes/RuntimeClassUI';
+
+export interface Props {
+  object: RuntimeClassUI;
+}

--- a/packages/webview/src/component/runtime-classes/runtime-class-helper.spec.ts
+++ b/packages/webview/src/component/runtime-classes/runtime-class-helper.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { RuntimeClassHelper } from './runtime-class-helper';
+
+let helper: RuntimeClassHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new RuntimeClassHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const obj = {
+    metadata: {
+      name: 'my-runtime',
+      uid: 'uid-rc',
+    },
+    handler: 'runc',
+  } as KubernetesObject;
+  const ui = helper.getRuntimeClassUI(obj);
+  expect(ui.kind).toEqual('RuntimeClass');
+  expect(ui.name).toEqual('my-runtime');
+  expect(ui.uid).toEqual('uid-rc');
+});
+
+test('expect handler field', async () => {
+  const obj = {
+    metadata: { name: 'kata-runtime' },
+    handler: 'kata',
+  } as KubernetesObject;
+  const ui = helper.getRuntimeClassUI(obj);
+  expect(ui.handler).toEqual('kata');
+});
+
+test('expect empty handler when missing', async () => {
+  const obj = {
+    metadata: { name: 'no-handler' },
+  } as KubernetesObject;
+  const ui = helper.getRuntimeClassUI(obj);
+  expect(ui.handler).toEqual('');
+});

--- a/packages/webview/src/component/runtime-classes/runtime-class-helper.ts
+++ b/packages/webview/src/component/runtime-classes/runtime-class-helper.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1RuntimeClass } from '@kubernetes/client-node';
+
+import type { RuntimeClassUI } from './RuntimeClassUI';
+
+export class RuntimeClassHelper {
+  getRuntimeClassUI(obj: KubernetesObject): RuntimeClassUI {
+    const runtimeClass = obj as V1RuntimeClass;
+    return {
+      kind: 'RuntimeClass',
+      uid: runtimeClass.metadata?.uid ?? '',
+      name: runtimeClass.metadata?.name ?? '',
+      status: 'RUNNING',
+      created: runtimeClass.metadata?.creationTimestamp,
+      handler: runtimeClass.handler ?? '',
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -60,6 +60,7 @@ import { gatewaysModule } from '/@/component/gateways/_gateways-module';
 import { limitRangesModule } from '/@/component/limit-ranges/_limit-ranges-module';
 import { pdbsModule } from '/@/component/pdbs/_pdbs-module';
 import { priorityClassesModule } from '/@/component/priority-classes/_priority-classes-module';
+import { runtimeClassesModule } from '/@/component/runtime-classes/_runtime-classes-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -114,6 +115,7 @@ export class InversifyBinding {
     await this.#container.load(limitRangesModule);
     await this.#container.load(pdbsModule);
     await this.#container.load(priorityClassesModule);
+    await this.#container.load(runtimeClassesModule);
 
     return this.#container;
   }

--- a/packages/webview/src/navigation/navigator.ts
+++ b/packages/webview/src/navigation/navigator.ts
@@ -91,6 +91,8 @@ export class Navigator {
       return 'gatewayclasses';
     } else if (kind === 'PriorityClass') {
       return 'priorityclasses';
+    } else if (kind === 'RuntimeClass') {
+      return 'runtimeclasses';
     }
     // otherwise do the simple conversion
     return kind.toLowerCase() + 's';

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -262,6 +262,7 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  });
   test('go to runtimeClasses page', async () => {
     const runtimeClassesPage = await navigation.openTabPage(KubernetesResources.RuntimeClasses);
     await playExpect(runtimeClassesPage.heading).toBeVisible();

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -262,6 +262,10 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  test('go to runtimeClasses page', async () => {
+    const runtimeClassesPage = await navigation.openTabPage(KubernetesResources.RuntimeClasses);
+    await playExpect(runtimeClassesPage.heading).toBeVisible();
+    await playExpect.poll(async () => runtimeClassesPage.isEmpty('No runtimeclasses')).toBeTruthy();
   });
   test('go to priorityClasses page', async () => {
     const priorityClassesPage = await navigation.openTabPage(KubernetesResources.PriorityClasses);

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -57,6 +57,7 @@ export enum KubernetesResources {
   LimitRanges = 'Limit Ranges',
   PodDisruptionBudgets = 'Pod Disruption Budgets',
   PriorityClasses = 'Priority Classes',
+  RuntimeClasses = 'Runtime Classes',
 }
 
 export const KubernetesResourceAttributes: Record<KubernetesResources, string[]> = {
@@ -170,4 +171,5 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
     'Actions',
   ],
   [KubernetesResources.PriorityClasses]: ['Status', 'Name', 'Value', 'Global Default', 'Preemption Policy', 'Age'],
+  [KubernetesResources.RuntimeClasses]: ['Status', 'Name', 'Handler', 'Age'],
 };

--- a/tests/playwright/src/model/pages/kubernetes-resource-page.ts
+++ b/tests/playwright/src/model/pages/kubernetes-resource-page.ts
@@ -75,7 +75,8 @@ export class KubernetesResourcePage extends MainPage {
       if (
         resourceType === KubernetesResources.Nodes ||
         resourceType === KubernetesResources.StorageClasses ||
-        resourceType === KubernetesResources.PriorityClasses
+        resourceType === KubernetesResources.PriorityClasses ||
+        resourceType === KubernetesResources.RuntimeClasses
       ) {
         resourceRowName = resourceRow.getByRole('cell').nth(2);
       } else {

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -54,6 +54,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.LimitRanges]: NavSection.Config,
   [KubernetesResources.PodDisruptionBudgets]: NavSection.Config,
   [KubernetesResources.PriorityClasses]: NavSection.Config,
+  [KubernetesResources.RuntimeClasses]: NavSection.Config,
 };
 
 export class KubernetesBar {
@@ -118,6 +119,8 @@ export class KubernetesBar {
         return new KubernetesResourcePage(this.page, 'pod disruption budgets');
       case 'Priority Classes':
         return new KubernetesResourcePage(this.page, 'priority classes');
+      case 'Runtime Classes':
+        return new KubernetesResourcePage(this.page, 'runtime classes');
       default:
         return new KubernetesResourcePage(this.page, kubernetesResource);
     }


### PR DESCRIPTION
feat(config): add RuntimeClass resource

### What does this PR do?

Adds resource views for RuntimeClass under the Config section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/598726d9-d5e9-4491-ab9a-a272f1381064

### What issues does this PR fix or reference?

Part of  https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Connect to a cluster with example a RuntimeClass resource
2. Confirm you are able to view the new section

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
