### PR TITLE
feat(config): add ValidatingWebhookConfiguration resource

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -96,6 +96,7 @@ import { PriorityClassesResourceFactory } from '/@/resources/priority-classes-re
 import { RuntimeClassesResourceFactory } from '/@/resources/runtime-classes-resource-factory.js';
 import { LeasesResourceFactory } from '/@/resources/leases-resource-factory.js';
 import { MutatingWebhooksResourceFactory } from '/@/resources/mutating-webhooks-resource-factory.js';
+import { ValidatingWebhooksResourceFactory } from '/@/resources/validating-webhooks-resource-factory.js';
 import { HpasResourceFactory } from '/@/resources/hpas-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
@@ -228,6 +229,7 @@ export class ContextsManager implements ContextsApi {
       new RuntimeClassesResourceFactory(),
       new LeasesResourceFactory(),
       new MutatingWebhooksResourceFactory(),
+      new ValidatingWebhooksResourceFactory(),
       new HpasResourceFactory(),
     ];
   }

--- a/packages/extension/src/resources/validating-webhooks-resource-factory.spec.ts
+++ b/packages/extension/src/resources/validating-webhooks-resource-factory.spec.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { ValidatingWebhooksResourceFactory } from './validating-webhooks-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new ValidatingWebhooksResourceFactory();
+  expect(factory.resource).toBe('validatingwebhookconfigurations');
+  expect(factory.kind).toBe('ValidatingWebhookConfiguration');
+});

--- a/packages/extension/src/resources/validating-webhooks-resource-factory.ts
+++ b/packages/extension/src/resources/validating-webhooks-resource-factory.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  KubernetesObject,
+  V1Status,
+  V1ValidatingWebhookConfiguration,
+  V1ValidatingWebhookConfigurationList,
+} from '@kubernetes/client-node';
+import { AdmissionregistrationV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class ValidatingWebhooksResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'validatingwebhookconfigurations',
+      kind: 'ValidatingWebhookConfiguration',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          group: 'admissionregistration.k8s.io',
+          verb: 'watch',
+          resource: 'validatingwebhookconfigurations',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteValidatingWebhookConfiguration);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1ValidatingWebhookConfiguration> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AdmissionregistrationV1Api);
+    const listFn = (): Promise<V1ValidatingWebhookConfigurationList> => apiClient.listValidatingWebhookConfiguration();
+    const path = `/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations`;
+    return new ResourceInformer<V1ValidatingWebhookConfiguration>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'validatingwebhookconfigurations',
+    });
+  }
+
+  deleteValidatingWebhookConfiguration(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AdmissionregistrationV1Api);
+    return apiClient.deleteValidatingWebhookConfiguration({ name });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -75,6 +75,8 @@ import LeasesList from './component/leases/LeasesList.svelte';
 import LeaseDetails from './component/leases/LeaseDetails.svelte';
 import MutatingWebhooksList from './component/mutating-webhooks/MutatingWebhooksList.svelte';
 import MutatingWebhookDetails from './component/mutating-webhooks/MutatingWebhookDetails.svelte';
+import ValidatingWebhooksList from './component/validating-webhooks/ValidatingWebhooksList.svelte';
+import ValidatingWebhookDetails from './component/validating-webhooks/ValidatingWebhookDetails.svelte';
 import HpasList from './component/hpas/HpasList.svelte';
 import HpaDetails from './component/hpas/HpaDetails.svelte';
 // import globally the monaco environment
@@ -241,6 +243,14 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/validatingwebhookconfigurations">
+    <ValidatingWebhooksList />
+  </Route>
+
+  <Route path="/validatingwebhookconfigurations/:name/*" let:meta>
+    <ValidatingWebhookDetails name={decodeURI(meta.params.name)} />
   </Route>
 
   <Route path="/horizontalpodautoscalers">

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -53,6 +53,7 @@ const configUrls = [
   navigator.kubernetesResourcesURL('RuntimeClass'),
   navigator.kubernetesResourcesURL('Lease'),
   navigator.kubernetesResourcesURL('MutatingWebhookConfiguration'),
+  navigator.kubernetesResourcesURL('ValidatingWebhookConfiguration'),
   navigator.kubernetesResourcesURL('HorizontalPodAutoscaler'),
 ];
 
@@ -181,6 +182,10 @@ $effect(() => {
         title="Mutating Webhook Configs"
         child={true}
         href={navigator.kubernetesResourcesURL('MutatingWebhookConfiguration')} />
+      <NavItem
+        title="Validating Webhook Configs"
+        child={true}
+        href={navigator.kubernetesResourcesURL('ValidatingWebhookConfiguration')} />
       <NavItem
         title="Horizontal Pod Autoscalers"
         child={true}

--- a/packages/webview/src/component/validating-webhooks/ValidatingWebhookDetails.svelte
+++ b/packages/webview/src/component/validating-webhooks/ValidatingWebhookDetails.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { ValidatingWebhookHelper } from './validating-webhook-helper';
+import type { ValidatingWebhookUI } from './ValidatingWebhookUI';
+import type { V1ValidatingWebhookConfiguration } from '@kubernetes/client-node';
+import ValidatingWebhookDetailsSummary from './ValidatingWebhookDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+}
+let { name }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const validatingWebhookHelper = dependencyAccessor.get<ValidatingWebhookHelper>(ValidatingWebhookHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1ValidatingWebhookConfiguration}
+  typedUI={{} as ValidatingWebhookUI}
+  kind="ValidatingWebhookConfiguration"
+  resourceName="validatingwebhookconfigurations"
+  listName="Validating Webhook Configurations"
+  name={name}
+  transformer={validatingWebhookHelper.getValidatingWebhookUI.bind(validatingWebhookHelper)}
+  SummaryComponent={ValidatingWebhookDetailsSummary} />

--- a/packages/webview/src/component/validating-webhooks/ValidatingWebhookDetails.svelte
+++ b/packages/webview/src/component/validating-webhooks/ValidatingWebhookDetails.svelte
@@ -6,6 +6,7 @@ import { ValidatingWebhookHelper } from './validating-webhook-helper';
 import type { ValidatingWebhookUI } from './ValidatingWebhookUI';
 import type { V1ValidatingWebhookConfiguration } from '@kubernetes/client-node';
 import ValidatingWebhookDetailsSummary from './ValidatingWebhookDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -24,4 +25,5 @@ const validatingWebhookHelper = dependencyAccessor.get<ValidatingWebhookHelper>(
   listName="Validating Webhook Configurations"
   name={name}
   transformer={validatingWebhookHelper.getValidatingWebhookUI.bind(validatingWebhookHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={ValidatingWebhookDetailsSummary} />

--- a/packages/webview/src/component/validating-webhooks/ValidatingWebhookDetailsSummary.svelte
+++ b/packages/webview/src/component/validating-webhooks/ValidatingWebhookDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1ValidatingWebhookConfiguration } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1ValidatingWebhookConfiguration;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/validating-webhooks/ValidatingWebhookDetailsSummary.svelte
+++ b/packages/webview/src/component/validating-webhooks/ValidatingWebhookDetailsSummary.svelte
@@ -1,20 +1,16 @@
 <script lang="ts">
 import type { V1ValidatingWebhookConfiguration } from '@kubernetes/client-node';
-import type { EventUI } from '/@/component/objects/EventUI';
 import Table from '/@/component/details/Table.svelte';
 import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
-import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
 
 interface Props {
   object: V1ValidatingWebhookConfiguration;
-  events: readonly EventUI[];
 }
-let { object, events }: Props = $props();
+let { object }: Props = $props();
 </script>
 
 <Table>
   {#if object.metadata}
     <ObjectMetaDetails artifact={object.metadata} />
   {/if}
-  <EventsDetails events={events} />
 </Table>

--- a/packages/webview/src/component/validating-webhooks/ValidatingWebhookUI.ts
+++ b/packages/webview/src/component/validating-webhooks/ValidatingWebhookUI.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface ValidatingWebhookUI extends KubernetesObjectUI {
+  uid: string;
+  created?: Date;
+  webhooks: number;
+  failurePolicy: string;
+}

--- a/packages/webview/src/component/validating-webhooks/ValidatingWebhooksList.svelte
+++ b/packages/webview/src/component/validating-webhooks/ValidatingWebhooksList.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import ActionsColumn from './columns/Actions.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { ValidatingWebhookUI } from './ValidatingWebhookUI';
+import { ValidatingWebhookHelper } from './validating-webhook-helper';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const validatingWebhookHelper = dependencyAccessor.get<ValidatingWebhookHelper>(ValidatingWebhookHelper);
+
+let statusColumn = new TableColumn<ValidatingWebhookUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<ValidatingWebhookUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let webhooksColumn = new TableColumn<ValidatingWebhookUI, string>('Webhooks', {
+  renderMapping: (obj): string => String(obj.webhooks),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.webhooks - b.webhooks,
+});
+
+let failurePolicyColumn = new TableColumn<ValidatingWebhookUI, string>('Failure Policy', {
+  renderMapping: (obj): string => obj.failurePolicy,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.failurePolicy.localeCompare(b.failurePolicy),
+});
+
+let ageColumn = new TableColumn<ValidatingWebhookUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  webhooksColumn,
+  failurePolicyColumn,
+  ageColumn,
+  new TableColumn<ValidatingWebhookUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<ValidatingWebhookUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'validatingwebhookconfigurations',
+      transformer: validatingWebhookHelper.getValidatingWebhookUI.bind(validatingWebhookHelper),
+    },
+  ]}
+  singular="validating webhook configuration"
+  plural="validating webhook configurations"
+  isNamespaced={false}
+  icon={icon['ValidatingWebhookConfiguration']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen
+      icon={icon['ValidatingWebhookConfiguration']}
+      resources={['validatingwebhookconfigurations']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/validating-webhooks/_validating-webhooks-module.ts
+++ b/packages/webview/src/component/validating-webhooks/_validating-webhooks-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { ValidatingWebhookHelper } from './validating-webhook-helper';
+
+const validatingWebhooksModule = new ContainerModule(options => {
+  options.bind<ValidatingWebhookHelper>(ValidatingWebhookHelper).toSelf().inSingletonScope();
+});
+
+export { validatingWebhooksModule };

--- a/packages/webview/src/component/validating-webhooks/columns/Actions.svelte
+++ b/packages/webview/src/component/validating-webhooks/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/validating-webhooks/columns/props.ts
+++ b/packages/webview/src/component/validating-webhooks/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ValidatingWebhookUI } from '/@/component/validating-webhooks/ValidatingWebhookUI';
+
+export interface Props {
+  object: ValidatingWebhookUI;
+}

--- a/packages/webview/src/component/validating-webhooks/validating-webhook-helper.spec.ts
+++ b/packages/webview/src/component/validating-webhooks/validating-webhook-helper.spec.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ValidatingWebhookConfiguration } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { ValidatingWebhookHelper } from './validating-webhook-helper';
+
+let helper: ValidatingWebhookHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new ValidatingWebhookHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const obj = {
+    metadata: {
+      name: 'my-validating-webhook',
+      uid: 'uid-vw',
+    },
+    webhooks: [],
+  } as V1ValidatingWebhookConfiguration;
+  const ui = helper.getValidatingWebhookUI(obj);
+  expect(ui.kind).toEqual('ValidatingWebhookConfiguration');
+  expect(ui.name).toEqual('my-validating-webhook');
+  expect(ui.uid).toEqual('uid-vw');
+});
+
+test('expect webhooks count', async () => {
+  const obj = {
+    metadata: { name: 'vw1' },
+    webhooks: [
+      { name: 'hook1', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+      { name: 'hook2', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+    ],
+  } as V1ValidatingWebhookConfiguration;
+  const ui = helper.getValidatingWebhookUI(obj);
+  expect(ui.webhooks).toEqual(2);
+});
+
+test('expect failurePolicy from webhooks', async () => {
+  const obj = {
+    metadata: { name: 'vw2' },
+    webhooks: [
+      { name: 'h1', failurePolicy: 'Fail', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+      { name: 'h2', failurePolicy: 'Ignore', clientConfig: {}, sideEffects: 'None', admissionReviewVersions: ['v1'] },
+    ],
+  } as V1ValidatingWebhookConfiguration;
+  const ui = helper.getValidatingWebhookUI(obj);
+  expect(ui.failurePolicy).toEqual('Fail, Ignore');
+});

--- a/packages/webview/src/component/validating-webhooks/validating-webhook-helper.ts
+++ b/packages/webview/src/component/validating-webhooks/validating-webhook-helper.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ValidatingWebhookConfiguration } from '@kubernetes/client-node';
+
+import type { ValidatingWebhookUI } from './ValidatingWebhookUI';
+
+export class ValidatingWebhookHelper {
+  getValidatingWebhookUI(obj: V1ValidatingWebhookConfiguration): ValidatingWebhookUI {
+    return {
+      kind: 'ValidatingWebhookConfiguration',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      created: obj.metadata?.creationTimestamp,
+      webhooks: obj.webhooks?.length ?? 0,
+      failurePolicy: [...new Set((obj.webhooks ?? []).map(w => w.failurePolicy ?? 'Fail'))].join(', '),
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -63,6 +63,7 @@ import { priorityClassesModule } from '/@/component/priority-classes/_priority-c
 import { runtimeClassesModule } from '/@/component/runtime-classes/_runtime-classes-module';
 import { leasesModule } from '/@/component/leases/_leases-module';
 import { mutatingWebhooksModule } from '/@/component/mutating-webhooks/_mutating-webhooks-module';
+import { validatingWebhooksModule } from '/@/component/validating-webhooks/_validating-webhooks-module';
 import { hpasModule } from '/@/component/hpas/_hpas-module';
 
 export class InversifyBinding {
@@ -121,6 +122,7 @@ export class InversifyBinding {
     await this.#container.load(runtimeClassesModule);
     await this.#container.load(leasesModule);
     await this.#container.load(mutatingWebhooksModule);
+    await this.#container.load(validatingWebhooksModule);
     await this.#container.load(hpasModule);
 
     return this.#container;

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -262,6 +262,7 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  });
   test('go to validatingWebhooks page', async () => {
     const validatingWebhooksPage = await navigation.openTabPage(KubernetesResources.ValidatingWebhookConfigs);
     await playExpect(validatingWebhooksPage.heading).toBeVisible();

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -262,6 +262,10 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  test('go to validatingWebhooks page', async () => {
+    const validatingWebhooksPage = await navigation.openTabPage(KubernetesResources.ValidatingWebhookConfigs);
+    await playExpect(validatingWebhooksPage.heading).toBeVisible();
+    await playExpect.poll(async () => validatingWebhooksPage.isEmpty('No validatingwebhookconfigurations')).toBeTruthy();
   });
   test('go to hpas page', async () => {
     const hpasPage = await navigation.openTabPage(KubernetesResources.HorizontalPodAutoscalers);

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -265,7 +265,9 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
   test('go to validatingWebhooks page', async () => {
     const validatingWebhooksPage = await navigation.openTabPage(KubernetesResources.ValidatingWebhookConfigs);
     await playExpect(validatingWebhooksPage.heading).toBeVisible();
-    await playExpect.poll(async () => validatingWebhooksPage.isEmpty('No validatingwebhookconfigurations')).toBeTruthy();
+    await playExpect
+      .poll(async () => validatingWebhooksPage.isEmpty('No validatingwebhookconfigurations'))
+      .toBeTruthy();
   });
   test('go to hpas page', async () => {
     const hpasPage = await navigation.openTabPage(KubernetesResources.HorizontalPodAutoscalers);

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -60,6 +60,7 @@ export enum KubernetesResources {
   RuntimeClasses = 'Runtime Classes',
   Leases = 'Leases',
   MutatingWebhookConfigs = 'Mutating Webhook Configs',
+  ValidatingWebhookConfigs = 'Validating Webhook Configs',
   HorizontalPodAutoscalers = 'Horizontal Pod Autoscalers',
 }
 
@@ -186,6 +187,15 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
     'Actions',
   ],
   [KubernetesResources.MutatingWebhookConfigs]: [
+    'Selected',
+    'Status',
+    'Name',
+    'Webhooks',
+    'Failure Policy',
+    'Age',
+    'Actions',
+  ],
+  [KubernetesResources.ValidatingWebhookConfigs]: [
     'Selected',
     'Status',
     'Name',

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -57,6 +57,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.RuntimeClasses]: NavSection.Config,
   [KubernetesResources.Leases]: NavSection.Config,
   [KubernetesResources.MutatingWebhookConfigs]: NavSection.Config,
+  [KubernetesResources.ValidatingWebhookConfigs]: NavSection.Config,
   [KubernetesResources.HorizontalPodAutoscalers]: NavSection.Config,
 };
 
@@ -126,6 +127,8 @@ export class KubernetesBar {
         return new KubernetesResourcePage(this.page, 'runtime classes');
       case 'Mutating Webhook Configs':
         return new KubernetesResourcePage(this.page, 'mutating webhook configurations');
+      case 'Validating Webhook Configs':
+        return new KubernetesResourcePage(this.page, 'validating webhook configurations');
       case 'Horizontal Pod Autoscalers':
         return new KubernetesResourcePage(this.page, 'horizontal pod autoscalers');
       default:


### PR DESCRIPTION
feat(config): add ValidatingWebhookConfiguration resource

### What does this PR do?

Adds resource views for ValidatingWebhookConfiguration under the Config section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/598726d9-d5e9-4491-ab9a-a272f1381064

### What issues does this PR fix or reference?

Part of  https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Connect to a cluster with example a ValidatingWebhookConfiguration resource
2. Confirm you are able to view the new section

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
