### PR TITLE
feat(config): add ServiceAccount resource

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -78,6 +78,7 @@ import { StatefulSetsResourceFactory } from '/@/resources/statefulsets-resource-
 import { ReplicaSetsResourceFactory } from '/@/resources/replicasets-resource-factory.js';
 import { PVsResourceFactory } from '/@/resources/pvs-resource-factory.js';
 import { StorageClassesResourceFactory } from '/@/resources/storage-classes-resource-factory.js';
+import { ServiceAccountsResourceFactory } from '/@/resources/service-accounts-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -191,6 +192,7 @@ export class ContextsManager implements ContextsApi {
       new ReplicaSetsResourceFactory(),
       new PVsResourceFactory(),
       new StorageClassesResourceFactory(),
+      new ServiceAccountsResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/service-accounts-resource-factory.spec.ts
+++ b/packages/extension/src/resources/service-accounts-resource-factory.spec.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { ServiceAccountsResourceFactory } from './service-accounts-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new ServiceAccountsResourceFactory();
+  expect(factory.resource).toBe('serviceaccounts');
+  expect(factory.kind).toBe('ServiceAccount');
+});

--- a/packages/extension/src/resources/service-accounts-resource-factory.ts
+++ b/packages/extension/src/resources/service-accounts-resource-factory.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1ServiceAccount, V1ServiceAccountList, V1Status } from '@kubernetes/client-node';
+import { CoreV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class ServiceAccountsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'serviceaccounts',
+      kind: 'ServiceAccount',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'serviceaccounts',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteServiceAccount);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1ServiceAccount> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    const listFn = (): Promise<V1ServiceAccountList> => apiClient.listNamespacedServiceAccount({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/serviceaccounts`;
+    return new ResourceInformer<V1ServiceAccount>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'serviceaccounts',
+    });
+  }
+
+  deleteServiceAccount(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    return apiClient.deleteNamespacedServiceAccount({ name, namespace });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -37,6 +37,8 @@ import PvsList from './component/pvs/PvsList.svelte';
 import PvDetails from './component/pvs/PvDetails.svelte';
 import StorageClassesList from './component/storage-classes/StorageClassesList.svelte';
 import StorageClassDetails from './component/storage-classes/StorageClassDetails.svelte';
+import ServiceAccountsList from './component/service-accounts/ServiceAccountsList.svelte';
+import ServiceAccountDetails from './component/service-accounts/ServiceAccountDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -193,5 +195,13 @@ const { meta }: Props = $props();
 
   <Route path="/storageclasses/:name/*" let:meta>
     <StorageClassDetails name={decodeURI(meta.params.name)} />
+  </Route>
+
+  <Route path="/serviceaccounts">
+    <ServiceAccountsList />
+  </Route>
+
+  <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
+    <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
   </Route>
 </div>

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -8,7 +8,6 @@ import {
   faLayerGroup,
   faNetworkWired,
   faServer,
-  faShieldHalved,
 } from '@fortawesome/free-solid-svg-icons';
 import { getContext, setContext } from 'svelte';
 import { Navigator } from '/@/navigation/navigator';
@@ -43,7 +42,7 @@ const workloadUrls = [
   navigator.kubernetesResourcesURL('CronJob'),
 ];
 
-const configUrls = [navigator.kubernetesResourcesURL('ConfigMap')];
+const configUrls = [navigator.kubernetesResourcesURL('ConfigMap'), navigator.kubernetesResourcesURL('ServiceAccount')];
 
 const networkUrls = [
   navigator.kubernetesResourcesURL('Service'),
@@ -55,14 +54,6 @@ const storageUrls = [
   navigator.kubernetesResourcesURL('PersistentVolumeClaim'),
   navigator.kubernetesResourcesURL('PersistentVolume'),
   navigator.kubernetesResourcesURL('StorageClass'),
-];
-
-const accessControlUrls = [
-  navigator.kubernetesResourcesURL('ServiceAccount'),
-  navigator.kubernetesResourcesURL('ClusterRole'),
-  navigator.kubernetesResourcesURL('Role'),
-  navigator.kubernetesResourcesURL('ClusterRoleBinding'),
-  navigator.kubernetesResourcesURL('RoleBinding'),
 ];
 
 const STORAGE_KEY = 'nav-sections-expanded';
@@ -91,14 +82,12 @@ let workloadsExpanded = $state(initExpanded('compute', workloadUrls));
 let configExpanded = $state(initExpanded('config', configUrls));
 let networkExpanded = $state(initExpanded('network', networkUrls));
 let storageExpanded = $state(initExpanded('storage', storageUrls));
-let accessControlExpanded = $state(initExpanded('accessControl', accessControlUrls));
 
 $effect(() => {
   if (isUnderSection(workloadUrls)) workloadsExpanded = true;
   if (isUnderSection(configUrls)) configExpanded = true;
   if (isUnderSection(networkUrls)) networkExpanded = true;
   if (isUnderSection(storageUrls)) storageExpanded = true;
-  if (isUnderSection(accessControlUrls)) accessControlExpanded = true;
 });
 
 $effect(() => {
@@ -112,9 +101,6 @@ $effect(() => {
 });
 $effect(() => {
   saveExpanded('storage', storageExpanded);
-});
-$effect(() => {
-  saveExpanded('accessControl', accessControlExpanded);
 });
 </script>
 
@@ -150,6 +136,7 @@ $effect(() => {
     <NavItem title="Config" icon={faGear} section={true} bind:expanded={configExpanded} href="" />
     {#if configExpanded}
       <NavItem title="ConfigMaps &amp; Secrets" child={true} href={navigator.kubernetesResourcesURL('ConfigMap')} />
+      <NavItem title="Service Accounts" child={true} href={navigator.kubernetesResourcesURL('ServiceAccount')} />
     {/if}
 
     <!-- Network section -->
@@ -169,17 +156,6 @@ $effect(() => {
         href={navigator.kubernetesResourcesURL('PersistentVolumeClaim')} />
       <NavItem title="Persistent Volumes" child={true} href={navigator.kubernetesResourcesURL('PersistentVolume')} />
       <NavItem title="Storage Classes" child={true} href={navigator.kubernetesResourcesURL('StorageClass')} />
-    {/if}
-
-    <!-- Access Control section -->
-    <NavItem
-      title="Access Control"
-      icon={faShieldHalved}
-      section={true}
-      bind:expanded={accessControlExpanded}
-      href="" />
-    {#if accessControlExpanded}
-
     {/if}
 
     <NavItem title="Namespaces" icon={faLayerGroup} href={navigator.kubernetesResourcesURL('Namespace')} />

--- a/packages/webview/src/component/service-accounts/ServiceAccountDetails.svelte
+++ b/packages/webview/src/component/service-accounts/ServiceAccountDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { ServiceAccountHelper } from './service-account-helper';
+import type { ServiceAccountUI } from './ServiceAccountUI';
+import type { V1ServiceAccount } from '@kubernetes/client-node';
+import ServiceAccountDetailsSummary from './ServiceAccountDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const serviceAccountHelper = dependencyAccessor.get<ServiceAccountHelper>(ServiceAccountHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1ServiceAccount}
+  typedUI={{} as ServiceAccountUI}
+  kind="ServiceAccount"
+  resourceName="serviceaccounts"
+  listName="Service Accounts"
+  name={name}
+  namespace={namespace}
+  transformer={serviceAccountHelper.getServiceAccountUI.bind(serviceAccountHelper)}
+  SummaryComponent={ServiceAccountDetailsSummary} />

--- a/packages/webview/src/component/service-accounts/ServiceAccountDetails.svelte
+++ b/packages/webview/src/component/service-accounts/ServiceAccountDetails.svelte
@@ -6,6 +6,7 @@ import { ServiceAccountHelper } from './service-account-helper';
 import type { ServiceAccountUI } from './ServiceAccountUI';
 import type { V1ServiceAccount } from '@kubernetes/client-node';
 import ServiceAccountDetailsSummary from './ServiceAccountDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -26,4 +27,5 @@ const serviceAccountHelper = dependencyAccessor.get<ServiceAccountHelper>(Servic
   name={name}
   namespace={namespace}
   transformer={serviceAccountHelper.getServiceAccountUI.bind(serviceAccountHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={ServiceAccountDetailsSummary} />

--- a/packages/webview/src/component/service-accounts/ServiceAccountDetailsSummary.svelte
+++ b/packages/webview/src/component/service-accounts/ServiceAccountDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1ServiceAccount } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1ServiceAccount;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/service-accounts/ServiceAccountDetailsSummary.svelte
+++ b/packages/webview/src/component/service-accounts/ServiceAccountDetailsSummary.svelte
@@ -1,20 +1,16 @@
 <script lang="ts">
 import type { V1ServiceAccount } from '@kubernetes/client-node';
-import type { EventUI } from '/@/component/objects/EventUI';
 import Table from '/@/component/details/Table.svelte';
 import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
-import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
 
 interface Props {
   object: V1ServiceAccount;
-  events: readonly EventUI[];
 }
-let { object, events }: Props = $props();
+let { object }: Props = $props();
 </script>
 
 <Table>
   {#if object.metadata}
     <ObjectMetaDetails artifact={object.metadata} />
   {/if}
-  <EventsDetails events={events} />
 </Table>

--- a/packages/webview/src/component/service-accounts/ServiceAccountUI.ts
+++ b/packages/webview/src/component/service-accounts/ServiceAccountUI.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface ServiceAccountUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  secrets: number;
+}

--- a/packages/webview/src/component/service-accounts/ServiceAccountsList.svelte
+++ b/packages/webview/src/component/service-accounts/ServiceAccountsList.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { ServiceAccountUI } from './ServiceAccountUI';
+import { ServiceAccountHelper } from './service-account-helper';
+import ActionsColumn from './columns/Actions.svelte';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const serviceAccountHelper = dependencyAccessor.get<ServiceAccountHelper>(ServiceAccountHelper);
+
+let statusColumn = new TableColumn<ServiceAccountUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<ServiceAccountUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let secretsColumn = new TableColumn<ServiceAccountUI, string>('Secrets', {
+  renderMapping: (obj): string => String(obj.secrets),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.secrets - b.secrets,
+});
+
+let ageColumn = new TableColumn<ServiceAccountUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  secretsColumn,
+  ageColumn,
+  new TableColumn<ServiceAccountUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<ServiceAccountUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'serviceaccounts',
+      transformer: serviceAccountHelper.getServiceAccountUI,
+    },
+  ]}
+  singular="service account"
+  plural="service accounts"
+  isNamespaced={true}
+  icon={icon['ServiceAccount']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['ServiceAccount']} resources={['serviceaccounts']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/service-accounts/ServiceAccountsList.svelte
+++ b/packages/webview/src/component/service-accounts/ServiceAccountsList.svelte
@@ -61,7 +61,7 @@ const row = new TableRow<ServiceAccountUI>({ selectable: (_obj): boolean => true
   kinds={[
     {
       resource: 'serviceaccounts',
-      transformer: serviceAccountHelper.getServiceAccountUI,
+      transformer: serviceAccountHelper.getServiceAccountUI.bind(serviceAccountHelper),
     },
   ]}
   singular="service account"

--- a/packages/webview/src/component/service-accounts/_service-accounts-module.ts
+++ b/packages/webview/src/component/service-accounts/_service-accounts-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { ServiceAccountHelper } from './service-account-helper';
+
+const serviceAccountsModule = new ContainerModule(options => {
+  options.bind<ServiceAccountHelper>(ServiceAccountHelper).toSelf().inSingletonScope();
+});
+
+export { serviceAccountsModule };

--- a/packages/webview/src/component/service-accounts/columns/Actions.svelte
+++ b/packages/webview/src/component/service-accounts/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/service-accounts/columns/props.ts
+++ b/packages/webview/src/component/service-accounts/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ServiceAccountUI } from '/@/component/service-accounts/ServiceAccountUI';
+
+export interface Props {
+  object: ServiceAccountUI;
+}

--- a/packages/webview/src/component/service-accounts/service-account-helper.spec.ts
+++ b/packages/webview/src/component/service-accounts/service-account-helper.spec.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ServiceAccount } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { ServiceAccountHelper } from './service-account-helper';
+
+let helper: ServiceAccountHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new ServiceAccountHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const sa: V1ServiceAccount = {
+    metadata: {
+      uid: 'sa-uid-1',
+      name: 'my-service-account',
+      namespace: 'kube-system',
+      creationTimestamp: new Date('2026-03-15T10:00:00Z'),
+    },
+    secrets: [{ name: 'secret-1' }, { name: 'secret-2' }],
+  };
+
+  const result = helper.getServiceAccountUI(sa);
+
+  expect(result.kind).toBe('ServiceAccount');
+  expect(result.uid).toBe('sa-uid-1');
+  expect(result.name).toBe('my-service-account');
+  expect(result.namespace).toBe('kube-system');
+  expect(result.status).toBe('RUNNING');
+  expect(result.selected).toBe(false);
+  expect(result.created).toEqual(new Date('2026-03-15T10:00:00Z'));
+});
+
+test('expect secrets count from secrets array length', async () => {
+  const sa: V1ServiceAccount = {
+    metadata: { uid: 'sa-uid-2', name: 'sa-with-secrets' },
+    secrets: [{ name: 'secret-a' }, { name: 'secret-b' }, { name: 'secret-c' }],
+  };
+
+  const result = helper.getServiceAccountUI(sa);
+
+  expect(result.secrets).toBe(3);
+});
+
+test('expect secrets count zero when no secrets', async () => {
+  const sa: V1ServiceAccount = {
+    metadata: { uid: 'sa-uid-3', name: 'sa-no-secrets' },
+  };
+
+  const result = helper.getServiceAccountUI(sa);
+
+  expect(result.secrets).toBe(0);
+});

--- a/packages/webview/src/component/service-accounts/service-account-helper.ts
+++ b/packages/webview/src/component/service-accounts/service-account-helper.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ServiceAccount } from '@kubernetes/client-node';
+
+import type { ServiceAccountUI } from './ServiceAccountUI';
+
+export class ServiceAccountHelper {
+  getServiceAccountUI(obj: V1ServiceAccount): ServiceAccountUI {
+    return {
+      kind: 'ServiceAccount',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: obj.metadata?.namespace ?? '',
+      created: obj.metadata?.creationTimestamp,
+      selected: false,
+      secrets: obj.secrets?.length ?? 0,
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -44,6 +44,7 @@ import { statefulSetsModule } from '/@/component/statefulsets/_statefulsets-modu
 import { replicaSetsModule } from '/@/component/replicasets/_replicasets-module';
 import { pvsModule } from '/@/component/pvs/_pvs-module';
 import { storageClassesModule } from '/@/component/storage-classes/_storage-classes-module';
+import { serviceAccountsModule } from '/@/component/service-accounts/_service-accounts-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -82,6 +83,7 @@ export class InversifyBinding {
     await this.#container.load(replicaSetsModule);
     await this.#container.load(pvsModule);
     await this.#container.load(storageClassesModule);
+    await this.#container.load(serviceAccountsModule);
 
     return this.#container;
   }

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -213,6 +213,13 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     await playExpect.poll(async () => storageClassesPage.isEmpty('No storageclasses')).toBeTruthy();
   });
 
+
+  test('go to serviceAccounts page', async () => {
+    const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
+    await playExpect(serviceAccountsPage.heading).toBeVisible();
+    await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  });
+
   test('go to configmaps & secrets page', async () => {
     const configMapsSecretsPage = await navigation.openTabPage(KubernetesResources.ConfigMapsSecrets);
     await playExpect(configMapsSecretsPage.heading).toBeVisible();

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -213,7 +213,6 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     await playExpect.poll(async () => storageClassesPage.isEmpty('No storageclasses')).toBeTruthy();
   });
 
-
   test('go to serviceAccounts page', async () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -41,6 +41,7 @@ export enum KubernetesResources {
   Pods = 'Pods',
   Cronjobs = 'CronJobs',
   Jobs = 'Jobs',
+  ServiceAccounts = 'Service Accounts',
 }
 
 export const KubernetesResourceAttributes: Record<KubernetesResources, string[]> = {
@@ -90,4 +91,5 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
     'Actions',
   ],
   [KubernetesResources.Jobs]: ['Selected', 'Status', 'Name', 'Conditions', 'Completions', 'Age', 'Actions'],
+  [KubernetesResources.ServiceAccounts]: ['Selected', 'Status', 'Name', 'Secrets', 'Age', 'Actions'],
 };

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -21,7 +21,6 @@ export enum NavSection {
   Config = 'Config',
   Network = 'Network',
   Storage = 'Storage',
-  AccessControl = 'Access Control',
 }
 
 export enum KubernetesResources {

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -38,6 +38,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.PVCs]: NavSection.Storage,
   [KubernetesResources.PersistentVolumes]: NavSection.Storage,
   [KubernetesResources.StorageClasses]: NavSection.Storage,
+  [KubernetesResources.ServiceAccounts]: NavSection.AccessControl,
 };
 
 export class KubernetesBar {

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -38,7 +38,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.PVCs]: NavSection.Storage,
   [KubernetesResources.PersistentVolumes]: NavSection.Storage,
   [KubernetesResources.StorageClasses]: NavSection.Storage,
-  [KubernetesResources.ServiceAccounts]: NavSection.AccessControl,
+  [KubernetesResources.ServiceAccounts]: NavSection.Config,
 };
 
 export class KubernetesBar {


### PR DESCRIPTION
feat(config): add ServiceAccount resource

### What does this PR do?

Adds resource views for ServiceAccount under the Config section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/0180522a-3ac0-41f2-bad4-3bf412c22c57

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Connect to a cluster with example a ServiceAccount resource
2. Confirm you are able to view the new section

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>