### PR TITLE
feat(config): add Lease resource

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -94,6 +94,7 @@ import { LimitRangesResourceFactory } from '/@/resources/limit-ranges-resource-f
 import { PdbsResourceFactory } from '/@/resources/pdbs-resource-factory.js';
 import { PriorityClassesResourceFactory } from '/@/resources/priority-classes-resource-factory.js';
 import { RuntimeClassesResourceFactory } from '/@/resources/runtime-classes-resource-factory.js';
+import { LeasesResourceFactory } from '/@/resources/leases-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -223,6 +224,7 @@ export class ContextsManager implements ContextsApi {
       new PdbsResourceFactory(),
       new PriorityClassesResourceFactory(),
       new RuntimeClassesResourceFactory(),
+      new LeasesResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/leases-resource-factory.spec.ts
+++ b/packages/extension/src/resources/leases-resource-factory.spec.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { LeasesResourceFactory } from './leases-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new LeasesResourceFactory();
+  expect(factory.resource).toBe('leases');
+  expect(factory.kind).toBe('Lease');
+});

--- a/packages/extension/src/resources/leases-resource-factory.ts
+++ b/packages/extension/src/resources/leases-resource-factory.ts
@@ -1,0 +1,71 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1Lease, V1LeaseList, V1Status } from '@kubernetes/client-node';
+import { CoordinationV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class LeasesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'leases',
+      kind: 'Lease',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          group: 'coordination.k8s.io',
+          verb: 'watch',
+          resource: 'leases',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteLease);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Lease> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoordinationV1Api);
+    const listFn = (): Promise<V1LeaseList> => apiClient.listNamespacedLease({ namespace });
+    const path = `/apis/coordination.k8s.io/v1/namespaces/${namespace}/leases`;
+    return new ResourceInformer<V1Lease>({ kubeconfig, path, listFn, kind: this.kind, plural: 'leases' });
+  }
+
+  deleteLease(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoordinationV1Api);
+    return apiClient.deleteNamespacedLease({ name, namespace });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -237,6 +237,8 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
   <Route path="/leases">
     <LeasesList />
   </Route>

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -71,6 +71,8 @@ import PriorityClassesList from './component/priority-classes/PriorityClassesLis
 import PriorityClassDetails from './component/priority-classes/PriorityClassDetails.svelte';
 import RuntimeClassesList from './component/runtime-classes/RuntimeClassesList.svelte';
 import RuntimeClassDetails from './component/runtime-classes/RuntimeClassDetails.svelte';
+import LeasesList from './component/leases/LeasesList.svelte';
+import LeaseDetails from './component/leases/LeaseDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -235,6 +237,12 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  <Route path="/leases">
+    <LeasesList />
+  </Route>
+
+  <Route path="/leases/:name/:namespace/*" let:meta>
+    <LeaseDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
   </Route>
 
   <Route path="/runtimeclasses">

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -51,6 +51,7 @@ const configUrls = [
   navigator.kubernetesResourcesURL('PodDisruptionBudget'),
   navigator.kubernetesResourcesURL('PriorityClass'),
   navigator.kubernetesResourcesURL('RuntimeClass'),
+  navigator.kubernetesResourcesURL('Lease'),
 ];
 
 const networkUrls = [
@@ -173,6 +174,7 @@ $effect(() => {
         href={navigator.kubernetesResourcesURL('PodDisruptionBudget')} />
       <NavItem title="Priority Classes" child={true} href={navigator.kubernetesResourcesURL('PriorityClass')} />
       <NavItem title="Runtime Classes" child={true} href={navigator.kubernetesResourcesURL('RuntimeClass')} />
+      <NavItem title="Leases" child={true} href={navigator.kubernetesResourcesURL('Lease')} />
     {/if}
 
     <!-- Network section -->

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -53,7 +53,6 @@ const configUrls = [
   navigator.kubernetesResourcesURL('RuntimeClass'),
   navigator.kubernetesResourcesURL('Lease'),
 ];
-const configUrls = [navigator.kubernetesResourcesURL('ConfigMap'), navigator.kubernetesResourcesURL('Lease')];
 
 const networkUrls = [
   navigator.kubernetesResourcesURL('Service'),

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -53,6 +53,7 @@ const configUrls = [
   navigator.kubernetesResourcesURL('RuntimeClass'),
   navigator.kubernetesResourcesURL('Lease'),
 ];
+const configUrls = [navigator.kubernetesResourcesURL('ConfigMap'), navigator.kubernetesResourcesURL('Lease')];
 
 const networkUrls = [
   navigator.kubernetesResourcesURL('Service'),

--- a/packages/webview/src/component/leases/LeaseDetails.svelte
+++ b/packages/webview/src/component/leases/LeaseDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { LeaseHelper } from './lease-helper';
+import type { LeaseUI } from './LeaseUI';
+import type { V1Lease } from '@kubernetes/client-node';
+import LeaseDetailsSummary from './LeaseDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const leaseHelper = dependencyAccessor.get<LeaseHelper>(LeaseHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1Lease}
+  typedUI={{} as LeaseUI}
+  kind="Lease"
+  resourceName="leases"
+  listName="Leases"
+  name={name}
+  namespace={namespace}
+  transformer={leaseHelper.getLeaseUI.bind(leaseHelper)}
+  SummaryComponent={LeaseDetailsSummary} />

--- a/packages/webview/src/component/leases/LeaseDetails.svelte
+++ b/packages/webview/src/component/leases/LeaseDetails.svelte
@@ -6,6 +6,7 @@ import { LeaseHelper } from './lease-helper';
 import type { LeaseUI } from './LeaseUI';
 import type { V1Lease } from '@kubernetes/client-node';
 import LeaseDetailsSummary from './LeaseDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -26,4 +27,5 @@ const leaseHelper = dependencyAccessor.get<LeaseHelper>(LeaseHelper);
   name={name}
   namespace={namespace}
   transformer={leaseHelper.getLeaseUI.bind(leaseHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={LeaseDetailsSummary} />

--- a/packages/webview/src/component/leases/LeaseDetailsSummary.svelte
+++ b/packages/webview/src/component/leases/LeaseDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1Lease } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1Lease;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/leases/LeaseUI.ts
+++ b/packages/webview/src/component/leases/LeaseUI.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface LeaseUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  holder: string;
+  leaseDuration: string;
+  renewTime: string;
+}

--- a/packages/webview/src/component/leases/LeasesList.svelte
+++ b/packages/webview/src/component/leases/LeasesList.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import ActionsColumn from './columns/Actions.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { LeaseUI } from './LeaseUI';
+import { LeaseHelper } from './lease-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const leaseHelper = dependencyAccessor.get<LeaseHelper>(LeaseHelper);
+
+let statusColumn = new TableColumn<LeaseUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<LeaseUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let holderColumn = new TableColumn<LeaseUI, string>('Holder', {
+  renderMapping: (obj): string => obj.holder,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.holder.localeCompare(b.holder),
+});
+
+let leaseDurationColumn = new TableColumn<LeaseUI, string>('Lease Duration', {
+  renderMapping: (obj): string => obj.leaseDuration,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.leaseDuration.localeCompare(b.leaseDuration),
+});
+
+let renewTimeColumn = new TableColumn<LeaseUI, string>('Renew Time', {
+  renderMapping: (obj): string => obj.renewTime,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.renewTime.localeCompare(b.renewTime),
+});
+
+let ageColumn = new TableColumn<LeaseUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  holderColumn,
+  leaseDurationColumn,
+  renewTimeColumn,
+  ageColumn,
+  new TableColumn<LeaseUI>('Actions', { align: 'right', width: '150px', renderer: ActionsColumn, overflow: true }),
+];
+
+const row = new TableRow<LeaseUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'leases',
+      transformer: leaseHelper.getLeaseUI,
+    },
+  ]}
+  singular="lease"
+  plural="leases"
+  isNamespaced={true}
+  icon={icon['Lease']}
+  columns={columns}
+  row={row}>
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['Lease']} resources={['leases']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/leases/LeasesList.svelte
+++ b/packages/webview/src/component/leases/LeasesList.svelte
@@ -70,7 +70,7 @@ const row = new TableRow<LeaseUI>({ selectable: (_obj): boolean => true });
   kinds={[
     {
       resource: 'leases',
-      transformer: leaseHelper.getLeaseUI,
+      transformer: leaseHelper.getLeaseUI.bind(leaseHelper),
     },
   ]}
   singular="lease"

--- a/packages/webview/src/component/leases/_leases-module.ts
+++ b/packages/webview/src/component/leases/_leases-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { LeaseHelper } from './lease-helper';
+
+const leasesModule = new ContainerModule(options => {
+  options.bind<LeaseHelper>(LeaseHelper).toSelf().inSingletonScope();
+});
+
+export { leasesModule };

--- a/packages/webview/src/component/leases/columns/Actions.svelte
+++ b/packages/webview/src/component/leases/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/leases/columns/props.ts
+++ b/packages/webview/src/component/leases/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { LeaseUI } from '/@/component/leases/LeaseUI';
+
+export interface Props {
+  object: LeaseUI;
+}

--- a/packages/webview/src/component/leases/lease-helper.spec.ts
+++ b/packages/webview/src/component/leases/lease-helper.spec.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Lease } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { LeaseHelper } from './lease-helper';
+
+let helper: LeaseHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new LeaseHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const lease = {
+    metadata: {
+      name: 'my-lease',
+      namespace: 'kube-system',
+      uid: 'uid-lease',
+    },
+    spec: {},
+  } as V1Lease;
+  const ui = helper.getLeaseUI(lease);
+  expect(ui.kind).toEqual('Lease');
+  expect(ui.name).toEqual('my-lease');
+  expect(ui.namespace).toEqual('kube-system');
+});
+
+test('expect holder and leaseDuration fields', async () => {
+  const lease = {
+    metadata: { name: 'lease1' },
+    spec: {
+      holderIdentity: 'node-1',
+      leaseDurationSeconds: 40,
+    },
+  } as V1Lease;
+  const ui = helper.getLeaseUI(lease);
+  expect(ui.holder).toEqual('node-1');
+  expect(ui.leaseDuration).toEqual('40s');
+});
+
+test('expect renewTime as ISO string', async () => {
+  const lease = {
+    metadata: { name: 'lease2' },
+    spec: {
+      renewTime: new Date('2026-01-15T10:30:00Z'),
+    },
+  } as V1Lease;
+  const ui = helper.getLeaseUI(lease);
+  expect(ui.renewTime).toEqual('2026-01-15T10:30:00.000Z');
+});
+
+test('expect empty strings when spec fields are missing', async () => {
+  const lease = {
+    metadata: { name: 'lease3' },
+  } as V1Lease;
+  const ui = helper.getLeaseUI(lease);
+  expect(ui.holder).toEqual('');
+  expect(ui.leaseDuration).toEqual('');
+  expect(ui.renewTime).toEqual('');
+});

--- a/packages/webview/src/component/leases/lease-helper.ts
+++ b/packages/webview/src/component/leases/lease-helper.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Lease } from '@kubernetes/client-node';
+
+import type { LeaseUI } from './LeaseUI';
+
+export class LeaseHelper {
+  getLeaseUI(lease: V1Lease): LeaseUI {
+    return {
+      kind: 'Lease',
+      uid: lease.metadata?.uid ?? '',
+      name: lease.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: lease.metadata?.namespace ?? '',
+      created: lease.metadata?.creationTimestamp,
+      selected: false,
+      holder: lease.spec?.holderIdentity ?? '',
+      leaseDuration:
+        lease.spec?.leaseDurationSeconds !== undefined ? `${String(lease.spec.leaseDurationSeconds)}s` : '',
+      renewTime: lease.spec?.renewTime ? new Date(lease.spec.renewTime).toISOString() : '',
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -61,6 +61,7 @@ import { limitRangesModule } from '/@/component/limit-ranges/_limit-ranges-modul
 import { pdbsModule } from '/@/component/pdbs/_pdbs-module';
 import { priorityClassesModule } from '/@/component/priority-classes/_priority-classes-module';
 import { runtimeClassesModule } from '/@/component/runtime-classes/_runtime-classes-module';
+import { leasesModule } from '/@/component/leases/_leases-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -116,6 +117,7 @@ export class InversifyBinding {
     await this.#container.load(pdbsModule);
     await this.#container.load(priorityClassesModule);
     await this.#container.load(runtimeClassesModule);
+    await this.#container.load(leasesModule);
 
     return this.#container;
   }

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -262,6 +262,7 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  });
   test('go to leases page', async () => {
     const leasesPage = await navigation.openTabPage(KubernetesResources.Leases);
     await playExpect(leasesPage.heading).toBeVisible();

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -262,6 +262,10 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  test('go to leases page', async () => {
+    const leasesPage = await navigation.openTabPage(KubernetesResources.Leases);
+    await playExpect(leasesPage.heading).toBeVisible();
+    await playExpect.poll(async () => leasesPage.isEmpty('No leases')).toBeTruthy();
   });
   test('go to runtimeClasses page', async () => {
     const runtimeClassesPage = await navigation.openTabPage(KubernetesResources.RuntimeClasses);

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -173,7 +173,6 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   ],
   [KubernetesResources.PriorityClasses]: ['Status', 'Name', 'Value', 'Global Default', 'Preemption Policy', 'Age'],
   [KubernetesResources.RuntimeClasses]: ['Status', 'Name', 'Handler', 'Age'],
-  [KubernetesResources.Leases]: ['Selected', 'Status', 'Name', 'Holder', 'Lease Duration', 'Renew Time', 'Age', 'Actions'],
   [KubernetesResources.Leases]: [
     'Selected',
     'Status',

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -58,6 +58,7 @@ export enum KubernetesResources {
   PodDisruptionBudgets = 'Pod Disruption Budgets',
   PriorityClasses = 'Priority Classes',
   RuntimeClasses = 'Runtime Classes',
+  Leases = 'Leases',
 }
 
 export const KubernetesResourceAttributes: Record<KubernetesResources, string[]> = {
@@ -172,4 +173,5 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   ],
   [KubernetesResources.PriorityClasses]: ['Status', 'Name', 'Value', 'Global Default', 'Preemption Policy', 'Age'],
   [KubernetesResources.RuntimeClasses]: ['Status', 'Name', 'Handler', 'Age'],
+  [KubernetesResources.Leases]: ['Selected', 'Status', 'Name', 'Holder', 'Lease Duration', 'Renew Time', 'Age', 'Actions'],
 };

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -174,4 +174,14 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   [KubernetesResources.PriorityClasses]: ['Status', 'Name', 'Value', 'Global Default', 'Preemption Policy', 'Age'],
   [KubernetesResources.RuntimeClasses]: ['Status', 'Name', 'Handler', 'Age'],
   [KubernetesResources.Leases]: ['Selected', 'Status', 'Name', 'Holder', 'Lease Duration', 'Renew Time', 'Age', 'Actions'],
+  [KubernetesResources.Leases]: [
+    'Selected',
+    'Status',
+    'Name',
+    'Holder',
+    'Lease Duration',
+    'Renew Time',
+    'Age',
+    'Actions',
+  ],
 };

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -55,6 +55,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.PodDisruptionBudgets]: NavSection.Config,
   [KubernetesResources.PriorityClasses]: NavSection.Config,
   [KubernetesResources.RuntimeClasses]: NavSection.Config,
+  [KubernetesResources.Leases]: NavSection.Config,
 };
 
 export class KubernetesBar {


### PR DESCRIPTION
feat(config): add Lease resource

### What does this PR do?

Adds resource views for Lease under the Config section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/598726d9-d5e9-4491-ab9a-a272f1381064

### What issues does this PR fix or reference?

Part of  https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Connect to a cluster with example a Lease resource
2. Confirm you are able to view the new section

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
