### PR TITLE
feat(access-control): add ClusterRole resource

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -81,6 +81,7 @@ import { StorageClassesResourceFactory } from '/@/resources/storage-classes-reso
 import { ServiceAccountsResourceFactory } from '/@/resources/service-accounts-resource-factory.js';
 import { RolesResourceFactory } from '/@/resources/roles-resource-factory.js';
 import { RoleBindingsResourceFactory } from '/@/resources/role-bindings-resource-factory.js';
+import { ClusterRolesResourceFactory } from '/@/resources/cluster-roles-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -197,6 +198,7 @@ export class ContextsManager implements ContextsApi {
       new ServiceAccountsResourceFactory(),
       new RolesResourceFactory(),
       new RoleBindingsResourceFactory(),
+      new ClusterRolesResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/cluster-roles-resource-factory.spec.ts
+++ b/packages/extension/src/resources/cluster-roles-resource-factory.spec.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { ClusterRolesResourceFactory } from './cluster-roles-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new ClusterRolesResourceFactory();
+  expect(factory.resource).toBe('clusterroles');
+  expect(factory.kind).toBe('ClusterRole');
+});

--- a/packages/extension/src/resources/cluster-roles-resource-factory.ts
+++ b/packages/extension/src/resources/cluster-roles-resource-factory.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1ClusterRole, V1ClusterRoleList, V1Status } from '@kubernetes/client-node';
+import { RbacAuthorizationV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class ClusterRolesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'clusterroles',
+      kind: 'ClusterRole',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'rbac.authorization.k8s.io',
+          resource: 'clusterroles',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteClusterRole);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1ClusterRole> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    const listFn = (): Promise<V1ClusterRoleList> => apiClient.listClusterRole();
+    const path = `/apis/rbac.authorization.k8s.io/v1/clusterroles`;
+    return new ResourceInformer<V1ClusterRole>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'clusterroles',
+    });
+  }
+
+  deleteClusterRole(kubeconfig: KubeConfigSingleContext, name: string): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    return apiClient.deleteClusterRole({ name });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -43,6 +43,8 @@ import RolesList from './component/roles/RolesList.svelte';
 import RoleDetails from './component/roles/RoleDetails.svelte';
 import RoleBindingsList from './component/role-bindings/RoleBindingsList.svelte';
 import RoleBindingDetails from './component/role-bindings/RoleBindingDetails.svelte';
+import ClusterRolesList from './component/cluster-roles/ClusterRolesList.svelte';
+import ClusterRoleDetails from './component/cluster-roles/ClusterRoleDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -207,6 +209,12 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  <Route path="/clusterroles">
+    <ClusterRolesList />
+  </Route>
+
+  <Route path="/clusterroles/:name/*" let:meta>
+    <ClusterRoleDetails name={decodeURI(meta.params.name)} />
   </Route>
 
   <Route path="/rolebindings">

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -209,6 +209,8 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
   <Route path="/clusterroles">
     <ClusterRolesList />
   </Route>

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -57,7 +57,11 @@ const storageUrls = [
   navigator.kubernetesResourcesURL('StorageClass'),
 ];
 
-const accessControlUrls = [navigator.kubernetesResourcesURL('Role'), navigator.kubernetesResourcesURL('RoleBinding')];
+const accessControlUrls = [
+  navigator.kubernetesResourcesURL('Role'),
+  navigator.kubernetesResourcesURL('RoleBinding'),
+  navigator.kubernetesResourcesURL('ClusterRole'),
+];
 
 const STORAGE_KEY = 'nav-sections-expanded';
 

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -176,6 +176,7 @@ $effect(() => {
     {#if accessControlExpanded}
       <NavItem title="Roles" child={true} href={navigator.kubernetesResourcesURL('Role')} />
       <NavItem title="Role Bindings" child={true} href={navigator.kubernetesResourcesURL('RoleBinding')} />
+      <NavItem title="Cluster Roles" child={true} href={navigator.kubernetesResourcesURL('ClusterRole')} />
     {/if}
 
     <NavItem title="Namespaces" icon={faLayerGroup} href={navigator.kubernetesResourcesURL('Namespace')} />

--- a/packages/webview/src/component/cluster-roles/ClusterRoleDetails.svelte
+++ b/packages/webview/src/component/cluster-roles/ClusterRoleDetails.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { ClusterRoleHelper } from './cluster-role-helper';
+import type { ClusterRoleUI } from './ClusterRoleUI';
+import type { V1ClusterRole } from '@kubernetes/client-node';
+import ClusterRoleDetailsSummary from './ClusterRoleDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+}
+let { name }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const clusterRoleHelper = dependencyAccessor.get<ClusterRoleHelper>(ClusterRoleHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1ClusterRole}
+  typedUI={{} as ClusterRoleUI}
+  kind="ClusterRole"
+  resourceName="clusterroles"
+  listName="Cluster Roles"
+  name={name}
+  transformer={clusterRoleHelper.getClusterRoleUI.bind(clusterRoleHelper)}
+  SummaryComponent={ClusterRoleDetailsSummary} />

--- a/packages/webview/src/component/cluster-roles/ClusterRoleDetails.svelte
+++ b/packages/webview/src/component/cluster-roles/ClusterRoleDetails.svelte
@@ -6,6 +6,7 @@ import { ClusterRoleHelper } from './cluster-role-helper';
 import type { ClusterRoleUI } from './ClusterRoleUI';
 import type { V1ClusterRole } from '@kubernetes/client-node';
 import ClusterRoleDetailsSummary from './ClusterRoleDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -24,4 +25,5 @@ const clusterRoleHelper = dependencyAccessor.get<ClusterRoleHelper>(ClusterRoleH
   listName="Cluster Roles"
   name={name}
   transformer={clusterRoleHelper.getClusterRoleUI.bind(clusterRoleHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={ClusterRoleDetailsSummary} />

--- a/packages/webview/src/component/cluster-roles/ClusterRoleDetailsSummary.svelte
+++ b/packages/webview/src/component/cluster-roles/ClusterRoleDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1ClusterRole } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1ClusterRole;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/cluster-roles/ClusterRoleDetailsSummary.svelte
+++ b/packages/webview/src/component/cluster-roles/ClusterRoleDetailsSummary.svelte
@@ -1,20 +1,16 @@
 <script lang="ts">
 import type { V1ClusterRole } from '@kubernetes/client-node';
-import type { EventUI } from '/@/component/objects/EventUI';
 import Table from '/@/component/details/Table.svelte';
 import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
-import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
 
 interface Props {
   object: V1ClusterRole;
-  events: readonly EventUI[];
 }
-let { object, events }: Props = $props();
+let { object }: Props = $props();
 </script>
 
 <Table>
   {#if object.metadata}
     <ObjectMetaDetails artifact={object.metadata} />
   {/if}
-  <EventsDetails events={events} />
 </Table>

--- a/packages/webview/src/component/cluster-roles/ClusterRoleUI.ts
+++ b/packages/webview/src/component/cluster-roles/ClusterRoleUI.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface ClusterRoleUI extends KubernetesObjectUI {
+  uid: string;
+  created?: Date;
+  rules: number;
+}

--- a/packages/webview/src/component/cluster-roles/ClusterRolesList.svelte
+++ b/packages/webview/src/component/cluster-roles/ClusterRolesList.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { ClusterRoleUI } from './ClusterRoleUI';
+import { ClusterRoleHelper } from './cluster-role-helper';
+import ActionsColumn from './columns/Actions.svelte';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const clusterRoleHelper = dependencyAccessor.get<ClusterRoleHelper>(ClusterRoleHelper);
+
+let statusColumn = new TableColumn<ClusterRoleUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<ClusterRoleUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let rulesColumn = new TableColumn<ClusterRoleUI, string>('Rules', {
+  renderMapping: (obj): string => String(obj.rules),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.rules - b.rules,
+});
+
+let ageColumn = new TableColumn<ClusterRoleUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  rulesColumn,
+  ageColumn,
+  new TableColumn<ClusterRoleUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<ClusterRoleUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'clusterroles',
+      transformer: clusterRoleHelper.getClusterRoleUI.bind(clusterRoleHelper),
+    },
+  ]}
+  singular="cluster role"
+  plural="cluster roles"
+  isNamespaced={false}
+  icon={icon['ClusterRole']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['ClusterRole']} resources={['clusterroles']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/cluster-roles/_cluster-roles-module.ts
+++ b/packages/webview/src/component/cluster-roles/_cluster-roles-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { ClusterRoleHelper } from './cluster-role-helper';
+
+const clusterRolesModule = new ContainerModule(options => {
+  options.bind<ClusterRoleHelper>(ClusterRoleHelper).toSelf().inSingletonScope();
+});
+
+export { clusterRolesModule };

--- a/packages/webview/src/component/cluster-roles/cluster-role-helper.spec.ts
+++ b/packages/webview/src/component/cluster-roles/cluster-role-helper.spec.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ClusterRole } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { ClusterRoleHelper } from './cluster-role-helper';
+
+let helper: ClusterRoleHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new ClusterRoleHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const cr: V1ClusterRole = {
+    metadata: {
+      uid: 'cr-uid-1',
+      name: 'cluster-admin',
+      creationTimestamp: new Date('2026-02-20T12:00:00Z'),
+    },
+    rules: [
+      { apiGroups: ['*'], resources: ['*'], verbs: ['*'] },
+      { apiGroups: [''], resources: ['pods'], verbs: ['get', 'list'] },
+    ],
+  };
+
+  const result = helper.getClusterRoleUI(cr);
+
+  expect(result.kind).toBe('ClusterRole');
+  expect(result.uid).toBe('cr-uid-1');
+  expect(result.name).toBe('cluster-admin');
+  expect(result.status).toBe('RUNNING');
+  expect(result.created).toEqual(new Date('2026-02-20T12:00:00Z'));
+});
+
+test('expect rules count from rules array length', async () => {
+  const cr: V1ClusterRole = {
+    metadata: { uid: 'cr-uid-2', name: 'role-with-rules' },
+    rules: [
+      { apiGroups: [''], resources: ['pods'], verbs: ['get'] },
+      { apiGroups: [''], resources: ['services'], verbs: ['list'] },
+      { apiGroups: ['apps'], resources: ['deployments'], verbs: ['create'] },
+    ],
+  };
+
+  const result = helper.getClusterRoleUI(cr);
+
+  expect(result.rules).toBe(3);
+});
+
+test('expect rules count zero when no rules', async () => {
+  const cr: V1ClusterRole = {
+    metadata: { uid: 'cr-uid-3', name: 'role-no-rules' },
+  };
+
+  const result = helper.getClusterRoleUI(cr);
+
+  expect(result.rules).toBe(0);
+});

--- a/packages/webview/src/component/cluster-roles/cluster-role-helper.ts
+++ b/packages/webview/src/component/cluster-roles/cluster-role-helper.ts
@@ -1,0 +1,34 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ClusterRole } from '@kubernetes/client-node';
+
+import type { ClusterRoleUI } from './ClusterRoleUI';
+
+export class ClusterRoleHelper {
+  getClusterRoleUI(obj: V1ClusterRole): ClusterRoleUI {
+    return {
+      kind: 'ClusterRole',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      created: obj.metadata?.creationTimestamp,
+      rules: obj.rules?.length ?? 0,
+    };
+  }
+}

--- a/packages/webview/src/component/cluster-roles/columns/Actions.svelte
+++ b/packages/webview/src/component/cluster-roles/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/cluster-roles/columns/props.ts
+++ b/packages/webview/src/component/cluster-roles/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ClusterRoleUI } from '/@/component/cluster-roles/ClusterRoleUI';
+
+export interface Props {
+  object: ClusterRoleUI;
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -47,6 +47,7 @@ import { storageClassesModule } from '/@/component/storage-classes/_storage-clas
 import { serviceAccountsModule } from '/@/component/service-accounts/_service-accounts-module';
 import { rolesModule } from '/@/component/roles/_roles-module';
 import { roleBindingsModule } from '/@/component/role-bindings/_role-bindings-module';
+import { clusterRolesModule } from '/@/component/cluster-roles/_cluster-roles-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -88,6 +89,7 @@ export class InversifyBinding {
     await this.#container.load(serviceAccountsModule);
     await this.#container.load(rolesModule);
     await this.#container.load(roleBindingsModule);
+    await this.#container.load(clusterRolesModule);
 
     return this.#container;
   }

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -217,6 +217,7 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  });
 
   test('go to clusterRoles page', async () => {
     const clusterRolesPage = await navigation.openTabPage(KubernetesResources.ClusterRoles);

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -217,6 +217,11 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+
+  test('go to clusterRoles page', async () => {
+    const clusterRolesPage = await navigation.openTabPage(KubernetesResources.ClusterRoles);
+    await playExpect(clusterRolesPage.heading).toBeVisible();
+    await playExpect.poll(async () => clusterRolesPage.isEmpty('No clusterroles')).toBeTruthy();
   });
 
   test('go to roleBindings page', async () => {

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -221,7 +221,7 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
   test('go to clusterRoles page', async () => {
     const clusterRolesPage = await navigation.openTabPage(KubernetesResources.ClusterRoles);
     await playExpect(clusterRolesPage.heading).toBeVisible();
-    await playExpect.poll(async () => clusterRolesPage.isEmpty('No clusterroles')).toBeTruthy();
+    await playExpect.poll(async () => clusterRolesPage.rowsAreVisible()).toBeTruthy();
   });
 
   test('go to roleBindings page', async () => {

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -44,6 +44,7 @@ export enum KubernetesResources {
   ServiceAccounts = 'Service Accounts',
   Roles = 'Roles',
   RoleBindings = 'Role Bindings',
+  ClusterRoles = 'Cluster Roles',
 }
 
 export const KubernetesResourceAttributes: Record<KubernetesResources, string[]> = {
@@ -96,4 +97,5 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   [KubernetesResources.ServiceAccounts]: ['Selected', 'Status', 'Name', 'Secrets', 'Age', 'Actions'],
   [KubernetesResources.Roles]: ['Selected', 'Status', 'Name', 'Rules', 'Age', 'Actions'],
   [KubernetesResources.RoleBindings]: ['Selected', 'Status', 'Name', 'Bindings', 'Role', 'Age', 'Actions'],
+  [KubernetesResources.ClusterRoles]: ['Selected', 'Status', 'Name', 'Rules', 'Age', 'Actions'],
 };

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -41,6 +41,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.ServiceAccounts]: NavSection.Config,
   [KubernetesResources.Roles]: NavSection.AccessControl,
   [KubernetesResources.RoleBindings]: NavSection.AccessControl,
+  [KubernetesResources.ClusterRoles]: NavSection.AccessControl,
 };
 
 export class KubernetesBar {


### PR DESCRIPTION
feat(access-control): add ClusterRole resource

### What does this PR do?

Adds resource views for ClusterRole under the Access Control section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/0180522a-3ac0-41f2-bad4-3bf412c22c57

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Connect to a cluster with example a ClusterRole resource
2. Confirm you are able to view the new section

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
