### PR TITLE
feat(access-control): add Role resource

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -79,6 +79,7 @@ import { ReplicaSetsResourceFactory } from '/@/resources/replicasets-resource-fa
 import { PVsResourceFactory } from '/@/resources/pvs-resource-factory.js';
 import { StorageClassesResourceFactory } from '/@/resources/storage-classes-resource-factory.js';
 import { ServiceAccountsResourceFactory } from '/@/resources/service-accounts-resource-factory.js';
+import { RolesResourceFactory } from '/@/resources/roles-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -193,6 +194,7 @@ export class ContextsManager implements ContextsApi {
       new PVsResourceFactory(),
       new StorageClassesResourceFactory(),
       new ServiceAccountsResourceFactory(),
+      new RolesResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/roles-resource-factory.spec.ts
+++ b/packages/extension/src/resources/roles-resource-factory.spec.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { RolesResourceFactory } from './roles-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new RolesResourceFactory();
+  expect(factory.resource).toBe('roles');
+  expect(factory.kind).toBe('Role');
+});

--- a/packages/extension/src/resources/roles-resource-factory.ts
+++ b/packages/extension/src/resources/roles-resource-factory.ts
@@ -1,0 +1,71 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1Role, V1RoleList, V1Status } from '@kubernetes/client-node';
+import { RbacAuthorizationV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class RolesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'roles',
+      kind: 'Role',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'rbac.authorization.k8s.io',
+          resource: 'roles',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteRole);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Role> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    const listFn = (): Promise<V1RoleList> => apiClient.listNamespacedRole({ namespace });
+    const path = `/apis/rbac.authorization.k8s.io/v1/namespaces/${namespace}/roles`;
+    return new ResourceInformer<V1Role>({ kubeconfig, path, listFn, kind: this.kind, plural: 'roles' });
+  }
+
+  deleteRole(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    return apiClient.deleteNamespacedRole({ name, namespace });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -205,6 +205,8 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
   <Route path="/roles">
     <RolesList />
   </Route>

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -39,6 +39,8 @@ import StorageClassesList from './component/storage-classes/StorageClassesList.s
 import StorageClassDetails from './component/storage-classes/StorageClassDetails.svelte';
 import ServiceAccountsList from './component/service-accounts/ServiceAccountsList.svelte';
 import ServiceAccountDetails from './component/service-accounts/ServiceAccountDetails.svelte';
+import RolesList from './component/roles/RolesList.svelte';
+import RoleDetails from './component/roles/RoleDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -203,5 +205,11 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  <Route path="/roles">
+    <RolesList />
+  </Route>
+
+  <Route path="/roles/:name/:namespace/*" let:meta>
+    <RoleDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
   </Route>
 </div>

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -57,10 +57,7 @@ const storageUrls = [
   navigator.kubernetesResourcesURL('StorageClass'),
 ];
 
-
-const accessControlUrls = [
-  navigator.kubernetesResourcesURL('Role'),
-];
+const accessControlUrls = [navigator.kubernetesResourcesURL('Role')];
 const STORAGE_KEY = 'nav-sections-expanded';
 
 function loadExpanded(): Record<string, boolean> {

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -158,6 +158,17 @@ $effect(() => {
       <NavItem title="Storage Classes" child={true} href={navigator.kubernetesResourcesURL('StorageClass')} />
     {/if}
 
+    <!-- Access Control section -->
+    <NavItem
+      title="Access Control"
+      icon={faShieldHalved}
+      section={true}
+      bind:expanded={accessControlExpanded}
+      href="" />
+    {#if accessControlExpanded}
+      <NavItem title="Roles" child={true} href={navigator.kubernetesResourcesURL('Role')} />
+    {/if}
+
     <NavItem title="Namespaces" icon={faLayerGroup} href={navigator.kubernetesResourcesURL('Namespace')} />
   </div>
 </nav>

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -8,6 +8,7 @@ import {
   faLayerGroup,
   faNetworkWired,
   faServer,
+  faShieldHalved,
 } from '@fortawesome/free-solid-svg-icons';
 import { getContext, setContext } from 'svelte';
 import { Navigator } from '/@/navigation/navigator';
@@ -56,6 +57,10 @@ const storageUrls = [
   navigator.kubernetesResourcesURL('StorageClass'),
 ];
 
+
+const accessControlUrls = [
+  navigator.kubernetesResourcesURL('Role'),
+];
 const STORAGE_KEY = 'nav-sections-expanded';
 
 function loadExpanded(): Record<string, boolean> {
@@ -82,12 +87,14 @@ let workloadsExpanded = $state(initExpanded('compute', workloadUrls));
 let configExpanded = $state(initExpanded('config', configUrls));
 let networkExpanded = $state(initExpanded('network', networkUrls));
 let storageExpanded = $state(initExpanded('storage', storageUrls));
+let accessControlExpanded = $state(initExpanded('accessControl', accessControlUrls));
 
 $effect(() => {
   if (isUnderSection(workloadUrls)) workloadsExpanded = true;
   if (isUnderSection(configUrls)) configExpanded = true;
   if (isUnderSection(networkUrls)) networkExpanded = true;
   if (isUnderSection(storageUrls)) storageExpanded = true;
+  if (isUnderSection(accessControlUrls)) accessControlExpanded = true;
 });
 
 $effect(() => {
@@ -101,6 +108,9 @@ $effect(() => {
 });
 $effect(() => {
   saveExpanded('storage', storageExpanded);
+});
+$effect(() => {
+  saveExpanded('accessControl', accessControlExpanded);
 });
 </script>
 

--- a/packages/webview/src/component/roles/RoleDetails.svelte
+++ b/packages/webview/src/component/roles/RoleDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { RoleHelper } from './role-helper';
+import type { RoleUI } from './RoleUI';
+import type { V1Role } from '@kubernetes/client-node';
+import RoleDetailsSummary from './RoleDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const roleHelper = dependencyAccessor.get<RoleHelper>(RoleHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1Role}
+  typedUI={{} as RoleUI}
+  kind="Role"
+  resourceName="roles"
+  listName="Roles"
+  name={name}
+  namespace={namespace}
+  transformer={roleHelper.getRoleUI.bind(roleHelper)}
+  SummaryComponent={RoleDetailsSummary} />

--- a/packages/webview/src/component/roles/RoleDetails.svelte
+++ b/packages/webview/src/component/roles/RoleDetails.svelte
@@ -6,6 +6,7 @@ import { RoleHelper } from './role-helper';
 import type { RoleUI } from './RoleUI';
 import type { V1Role } from '@kubernetes/client-node';
 import RoleDetailsSummary from './RoleDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -26,4 +27,5 @@ const roleHelper = dependencyAccessor.get<RoleHelper>(RoleHelper);
   name={name}
   namespace={namespace}
   transformer={roleHelper.getRoleUI.bind(roleHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={RoleDetailsSummary} />

--- a/packages/webview/src/component/roles/RoleDetailsSummary.svelte
+++ b/packages/webview/src/component/roles/RoleDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1Role } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1Role;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/roles/RoleDetailsSummary.svelte
+++ b/packages/webview/src/component/roles/RoleDetailsSummary.svelte
@@ -1,20 +1,16 @@
 <script lang="ts">
 import type { V1Role } from '@kubernetes/client-node';
-import type { EventUI } from '/@/component/objects/EventUI';
 import Table from '/@/component/details/Table.svelte';
 import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
-import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
 
 interface Props {
   object: V1Role;
-  events: readonly EventUI[];
 }
-let { object, events }: Props = $props();
+let { object }: Props = $props();
 </script>
 
 <Table>
   {#if object.metadata}
     <ObjectMetaDetails artifact={object.metadata} />
   {/if}
-  <EventsDetails events={events} />
 </Table>

--- a/packages/webview/src/component/roles/RoleUI.ts
+++ b/packages/webview/src/component/roles/RoleUI.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface RoleUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  rules: number;
+}

--- a/packages/webview/src/component/roles/RolesList.svelte
+++ b/packages/webview/src/component/roles/RolesList.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { RoleUI } from './RoleUI';
+import { RoleHelper } from './role-helper';
+import ActionsColumn from './columns/Actions.svelte';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const roleHelper = dependencyAccessor.get<RoleHelper>(RoleHelper);
+
+let statusColumn = new TableColumn<RoleUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<RoleUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let rulesColumn = new TableColumn<RoleUI, string>('Rules', {
+  renderMapping: (obj): string => String(obj.rules),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.rules - b.rules,
+});
+
+let ageColumn = new TableColumn<RoleUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  rulesColumn,
+  ageColumn,
+  new TableColumn<RoleUI>('Actions', { align: 'right', width: '150px', renderer: ActionsColumn, overflow: true }),
+];
+
+const row = new TableRow<RoleUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'roles',
+      transformer: roleHelper.getRoleUI,
+    },
+  ]}
+  singular="role"
+  plural="roles"
+  isNamespaced={true}
+  icon={icon['Role']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['Role']} resources={['roles']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/roles/RolesList.svelte
+++ b/packages/webview/src/component/roles/RolesList.svelte
@@ -56,7 +56,7 @@ const row = new TableRow<RoleUI>({ selectable: (_obj): boolean => true });
   kinds={[
     {
       resource: 'roles',
-      transformer: roleHelper.getRoleUI,
+      transformer: roleHelper.getRoleUI.bind(roleHelper),
     },
   ]}
   singular="role"

--- a/packages/webview/src/component/roles/_roles-module.ts
+++ b/packages/webview/src/component/roles/_roles-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { RoleHelper } from './role-helper';
+
+const rolesModule = new ContainerModule(options => {
+  options.bind<RoleHelper>(RoleHelper).toSelf().inSingletonScope();
+});
+
+export { rolesModule };

--- a/packages/webview/src/component/roles/columns/Actions.svelte
+++ b/packages/webview/src/component/roles/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/roles/columns/props.ts
+++ b/packages/webview/src/component/roles/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { RoleUI } from '/@/component/roles/RoleUI';
+
+export interface Props {
+  object: RoleUI;
+}

--- a/packages/webview/src/component/roles/role-helper.spec.ts
+++ b/packages/webview/src/component/roles/role-helper.spec.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Role } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { RoleHelper } from './role-helper';
+
+let helper: RoleHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new RoleHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const role: V1Role = {
+    metadata: {
+      uid: 'role-uid-1',
+      name: 'pod-reader',
+      namespace: 'default',
+      creationTimestamp: new Date('2026-04-10T08:30:00Z'),
+    },
+    rules: [{ apiGroups: [''], resources: ['pods'], verbs: ['get', 'watch', 'list'] }],
+  };
+
+  const result = helper.getRoleUI(role);
+
+  expect(result.kind).toBe('Role');
+  expect(result.uid).toBe('role-uid-1');
+  expect(result.name).toBe('pod-reader');
+  expect(result.namespace).toBe('default');
+  expect(result.status).toBe('RUNNING');
+  expect(result.selected).toBe(false);
+  expect(result.created).toEqual(new Date('2026-04-10T08:30:00Z'));
+});
+
+test('expect rules count from rules array length', async () => {
+  const role: V1Role = {
+    metadata: { uid: 'role-uid-2', name: 'multi-rule-role', namespace: 'staging' },
+    rules: [
+      { apiGroups: [''], resources: ['pods'], verbs: ['get'] },
+      { apiGroups: [''], resources: ['configmaps'], verbs: ['get', 'list'] },
+    ],
+  };
+
+  const result = helper.getRoleUI(role);
+
+  expect(result.rules).toBe(2);
+});
+
+test('expect rules count zero when no rules', async () => {
+  const role: V1Role = {
+    metadata: { uid: 'role-uid-3', name: 'empty-role', namespace: 'default' },
+  };
+
+  const result = helper.getRoleUI(role);
+
+  expect(result.rules).toBe(0);
+});

--- a/packages/webview/src/component/roles/role-helper.ts
+++ b/packages/webview/src/component/roles/role-helper.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Role } from '@kubernetes/client-node';
+
+import type { RoleUI } from './RoleUI';
+
+export class RoleHelper {
+  getRoleUI(obj: V1Role): RoleUI {
+    return {
+      kind: 'Role',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: obj.metadata?.namespace ?? '',
+      created: obj.metadata?.creationTimestamp,
+      selected: false,
+      rules: obj.rules?.length ?? 0,
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -45,6 +45,7 @@ import { replicaSetsModule } from '/@/component/replicasets/_replicasets-module'
 import { pvsModule } from '/@/component/pvs/_pvs-module';
 import { storageClassesModule } from '/@/component/storage-classes/_storage-classes-module';
 import { serviceAccountsModule } from '/@/component/service-accounts/_service-accounts-module';
+import { rolesModule } from '/@/component/roles/_roles-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -84,6 +85,7 @@ export class InversifyBinding {
     await this.#container.load(pvsModule);
     await this.#container.load(storageClassesModule);
     await this.#container.load(serviceAccountsModule);
+    await this.#container.load(rolesModule);
 
     return this.#container;
   }

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -217,6 +217,7 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  });
 
   test('go to roles page', async () => {
     const rolesPage = await navigation.openTabPage(KubernetesResources.Roles);

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -217,6 +217,11 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+
+  test('go to roles page', async () => {
+    const rolesPage = await navigation.openTabPage(KubernetesResources.Roles);
+    await playExpect(rolesPage.heading).toBeVisible();
+    await playExpect.poll(async () => rolesPage.isEmpty('No roles')).toBeTruthy();
   });
 
   test('go to configmaps & secrets page', async () => {

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -21,6 +21,7 @@ export enum NavSection {
   Config = 'Config',
   Network = 'Network',
   Storage = 'Storage',
+  AccessControl = 'Access Control',
 }
 
 export enum KubernetesResources {

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -41,6 +41,7 @@ export enum KubernetesResources {
   Cronjobs = 'CronJobs',
   Jobs = 'Jobs',
   ServiceAccounts = 'Service Accounts',
+  Roles = 'Roles',
 }
 
 export const KubernetesResourceAttributes: Record<KubernetesResources, string[]> = {
@@ -91,4 +92,5 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   ],
   [KubernetesResources.Jobs]: ['Selected', 'Status', 'Name', 'Conditions', 'Completions', 'Age', 'Actions'],
   [KubernetesResources.ServiceAccounts]: ['Selected', 'Status', 'Name', 'Secrets', 'Age', 'Actions'],
+  [KubernetesResources.Roles]: ['Selected', 'Status', 'Name', 'Rules', 'Age', 'Actions'],
 };

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -39,6 +39,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.PersistentVolumes]: NavSection.Storage,
   [KubernetesResources.StorageClasses]: NavSection.Storage,
   [KubernetesResources.ServiceAccounts]: NavSection.Config,
+  [KubernetesResources.Roles]: NavSection.AccessControl,
 };
 
 export class KubernetesBar {


### PR DESCRIPTION
feat(access-control): add Role resource

### What does this PR do?

Adds resource views for Role under the Access Control section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/0180522a-3ac0-41f2-bad4-3bf412c22c57

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Connect to a cluster with example a Role resource
2. Confirm you are able to view the new section

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
