### PR TITLE
feat(access-control): add Access Control navigation section

### DIFF
--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -8,6 +8,7 @@ import {
   faLayerGroup,
   faNetworkWired,
   faServer,
+  faShieldHalved,
 } from '@fortawesome/free-solid-svg-icons';
 import { getContext, setContext } from 'svelte';
 import { Navigator } from '/@/navigation/navigator';
@@ -56,6 +57,14 @@ const storageUrls = [
   navigator.kubernetesResourcesURL('StorageClass'),
 ];
 
+const accessControlUrls = [
+  navigator.kubernetesResourcesURL('ServiceAccount'),
+  navigator.kubernetesResourcesURL('ClusterRole'),
+  navigator.kubernetesResourcesURL('Role'),
+  navigator.kubernetesResourcesURL('ClusterRoleBinding'),
+  navigator.kubernetesResourcesURL('RoleBinding'),
+];
+
 const STORAGE_KEY = 'nav-sections-expanded';
 
 function loadExpanded(): Record<string, boolean> {
@@ -82,12 +91,14 @@ let workloadsExpanded = $state(initExpanded('compute', workloadUrls));
 let configExpanded = $state(initExpanded('config', configUrls));
 let networkExpanded = $state(initExpanded('network', networkUrls));
 let storageExpanded = $state(initExpanded('storage', storageUrls));
+let accessControlExpanded = $state(initExpanded('accessControl', accessControlUrls));
 
 $effect(() => {
   if (isUnderSection(workloadUrls)) workloadsExpanded = true;
   if (isUnderSection(configUrls)) configExpanded = true;
   if (isUnderSection(networkUrls)) networkExpanded = true;
   if (isUnderSection(storageUrls)) storageExpanded = true;
+  if (isUnderSection(accessControlUrls)) accessControlExpanded = true;
 });
 
 $effect(() => {
@@ -101,6 +112,9 @@ $effect(() => {
 });
 $effect(() => {
   saveExpanded('storage', storageExpanded);
+});
+$effect(() => {
+  saveExpanded('accessControl', accessControlExpanded);
 });
 </script>
 
@@ -155,6 +169,16 @@ $effect(() => {
         href={navigator.kubernetesResourcesURL('PersistentVolumeClaim')} />
       <NavItem title="Persistent Volumes" child={true} href={navigator.kubernetesResourcesURL('PersistentVolume')} />
       <NavItem title="Storage Classes" child={true} href={navigator.kubernetesResourcesURL('StorageClass')} />
+    {/if}
+
+    <!-- Access Control section -->
+    <NavItem
+      title="Access Control"
+      icon={faShieldHalved}
+      section={true}
+      bind:expanded={accessControlExpanded}
+      href="" />
+    {#if accessControlExpanded}
     {/if}
 
     <NavItem title="Namespaces" icon={faLayerGroup} href={navigator.kubernetesResourcesURL('Namespace')} />

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -179,6 +179,7 @@ $effect(() => {
       bind:expanded={accessControlExpanded}
       href="" />
     {#if accessControlExpanded}
+
     {/if}
 
     <NavItem title="Namespaces" icon={faLayerGroup} href={navigator.kubernetesResourcesURL('Namespace')} />

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -21,6 +21,7 @@ export enum NavSection {
   Config = 'Config',
   Network = 'Network',
   Storage = 'Storage',
+  AccessControl = 'Access Control',
 }
 
 export enum KubernetesResources {


### PR DESCRIPTION
feat(access-control): add Access Control navigation section

### What does this PR do?

Adds the Access Control section to the navigation sidebar with the shield icon. This is the foundation for adding RBAC resource views (ServiceAccounts, Roles, ClusterRoles, RoleBindings, ClusterRoleBindings).

### Screenshot / video of UI

https://github.com/user-attachments/assets/0180522a-3ac0-41f2-bad4-3bf412c22c57

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Open the extension
2. Confirm you see the new Access Control section in the navigation sidebar

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
