### PR TITLE
feat(access-control): add ClusterRoleBinding resource

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -82,6 +82,7 @@ import { ServiceAccountsResourceFactory } from '/@/resources/service-accounts-re
 import { RolesResourceFactory } from '/@/resources/roles-resource-factory.js';
 import { RoleBindingsResourceFactory } from '/@/resources/role-bindings-resource-factory.js';
 import { ClusterRolesResourceFactory } from '/@/resources/cluster-roles-resource-factory.js';
+import { ClusterRoleBindingsResourceFactory } from '/@/resources/cluster-role-bindings-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -199,6 +200,7 @@ export class ContextsManager implements ContextsApi {
       new RolesResourceFactory(),
       new RoleBindingsResourceFactory(),
       new ClusterRolesResourceFactory(),
+      new ClusterRoleBindingsResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/cluster-role-bindings-resource-factory.spec.ts
+++ b/packages/extension/src/resources/cluster-role-bindings-resource-factory.spec.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { ClusterRoleBindingsResourceFactory } from './cluster-role-bindings-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new ClusterRoleBindingsResourceFactory();
+  expect(factory.resource).toBe('clusterrolebindings');
+  expect(factory.kind).toBe('ClusterRoleBinding');
+});

--- a/packages/extension/src/resources/cluster-role-bindings-resource-factory.ts
+++ b/packages/extension/src/resources/cluster-role-bindings-resource-factory.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  KubernetesObject,
+  V1ClusterRoleBinding,
+  V1ClusterRoleBindingList,
+  V1Status,
+} from '@kubernetes/client-node';
+import { RbacAuthorizationV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class ClusterRoleBindingsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'clusterrolebindings',
+      kind: 'ClusterRoleBinding',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'rbac.authorization.k8s.io',
+          resource: 'clusterrolebindings',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteClusterRoleBinding);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1ClusterRoleBinding> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    const listFn = (): Promise<V1ClusterRoleBindingList> => apiClient.listClusterRoleBinding();
+    const path = `/apis/rbac.authorization.k8s.io/v1/clusterrolebindings`;
+    return new ResourceInformer<V1ClusterRoleBinding>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'clusterrolebindings',
+    });
+  }
+
+  deleteClusterRoleBinding(kubeconfig: KubeConfigSingleContext, name: string): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    return apiClient.deleteClusterRoleBinding({ name });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -45,6 +45,8 @@ import RoleBindingsList from './component/role-bindings/RoleBindingsList.svelte'
 import RoleBindingDetails from './component/role-bindings/RoleBindingDetails.svelte';
 import ClusterRolesList from './component/cluster-roles/ClusterRolesList.svelte';
 import ClusterRoleDetails from './component/cluster-roles/ClusterRoleDetails.svelte';
+import ClusterRoleBindingsList from './component/cluster-role-bindings/ClusterRoleBindingsList.svelte';
+import ClusterRoleBindingDetails from './component/cluster-role-bindings/ClusterRoleBindingDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -209,6 +211,12 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  <Route path="/clusterrolebindings">
+    <ClusterRoleBindingsList />
+  </Route>
+
+  <Route path="/clusterrolebindings/:name/*" let:meta>
+    <ClusterRoleBindingDetails name={decodeURI(meta.params.name)} />
   </Route>
 
   <Route path="/clusterroles">

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -211,6 +211,8 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
   <Route path="/clusterrolebindings">
     <ClusterRoleBindingsList />
   </Route>

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -61,6 +61,7 @@ const accessControlUrls = [
   navigator.kubernetesResourcesURL('Role'),
   navigator.kubernetesResourcesURL('RoleBinding'),
   navigator.kubernetesResourcesURL('ClusterRole'),
+  navigator.kubernetesResourcesURL('ClusterRoleBinding'),
 ];
 
 const STORAGE_KEY = 'nav-sections-expanded';

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -181,6 +181,10 @@ $effect(() => {
       <NavItem title="Roles" child={true} href={navigator.kubernetesResourcesURL('Role')} />
       <NavItem title="Role Bindings" child={true} href={navigator.kubernetesResourcesURL('RoleBinding')} />
       <NavItem title="Cluster Roles" child={true} href={navigator.kubernetesResourcesURL('ClusterRole')} />
+      <NavItem
+        title="Cluster Role Bindings"
+        child={true}
+        href={navigator.kubernetesResourcesURL('ClusterRoleBinding')} />
     {/if}
 
     <NavItem title="Namespaces" icon={faLayerGroup} href={navigator.kubernetesResourcesURL('Namespace')} />

--- a/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingDetails.svelte
+++ b/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingDetails.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { ClusterRoleBindingHelper } from './cluster-role-binding-helper';
+import type { ClusterRoleBindingUI } from './ClusterRoleBindingUI';
+import type { V1ClusterRoleBinding } from '@kubernetes/client-node';
+import ClusterRoleBindingDetailsSummary from './ClusterRoleBindingDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+}
+let { name }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const clusterRoleBindingHelper = dependencyAccessor.get<ClusterRoleBindingHelper>(ClusterRoleBindingHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1ClusterRoleBinding}
+  typedUI={{} as ClusterRoleBindingUI}
+  kind="ClusterRoleBinding"
+  resourceName="clusterrolebindings"
+  listName="Cluster Role Bindings"
+  name={name}
+  transformer={clusterRoleBindingHelper.getClusterRoleBindingUI.bind(clusterRoleBindingHelper)}
+  SummaryComponent={ClusterRoleBindingDetailsSummary} />

--- a/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingDetails.svelte
+++ b/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingDetails.svelte
@@ -6,6 +6,7 @@ import { ClusterRoleBindingHelper } from './cluster-role-binding-helper';
 import type { ClusterRoleBindingUI } from './ClusterRoleBindingUI';
 import type { V1ClusterRoleBinding } from '@kubernetes/client-node';
 import ClusterRoleBindingDetailsSummary from './ClusterRoleBindingDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -24,4 +25,5 @@ const clusterRoleBindingHelper = dependencyAccessor.get<ClusterRoleBindingHelper
   listName="Cluster Role Bindings"
   name={name}
   transformer={clusterRoleBindingHelper.getClusterRoleBindingUI.bind(clusterRoleBindingHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={ClusterRoleBindingDetailsSummary} />

--- a/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingDetailsSummary.svelte
+++ b/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1ClusterRoleBinding } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1ClusterRoleBinding;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingDetailsSummary.svelte
+++ b/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingDetailsSummary.svelte
@@ -1,20 +1,16 @@
 <script lang="ts">
 import type { V1ClusterRoleBinding } from '@kubernetes/client-node';
-import type { EventUI } from '/@/component/objects/EventUI';
 import Table from '/@/component/details/Table.svelte';
 import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
-import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
 
 interface Props {
   object: V1ClusterRoleBinding;
-  events: readonly EventUI[];
 }
-let { object, events }: Props = $props();
+let { object }: Props = $props();
 </script>
 
 <Table>
   {#if object.metadata}
     <ObjectMetaDetails artifact={object.metadata} />
   {/if}
-  <EventsDetails events={events} />
 </Table>

--- a/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingUI.ts
+++ b/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingUI.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface ClusterRoleBindingUI extends KubernetesObjectUI {
+  uid: string;
+  created?: Date;
+  bindings: string;
+  role: string;
+}

--- a/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingsList.svelte
+++ b/packages/webview/src/component/cluster-role-bindings/ClusterRoleBindingsList.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { ClusterRoleBindingUI } from './ClusterRoleBindingUI';
+import { ClusterRoleBindingHelper } from './cluster-role-binding-helper';
+import ActionsColumn from './columns/Actions.svelte';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const clusterRoleBindingHelper = dependencyAccessor.get<ClusterRoleBindingHelper>(ClusterRoleBindingHelper);
+
+let statusColumn = new TableColumn<ClusterRoleBindingUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<ClusterRoleBindingUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let bindingsColumn = new TableColumn<ClusterRoleBindingUI, string>('Bindings', {
+  width: '2fr',
+  renderMapping: (obj): string => obj.bindings,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.bindings.localeCompare(b.bindings),
+});
+
+let roleColumn = new TableColumn<ClusterRoleBindingUI, string>('Role', {
+  renderMapping: (obj): string => obj.role,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.role.localeCompare(b.role),
+});
+
+let ageColumn = new TableColumn<ClusterRoleBindingUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  bindingsColumn,
+  roleColumn,
+  ageColumn,
+  new TableColumn<ClusterRoleBindingUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<ClusterRoleBindingUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'clusterrolebindings',
+      transformer: clusterRoleBindingHelper.getClusterRoleBindingUI.bind(clusterRoleBindingHelper),
+    },
+  ]}
+  singular="cluster role binding"
+  plural="cluster role bindings"
+  isNamespaced={false}
+  icon={icon['ClusterRoleBinding']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['ClusterRoleBinding']} resources={['clusterrolebindings']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/cluster-role-bindings/_cluster-role-bindings-module.ts
+++ b/packages/webview/src/component/cluster-role-bindings/_cluster-role-bindings-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { ClusterRoleBindingHelper } from './cluster-role-binding-helper';
+
+const clusterRoleBindingsModule = new ContainerModule(options => {
+  options.bind<ClusterRoleBindingHelper>(ClusterRoleBindingHelper).toSelf().inSingletonScope();
+});
+
+export { clusterRoleBindingsModule };

--- a/packages/webview/src/component/cluster-role-bindings/cluster-role-binding-helper.spec.ts
+++ b/packages/webview/src/component/cluster-role-bindings/cluster-role-binding-helper.spec.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ClusterRoleBinding } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { ClusterRoleBindingHelper } from './cluster-role-binding-helper';
+
+let helper: ClusterRoleBindingHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new ClusterRoleBindingHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const crb: V1ClusterRoleBinding = {
+    metadata: {
+      uid: 'crb-uid-1',
+      name: 'admin-binding',
+      creationTimestamp: new Date('2026-05-01T14:00:00Z'),
+    },
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'ClusterRole',
+      name: 'cluster-admin',
+    },
+    subjects: [{ kind: 'User', name: 'alice', apiGroup: 'rbac.authorization.k8s.io' }],
+  };
+
+  const result = helper.getClusterRoleBindingUI(crb);
+
+  expect(result.kind).toBe('ClusterRoleBinding');
+  expect(result.uid).toBe('crb-uid-1');
+  expect(result.name).toBe('admin-binding');
+  expect(result.status).toBe('RUNNING');
+  expect(result.created).toEqual(new Date('2026-05-01T14:00:00Z'));
+});
+
+test('expect bindings joined from subjects names', async () => {
+  const crb: V1ClusterRoleBinding = {
+    metadata: { uid: 'crb-uid-2', name: 'multi-binding' },
+    roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'ClusterRole', name: 'view' },
+    subjects: [
+      { kind: 'User', name: 'alice', apiGroup: 'rbac.authorization.k8s.io' },
+      { kind: 'User', name: 'bob', apiGroup: 'rbac.authorization.k8s.io' },
+      { kind: 'ServiceAccount', name: 'deployer', apiGroup: '' },
+    ],
+  };
+
+  const result = helper.getClusterRoleBindingUI(crb);
+
+  expect(result.bindings).toBe('alice, bob, deployer');
+});
+
+test('expect role from roleRef name', async () => {
+  const crb: V1ClusterRoleBinding = {
+    metadata: { uid: 'crb-uid-3', name: 'editor-binding' },
+    roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'ClusterRole', name: 'edit' },
+  };
+
+  const result = helper.getClusterRoleBindingUI(crb);
+
+  expect(result.role).toBe('edit');
+  expect(result.bindings).toBe('');
+});

--- a/packages/webview/src/component/cluster-role-bindings/cluster-role-binding-helper.ts
+++ b/packages/webview/src/component/cluster-role-bindings/cluster-role-binding-helper.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1ClusterRoleBinding } from '@kubernetes/client-node';
+
+import type { ClusterRoleBindingUI } from './ClusterRoleBindingUI';
+
+export class ClusterRoleBindingHelper {
+  getClusterRoleBindingUI(o: KubernetesObject): ClusterRoleBindingUI {
+    const obj = o as V1ClusterRoleBinding;
+    return {
+      kind: 'ClusterRoleBinding',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      created: obj.metadata?.creationTimestamp,
+      bindings: (obj.subjects ?? []).map(s => s.name).join(', '),
+      role: obj.roleRef?.name ?? '',
+    };
+  }
+}

--- a/packages/webview/src/component/cluster-role-bindings/columns/Actions.svelte
+++ b/packages/webview/src/component/cluster-role-bindings/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/cluster-role-bindings/columns/props.ts
+++ b/packages/webview/src/component/cluster-role-bindings/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ClusterRoleBindingUI } from '/@/component/cluster-role-bindings/ClusterRoleBindingUI';
+
+export interface Props {
+  object: ClusterRoleBindingUI;
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -48,6 +48,7 @@ import { serviceAccountsModule } from '/@/component/service-accounts/_service-ac
 import { rolesModule } from '/@/component/roles/_roles-module';
 import { roleBindingsModule } from '/@/component/role-bindings/_role-bindings-module';
 import { clusterRolesModule } from '/@/component/cluster-roles/_cluster-roles-module';
+import { clusterRoleBindingsModule } from '/@/component/cluster-role-bindings/_cluster-role-bindings-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -90,6 +91,7 @@ export class InversifyBinding {
     await this.#container.load(rolesModule);
     await this.#container.load(roleBindingsModule);
     await this.#container.load(clusterRolesModule);
+    await this.#container.load(clusterRoleBindingsModule);
 
     return this.#container;
   }

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -217,6 +217,7 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  });
 
   test('go to clusterRoleBindings page', async () => {
     const clusterRoleBindingsPage = await navigation.openTabPage(KubernetesResources.ClusterRoleBindings);

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -221,7 +221,7 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
   test('go to clusterRoleBindings page', async () => {
     const clusterRoleBindingsPage = await navigation.openTabPage(KubernetesResources.ClusterRoleBindings);
     await playExpect(clusterRoleBindingsPage.heading).toBeVisible();
-    await playExpect.poll(async () => clusterRoleBindingsPage.isEmpty('No clusterrolebindings')).toBeTruthy();
+    await playExpect.poll(async () => clusterRoleBindingsPage.rowsAreVisible()).toBeTruthy();
   });
 
   test('go to clusterRoles page', async () => {

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -217,6 +217,11 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+
+  test('go to clusterRoleBindings page', async () => {
+    const clusterRoleBindingsPage = await navigation.openTabPage(KubernetesResources.ClusterRoleBindings);
+    await playExpect(clusterRoleBindingsPage.heading).toBeVisible();
+    await playExpect.poll(async () => clusterRoleBindingsPage.isEmpty('No clusterrolebindings')).toBeTruthy();
   });
 
   test('go to clusterRoles page', async () => {

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -45,6 +45,7 @@ export enum KubernetesResources {
   Roles = 'Roles',
   RoleBindings = 'Role Bindings',
   ClusterRoles = 'Cluster Roles',
+  ClusterRoleBindings = 'Cluster Role Bindings',
 }
 
 export const KubernetesResourceAttributes: Record<KubernetesResources, string[]> = {
@@ -98,4 +99,5 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   [KubernetesResources.Roles]: ['Selected', 'Status', 'Name', 'Rules', 'Age', 'Actions'],
   [KubernetesResources.RoleBindings]: ['Selected', 'Status', 'Name', 'Bindings', 'Role', 'Age', 'Actions'],
   [KubernetesResources.ClusterRoles]: ['Selected', 'Status', 'Name', 'Rules', 'Age', 'Actions'],
+  [KubernetesResources.ClusterRoleBindings]: ['Selected', 'Status', 'Name', 'Bindings', 'Role', 'Age', 'Actions'],
 };

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -42,6 +42,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.Roles]: NavSection.AccessControl,
   [KubernetesResources.RoleBindings]: NavSection.AccessControl,
   [KubernetesResources.ClusterRoles]: NavSection.AccessControl,
+  [KubernetesResources.ClusterRoleBindings]: NavSection.AccessControl,
 };
 
 export class KubernetesBar {


### PR DESCRIPTION
feat(access-control): add ClusterRoleBinding resource

### What does this PR do?

Adds resource views for ClusterRoleBinding under the Access Control section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/0180522a-3ac0-41f2-bad4-3bf412c22c57

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Connect to a cluster with example a ClusterRoleBinding resource
2. Confirm you are able to view the new section

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
