### PR TITLE
feat(config): add MutatingWebhookConfiguration resource

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -95,6 +95,7 @@ import { PdbsResourceFactory } from '/@/resources/pdbs-resource-factory.js';
 import { PriorityClassesResourceFactory } from '/@/resources/priority-classes-resource-factory.js';
 import { RuntimeClassesResourceFactory } from '/@/resources/runtime-classes-resource-factory.js';
 import { LeasesResourceFactory } from '/@/resources/leases-resource-factory.js';
+import { MutatingWebhooksResourceFactory } from '/@/resources/mutating-webhooks-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -225,6 +226,7 @@ export class ContextsManager implements ContextsApi {
       new PriorityClassesResourceFactory(),
       new RuntimeClassesResourceFactory(),
       new LeasesResourceFactory(),
+      new MutatingWebhooksResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/mutating-webhooks-resource-factory.spec.ts
+++ b/packages/extension/src/resources/mutating-webhooks-resource-factory.spec.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { MutatingWebhooksResourceFactory } from './mutating-webhooks-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new MutatingWebhooksResourceFactory();
+  expect(factory.resource).toBe('mutatingwebhookconfigurations');
+  expect(factory.kind).toBe('MutatingWebhookConfiguration');
+});

--- a/packages/extension/src/resources/mutating-webhooks-resource-factory.ts
+++ b/packages/extension/src/resources/mutating-webhooks-resource-factory.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  KubernetesObject,
+  V1MutatingWebhookConfiguration,
+  V1MutatingWebhookConfigurationList,
+  V1Status,
+} from '@kubernetes/client-node';
+import { AdmissionregistrationV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class MutatingWebhooksResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'mutatingwebhookconfigurations',
+      kind: 'MutatingWebhookConfiguration',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          group: 'admissionregistration.k8s.io',
+          verb: 'watch',
+          resource: 'mutatingwebhookconfigurations',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteMutatingWebhookConfiguration);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1MutatingWebhookConfiguration> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AdmissionregistrationV1Api);
+    const listFn = (): Promise<V1MutatingWebhookConfigurationList> => apiClient.listMutatingWebhookConfiguration();
+    const path = `/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations`;
+    return new ResourceInformer<V1MutatingWebhookConfiguration>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'mutatingwebhookconfigurations',
+    });
+  }
+
+  deleteMutatingWebhookConfiguration(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AdmissionregistrationV1Api);
+    return apiClient.deleteMutatingWebhookConfiguration({ name });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -239,6 +239,8 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
   <Route path="/mutatingwebhookconfigurations">
     <MutatingWebhooksList />
   </Route>

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -73,6 +73,8 @@ import RuntimeClassesList from './component/runtime-classes/RuntimeClassesList.s
 import RuntimeClassDetails from './component/runtime-classes/RuntimeClassDetails.svelte';
 import LeasesList from './component/leases/LeasesList.svelte';
 import LeaseDetails from './component/leases/LeaseDetails.svelte';
+import MutatingWebhooksList from './component/mutating-webhooks/MutatingWebhooksList.svelte';
+import MutatingWebhookDetails from './component/mutating-webhooks/MutatingWebhookDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -237,6 +239,12 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  <Route path="/mutatingwebhookconfigurations">
+    <MutatingWebhooksList />
+  </Route>
+
+  <Route path="/mutatingwebhookconfigurations/:name/*" let:meta>
+    <MutatingWebhookDetails name={decodeURI(meta.params.name)} />
   </Route>
 
   <Route path="/leases">

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -176,7 +176,6 @@ $effect(() => {
       <NavItem title="Priority Classes" child={true} href={navigator.kubernetesResourcesURL('PriorityClass')} />
       <NavItem title="Runtime Classes" child={true} href={navigator.kubernetesResourcesURL('RuntimeClass')} />
       <NavItem title="Leases" child={true} href={navigator.kubernetesResourcesURL('Lease')} />
-      <NavItem title="Mutating Webhook Configs" child={true} href={navigator.kubernetesResourcesURL('MutatingWebhookConfiguration')} />
       <NavItem
         title="Mutating Webhook Configs"
         child={true}

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -52,6 +52,7 @@ const configUrls = [
   navigator.kubernetesResourcesURL('PriorityClass'),
   navigator.kubernetesResourcesURL('RuntimeClass'),
   navigator.kubernetesResourcesURL('Lease'),
+  navigator.kubernetesResourcesURL('MutatingWebhookConfiguration'),
 ];
 
 const networkUrls = [
@@ -175,6 +176,7 @@ $effect(() => {
       <NavItem title="Priority Classes" child={true} href={navigator.kubernetesResourcesURL('PriorityClass')} />
       <NavItem title="Runtime Classes" child={true} href={navigator.kubernetesResourcesURL('RuntimeClass')} />
       <NavItem title="Leases" child={true} href={navigator.kubernetesResourcesURL('Lease')} />
+      <NavItem title="Mutating Webhook Configs" child={true} href={navigator.kubernetesResourcesURL('MutatingWebhookConfiguration')} />
     {/if}
 
     <!-- Network section -->

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -177,6 +177,10 @@ $effect(() => {
       <NavItem title="Runtime Classes" child={true} href={navigator.kubernetesResourcesURL('RuntimeClass')} />
       <NavItem title="Leases" child={true} href={navigator.kubernetesResourcesURL('Lease')} />
       <NavItem title="Mutating Webhook Configs" child={true} href={navigator.kubernetesResourcesURL('MutatingWebhookConfiguration')} />
+      <NavItem
+        title="Mutating Webhook Configs"
+        child={true}
+        href={navigator.kubernetesResourcesURL('MutatingWebhookConfiguration')} />
     {/if}
 
     <!-- Network section -->

--- a/packages/webview/src/component/mutating-webhooks/MutatingWebhookDetails.svelte
+++ b/packages/webview/src/component/mutating-webhooks/MutatingWebhookDetails.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { MutatingWebhookHelper } from './mutating-webhook-helper';
+import type { MutatingWebhookUI } from './MutatingWebhookUI';
+import type { V1MutatingWebhookConfiguration } from '@kubernetes/client-node';
+import MutatingWebhookDetailsSummary from './MutatingWebhookDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+}
+let { name }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const mutatingWebhookHelper = dependencyAccessor.get<MutatingWebhookHelper>(MutatingWebhookHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1MutatingWebhookConfiguration}
+  typedUI={{} as MutatingWebhookUI}
+  kind="MutatingWebhookConfiguration"
+  resourceName="mutatingwebhookconfigurations"
+  listName="Mutating Webhook Configurations"
+  name={name}
+  transformer={mutatingWebhookHelper.getMutatingWebhookUI.bind(mutatingWebhookHelper)}
+  SummaryComponent={MutatingWebhookDetailsSummary} />

--- a/packages/webview/src/component/mutating-webhooks/MutatingWebhookDetails.svelte
+++ b/packages/webview/src/component/mutating-webhooks/MutatingWebhookDetails.svelte
@@ -6,6 +6,7 @@ import { MutatingWebhookHelper } from './mutating-webhook-helper';
 import type { MutatingWebhookUI } from './MutatingWebhookUI';
 import type { V1MutatingWebhookConfiguration } from '@kubernetes/client-node';
 import MutatingWebhookDetailsSummary from './MutatingWebhookDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -24,4 +25,5 @@ const mutatingWebhookHelper = dependencyAccessor.get<MutatingWebhookHelper>(Muta
   listName="Mutating Webhook Configurations"
   name={name}
   transformer={mutatingWebhookHelper.getMutatingWebhookUI.bind(mutatingWebhookHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={MutatingWebhookDetailsSummary} />

--- a/packages/webview/src/component/mutating-webhooks/MutatingWebhookDetailsSummary.svelte
+++ b/packages/webview/src/component/mutating-webhooks/MutatingWebhookDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1MutatingWebhookConfiguration } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1MutatingWebhookConfiguration;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/mutating-webhooks/MutatingWebhookDetailsSummary.svelte
+++ b/packages/webview/src/component/mutating-webhooks/MutatingWebhookDetailsSummary.svelte
@@ -1,20 +1,16 @@
 <script lang="ts">
 import type { V1MutatingWebhookConfiguration } from '@kubernetes/client-node';
-import type { EventUI } from '/@/component/objects/EventUI';
 import Table from '/@/component/details/Table.svelte';
 import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
-import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
 
 interface Props {
   object: V1MutatingWebhookConfiguration;
-  events: readonly EventUI[];
 }
-let { object, events }: Props = $props();
+let { object }: Props = $props();
 </script>
 
 <Table>
   {#if object.metadata}
     <ObjectMetaDetails artifact={object.metadata} />
   {/if}
-  <EventsDetails events={events} />
 </Table>

--- a/packages/webview/src/component/mutating-webhooks/MutatingWebhookUI.ts
+++ b/packages/webview/src/component/mutating-webhooks/MutatingWebhookUI.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface MutatingWebhookUI extends KubernetesObjectUI {
+  uid: string;
+  created?: Date;
+  webhooks: number;
+  failurePolicy: string;
+}

--- a/packages/webview/src/component/mutating-webhooks/MutatingWebhooksList.svelte
+++ b/packages/webview/src/component/mutating-webhooks/MutatingWebhooksList.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import ActionsColumn from './columns/Actions.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { MutatingWebhookUI } from './MutatingWebhookUI';
+import { MutatingWebhookHelper } from './mutating-webhook-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const mutatingWebhookHelper = dependencyAccessor.get<MutatingWebhookHelper>(MutatingWebhookHelper);
+
+let statusColumn = new TableColumn<MutatingWebhookUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<MutatingWebhookUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let webhooksColumn = new TableColumn<MutatingWebhookUI, string>('Webhooks', {
+  renderMapping: (obj): string => String(obj.webhooks),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.webhooks - b.webhooks,
+});
+
+let failurePolicyColumn = new TableColumn<MutatingWebhookUI, string>('Failure Policy', {
+  renderMapping: (obj): string => obj.failurePolicy,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.failurePolicy.localeCompare(b.failurePolicy),
+});
+
+let ageColumn = new TableColumn<MutatingWebhookUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  webhooksColumn,
+  failurePolicyColumn,
+  ageColumn,
+  new TableColumn<MutatingWebhookUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<MutatingWebhookUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'mutatingwebhookconfigurations',
+      transformer: mutatingWebhookHelper.getMutatingWebhookUI.bind(mutatingWebhookHelper),
+    },
+  ]}
+  singular="mutating webhook configuration"
+  plural="mutating webhook configurations"
+  isNamespaced={false}
+  icon={icon['MutatingWebhookConfiguration']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['MutatingWebhookConfiguration']} resources={['mutatingwebhookconfigurations']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/mutating-webhooks/_mutating-webhooks-module.ts
+++ b/packages/webview/src/component/mutating-webhooks/_mutating-webhooks-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { MutatingWebhookHelper } from './mutating-webhook-helper';
+
+const mutatingWebhooksModule = new ContainerModule(options => {
+  options.bind<MutatingWebhookHelper>(MutatingWebhookHelper).toSelf().inSingletonScope();
+});
+
+export { mutatingWebhooksModule };

--- a/packages/webview/src/component/mutating-webhooks/columns/Actions.svelte
+++ b/packages/webview/src/component/mutating-webhooks/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/mutating-webhooks/columns/props.ts
+++ b/packages/webview/src/component/mutating-webhooks/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { MutatingWebhookUI } from '/@/component/mutating-webhooks/MutatingWebhookUI';
+
+export interface Props {
+  object: MutatingWebhookUI;
+}

--- a/packages/webview/src/component/mutating-webhooks/mutating-webhook-helper.spec.ts
+++ b/packages/webview/src/component/mutating-webhooks/mutating-webhook-helper.spec.ts
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1MutatingWebhookConfiguration } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { MutatingWebhookHelper } from './mutating-webhook-helper';
+
+let helper: MutatingWebhookHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new MutatingWebhookHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const obj = {
+    metadata: {
+      name: 'my-mutating-webhook',
+      uid: 'uid-mw',
+    },
+    webhooks: [],
+  } as V1MutatingWebhookConfiguration;
+  const ui = helper.getMutatingWebhookUI(obj);
+  expect(ui.kind).toEqual('MutatingWebhookConfiguration');
+  expect(ui.name).toEqual('my-mutating-webhook');
+  expect(ui.uid).toEqual('uid-mw');
+});
+
+test('expect webhooks count', async () => {
+  const obj = {
+    metadata: { name: 'mw1' },
+    webhooks: [
+      { name: 'hook1', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+      { name: 'hook2', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+      { name: 'hook3', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+    ],
+  } as V1MutatingWebhookConfiguration;
+  const ui = helper.getMutatingWebhookUI(obj);
+  expect(ui.webhooks).toEqual(3);
+});
+
+test('expect failurePolicy deduplication', async () => {
+  const obj = {
+    metadata: { name: 'mw2' },
+    webhooks: [
+      { name: 'h1', failurePolicy: 'Ignore', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+      { name: 'h2', failurePolicy: 'Ignore', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+      { name: 'h3', failurePolicy: 'Fail', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+    ],
+  } as V1MutatingWebhookConfiguration;
+  const ui = helper.getMutatingWebhookUI(obj);
+  expect(ui.failurePolicy).toEqual('Ignore, Fail');
+});

--- a/packages/webview/src/component/mutating-webhooks/mutating-webhook-helper.ts
+++ b/packages/webview/src/component/mutating-webhooks/mutating-webhook-helper.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1MutatingWebhookConfiguration } from '@kubernetes/client-node';
+
+import type { MutatingWebhookUI } from './MutatingWebhookUI';
+
+export class MutatingWebhookHelper {
+  getMutatingWebhookUI(obj: V1MutatingWebhookConfiguration): MutatingWebhookUI {
+    return {
+      kind: 'MutatingWebhookConfiguration',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      created: obj.metadata?.creationTimestamp,
+      webhooks: obj.webhooks?.length ?? 0,
+      failurePolicy: [...new Set((obj.webhooks ?? []).map(w => w.failurePolicy ?? 'Fail'))].join(', '),
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -62,6 +62,7 @@ import { pdbsModule } from '/@/component/pdbs/_pdbs-module';
 import { priorityClassesModule } from '/@/component/priority-classes/_priority-classes-module';
 import { runtimeClassesModule } from '/@/component/runtime-classes/_runtime-classes-module';
 import { leasesModule } from '/@/component/leases/_leases-module';
+import { mutatingWebhooksModule } from '/@/component/mutating-webhooks/_mutating-webhooks-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -118,6 +119,7 @@ export class InversifyBinding {
     await this.#container.load(priorityClassesModule);
     await this.#container.load(runtimeClassesModule);
     await this.#container.load(leasesModule);
+    await this.#container.load(mutatingWebhooksModule);
 
     return this.#container;
   }

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -262,6 +262,7 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  });
   test('go to mutatingWebhooks page', async () => {
     const mutatingWebhooksPage = await navigation.openTabPage(KubernetesResources.MutatingWebhookConfigs);
     await playExpect(mutatingWebhooksPage.heading).toBeVisible();

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -262,6 +262,10 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  test('go to mutatingWebhooks page', async () => {
+    const mutatingWebhooksPage = await navigation.openTabPage(KubernetesResources.MutatingWebhookConfigs);
+    await playExpect(mutatingWebhooksPage.heading).toBeVisible();
+    await playExpect.poll(async () => mutatingWebhooksPage.isEmpty('No mutatingwebhookconfigurations')).toBeTruthy();
   });
   test('go to leases page', async () => {
     const leasesPage = await navigation.openTabPage(KubernetesResources.Leases);

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -185,4 +185,13 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
     'Actions',
   ],
   [KubernetesResources.MutatingWebhookConfigs]: ['Selected', 'Status', 'Name', 'Webhooks', 'Failure Policy', 'Age', 'Actions'],
+  [KubernetesResources.MutatingWebhookConfigs]: [
+    'Selected',
+    'Status',
+    'Name',
+    'Webhooks',
+    'Failure Policy',
+    'Age',
+    'Actions',
+  ],
 };

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -59,6 +59,7 @@ export enum KubernetesResources {
   PriorityClasses = 'Priority Classes',
   RuntimeClasses = 'Runtime Classes',
   Leases = 'Leases',
+  MutatingWebhookConfigs = 'Mutating Webhook Configs',
 }
 
 export const KubernetesResourceAttributes: Record<KubernetesResources, string[]> = {
@@ -183,4 +184,5 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
     'Age',
     'Actions',
   ],
+  [KubernetesResources.MutatingWebhookConfigs]: ['Selected', 'Status', 'Name', 'Webhooks', 'Failure Policy', 'Age', 'Actions'],
 };

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -184,7 +184,6 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
     'Age',
     'Actions',
   ],
-  [KubernetesResources.MutatingWebhookConfigs]: ['Selected', 'Status', 'Name', 'Webhooks', 'Failure Policy', 'Age', 'Actions'],
   [KubernetesResources.MutatingWebhookConfigs]: [
     'Selected',
     'Status',

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -56,6 +56,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.PriorityClasses]: NavSection.Config,
   [KubernetesResources.RuntimeClasses]: NavSection.Config,
   [KubernetesResources.Leases]: NavSection.Config,
+  [KubernetesResources.MutatingWebhookConfigs]: NavSection.Config,
 };
 
 export class KubernetesBar {
@@ -122,6 +123,8 @@ export class KubernetesBar {
         return new KubernetesResourcePage(this.page, 'priority classes');
       case 'Runtime Classes':
         return new KubernetesResourcePage(this.page, 'runtime classes');
+      case 'Mutating Webhook Configs':
+        return new KubernetesResourcePage(this.page, 'mutating webhook configurations');
       default:
         return new KubernetesResourcePage(this.page, kubernetesResource);
     }


### PR DESCRIPTION
feat(config): add MutatingWebhookConfiguration resource

### What does this PR do?

Adds resource views for MutatingWebhookConfiguration under the Config section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/598726d9-d5e9-4491-ab9a-a272f1381064

### What issues does this PR fix or reference?

Part of  https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Connect to a cluster with example a MutatingWebhookConfiguration resource
2. Confirm you are able to view the new section

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
