### PR TITLE
feat(access-control): add RoleBinding resource

### DIFF
--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -80,6 +80,7 @@ import { PVsResourceFactory } from '/@/resources/pvs-resource-factory.js';
 import { StorageClassesResourceFactory } from '/@/resources/storage-classes-resource-factory.js';
 import { ServiceAccountsResourceFactory } from '/@/resources/service-accounts-resource-factory.js';
 import { RolesResourceFactory } from '/@/resources/roles-resource-factory.js';
+import { RoleBindingsResourceFactory } from '/@/resources/role-bindings-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
 import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
@@ -195,6 +196,7 @@ export class ContextsManager implements ContextsApi {
       new StorageClassesResourceFactory(),
       new ServiceAccountsResourceFactory(),
       new RolesResourceFactory(),
+      new RoleBindingsResourceFactory(),
     ];
   }
 

--- a/packages/extension/src/resources/role-bindings-resource-factory.spec.ts
+++ b/packages/extension/src/resources/role-bindings-resource-factory.spec.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { RoleBindingsResourceFactory } from './role-bindings-resource-factory.js';
+
+test('factory has correct resource name and kind', () => {
+  const factory = new RoleBindingsResourceFactory();
+  expect(factory.resource).toBe('rolebindings');
+  expect(factory.kind).toBe('RoleBinding');
+});

--- a/packages/extension/src/resources/role-bindings-resource-factory.ts
+++ b/packages/extension/src/resources/role-bindings-resource-factory.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1RoleBinding, V1RoleBindingList, V1Status } from '@kubernetes/client-node';
+import { RbacAuthorizationV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from '/@/types/kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from '/@/types/resource-informer.js';
+
+export class RoleBindingsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'rolebindings',
+      kind: 'RoleBinding',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'rbac.authorization.k8s.io',
+          resource: 'rolebindings',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer.bind(this),
+    });
+    this.setDeleteObject(this.deleteRoleBinding);
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1RoleBinding> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    const listFn = (): Promise<V1RoleBindingList> => apiClient.listNamespacedRoleBinding({ namespace });
+    const path = `/apis/rbac.authorization.k8s.io/v1/namespaces/${namespace}/rolebindings`;
+    return new ResourceInformer<V1RoleBinding>({
+      kubeconfig,
+      path,
+      listFn,
+      kind: this.kind,
+      plural: 'rolebindings',
+    });
+  }
+
+  deleteRoleBinding(
+    kubeconfig: KubeConfigSingleContext,
+    name: string,
+    namespace: string,
+  ): Promise<V1Status | KubernetesObject> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(RbacAuthorizationV1Api);
+    return apiClient.deleteNamespacedRoleBinding({ name, namespace });
+  }
+}

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -41,6 +41,8 @@ import ServiceAccountsList from './component/service-accounts/ServiceAccountsLis
 import ServiceAccountDetails from './component/service-accounts/ServiceAccountDetails.svelte';
 import RolesList from './component/roles/RolesList.svelte';
 import RoleDetails from './component/roles/RoleDetails.svelte';
+import RoleBindingsList from './component/role-bindings/RoleBindingsList.svelte';
+import RoleBindingDetails from './component/role-bindings/RoleBindingDetails.svelte';
 // import globally the monaco environment
 import './monaco-environment';
 import type { TinroRouteMeta } from 'tinro';
@@ -205,6 +207,14 @@ const { meta }: Props = $props();
 
   <Route path="/serviceaccounts/:name/:namespace/*" let:meta>
     <ServiceAccountDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+  </Route>
+
+  <Route path="/rolebindings">
+    <RoleBindingsList />
+  </Route>
+
+  <Route path="/rolebindings/:name/:namespace/*" let:meta>
+    <RoleBindingDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
   </Route>
 
   <Route path="/roles">

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -174,6 +174,7 @@ $effect(() => {
       href="" />
     {#if accessControlExpanded}
       <NavItem title="Roles" child={true} href={navigator.kubernetesResourcesURL('Role')} />
+      <NavItem title="Role Bindings" child={true} href={navigator.kubernetesResourcesURL('RoleBinding')} />
     {/if}
 
     <NavItem title="Namespaces" icon={faLayerGroup} href={navigator.kubernetesResourcesURL('Namespace')} />

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -57,10 +57,7 @@ const storageUrls = [
   navigator.kubernetesResourcesURL('StorageClass'),
 ];
 
-const accessControlUrls = [
-  navigator.kubernetesResourcesURL('Role'),
-  navigator.kubernetesResourcesURL('RoleBinding'),
-];
+const accessControlUrls = [navigator.kubernetesResourcesURL('Role'), navigator.kubernetesResourcesURL('RoleBinding')];
 
 const STORAGE_KEY = 'nav-sections-expanded';
 

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -57,7 +57,11 @@ const storageUrls = [
   navigator.kubernetesResourcesURL('StorageClass'),
 ];
 
-const accessControlUrls = [navigator.kubernetesResourcesURL('Role')];
+const accessControlUrls = [
+  navigator.kubernetesResourcesURL('Role'),
+  navigator.kubernetesResourcesURL('RoleBinding'),
+];
+
 const STORAGE_KEY = 'nav-sections-expanded';
 
 function loadExpanded(): Record<string, boolean> {

--- a/packages/webview/src/component/role-bindings/RoleBindingDetails.svelte
+++ b/packages/webview/src/component/role-bindings/RoleBindingDetails.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import KubernetesObjectDetails from '/@/component/objects/KubernetesObjectDetails.svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import { RoleBindingHelper } from './role-binding-helper';
+import type { RoleBindingUI } from './RoleBindingUI';
+import type { V1RoleBinding } from '@kubernetes/client-node';
+import RoleBindingDetailsSummary from './RoleBindingDetailsSummary.svelte';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const roleBindingHelper = dependencyAccessor.get<RoleBindingHelper>(RoleBindingHelper);
+</script>
+
+<KubernetesObjectDetails
+  typed={{} as V1RoleBinding}
+  typedUI={{} as RoleBindingUI}
+  kind="RoleBinding"
+  resourceName="rolebindings"
+  listName="Role Bindings"
+  name={name}
+  namespace={namespace}
+  transformer={roleBindingHelper.getRoleBindingUI.bind(roleBindingHelper)}
+  SummaryComponent={RoleBindingDetailsSummary} />

--- a/packages/webview/src/component/role-bindings/RoleBindingDetails.svelte
+++ b/packages/webview/src/component/role-bindings/RoleBindingDetails.svelte
@@ -6,6 +6,7 @@ import { RoleBindingHelper } from './role-binding-helper';
 import type { RoleBindingUI } from './RoleBindingUI';
 import type { V1RoleBinding } from '@kubernetes/client-node';
 import RoleBindingDetailsSummary from './RoleBindingDetailsSummary.svelte';
+import Actions from './columns/Actions.svelte';
 
 interface Props {
   name: string;
@@ -26,4 +27,5 @@ const roleBindingHelper = dependencyAccessor.get<RoleBindingHelper>(RoleBindingH
   name={name}
   namespace={namespace}
   transformer={roleBindingHelper.getRoleBindingUI.bind(roleBindingHelper)}
+  ActionsComponent={Actions}
   SummaryComponent={RoleBindingDetailsSummary} />

--- a/packages/webview/src/component/role-bindings/RoleBindingDetailsSummary.svelte
+++ b/packages/webview/src/component/role-bindings/RoleBindingDetailsSummary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { V1RoleBinding } from '@kubernetes/client-node';
+import type { EventUI } from '/@/component/objects/EventUI';
+import Table from '/@/component/details/Table.svelte';
+import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
+import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
+
+interface Props {
+  object: V1RoleBinding;
+  events: readonly EventUI[];
+}
+let { object, events }: Props = $props();
+</script>
+
+<Table>
+  {#if object.metadata}
+    <ObjectMetaDetails artifact={object.metadata} />
+  {/if}
+  <EventsDetails events={events} />
+</Table>

--- a/packages/webview/src/component/role-bindings/RoleBindingDetailsSummary.svelte
+++ b/packages/webview/src/component/role-bindings/RoleBindingDetailsSummary.svelte
@@ -1,20 +1,16 @@
 <script lang="ts">
 import type { V1RoleBinding } from '@kubernetes/client-node';
-import type { EventUI } from '/@/component/objects/EventUI';
 import Table from '/@/component/details/Table.svelte';
 import ObjectMetaDetails from '/@/component/objects/details/ObjectMetaDetails.svelte';
-import EventsDetails from '/@/component/objects/details/EventsDetails.svelte';
 
 interface Props {
   object: V1RoleBinding;
-  events: readonly EventUI[];
 }
-let { object, events }: Props = $props();
+let { object }: Props = $props();
 </script>
 
 <Table>
   {#if object.metadata}
     <ObjectMetaDetails artifact={object.metadata} />
   {/if}
-  <EventsDetails events={events} />
 </Table>

--- a/packages/webview/src/component/role-bindings/RoleBindingUI.ts
+++ b/packages/webview/src/component/role-bindings/RoleBindingUI.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesNamespacedObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+export interface RoleBindingUI extends KubernetesNamespacedObjectUI {
+  uid: string;
+  created?: Date;
+  bindings: string;
+  role: string;
+}

--- a/packages/webview/src/component/role-bindings/RoleBindingsList.svelte
+++ b/packages/webview/src/component/role-bindings/RoleBindingsList.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import NameColumn from '/@/component/objects/columns/Name.svelte';
+import StatusColumn from '/@/component/objects/columns/Status.svelte';
+import KubernetesObjectsList from '/@/component/objects/KubernetesObjectsList.svelte';
+import { getContext } from 'svelte';
+import { DependencyAccessor } from '/@/inject/dependency-accessor';
+import KubernetesEmptyScreen from '/@/component/objects/KubernetesEmptyScreen.svelte';
+import { icon } from '/@/component/icons/icon';
+import type { RoleBindingUI } from './RoleBindingUI';
+import { RoleBindingHelper } from './role-binding-helper';
+import ActionsColumn from './columns/Actions.svelte';
+
+const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
+const roleBindingHelper = dependencyAccessor.get<RoleBindingHelper>(RoleBindingHelper);
+
+let statusColumn = new TableColumn<RoleBindingUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: StatusColumn,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<RoleBindingUI>('Name', {
+  width: '1.3fr',
+  renderer: NameColumn,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let bindingsColumn = new TableColumn<RoleBindingUI, string>('Bindings', {
+  width: '2fr',
+  renderMapping: (obj): string => obj.bindings,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.bindings.localeCompare(b.bindings),
+});
+
+let roleColumn = new TableColumn<RoleBindingUI, string>('Role', {
+  renderMapping: (obj): string => obj.role,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.role.localeCompare(b.role),
+});
+
+let ageColumn = new TableColumn<RoleBindingUI, Date | undefined>('Age', {
+  renderMapping: (obj): Date | undefined => obj.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  bindingsColumn,
+  roleColumn,
+  ageColumn,
+  new TableColumn<RoleBindingUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ActionsColumn,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<RoleBindingUI>({ selectable: (_obj): boolean => true });
+</script>
+
+<KubernetesObjectsList
+  kinds={[
+    {
+      resource: 'rolebindings',
+      transformer: roleBindingHelper.getRoleBindingUI,
+    },
+  ]}
+  singular="role binding"
+  plural="role bindings"
+  isNamespaced={true}
+  icon={icon['RoleBinding']}
+  columns={columns}
+  row={row}>
+  {#snippet emptySnippet()}
+    <KubernetesEmptyScreen icon={icon['RoleBinding']} resources={['rolebindings']} />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/webview/src/component/role-bindings/RoleBindingsList.svelte
+++ b/packages/webview/src/component/role-bindings/RoleBindingsList.svelte
@@ -69,7 +69,7 @@ const row = new TableRow<RoleBindingUI>({ selectable: (_obj): boolean => true })
   kinds={[
     {
       resource: 'rolebindings',
-      transformer: roleBindingHelper.getRoleBindingUI,
+      transformer: roleBindingHelper.getRoleBindingUI.bind(roleBindingHelper),
     },
   ]}
   singular="role binding"

--- a/packages/webview/src/component/role-bindings/_role-bindings-module.ts
+++ b/packages/webview/src/component/role-bindings/_role-bindings-module.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { RoleBindingHelper } from './role-binding-helper';
+
+const roleBindingsModule = new ContainerModule(options => {
+  options.bind<RoleBindingHelper>(RoleBindingHelper).toSelf().inSingletonScope();
+});
+
+export { roleBindingsModule };

--- a/packages/webview/src/component/role-bindings/columns/Actions.svelte
+++ b/packages/webview/src/component/role-bindings/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DeleteAction from '/@/component/objects/columns/DeleteAction.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DeleteAction object={object} />

--- a/packages/webview/src/component/role-bindings/columns/props.ts
+++ b/packages/webview/src/component/role-bindings/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { RoleBindingUI } from '/@/component/role-bindings/RoleBindingUI';
+
+export interface Props {
+  object: RoleBindingUI;
+}

--- a/packages/webview/src/component/role-bindings/role-binding-helper.spec.ts
+++ b/packages/webview/src/component/role-bindings/role-binding-helper.spec.ts
@@ -1,0 +1,83 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1RoleBinding } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { RoleBindingHelper } from './role-binding-helper';
+
+let helper: RoleBindingHelper;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helper = new RoleBindingHelper();
+});
+
+test('expect basic UI conversion', async () => {
+  const rb: V1RoleBinding = {
+    metadata: {
+      uid: 'rb-uid-1',
+      name: 'dev-binding',
+      namespace: 'development',
+      creationTimestamp: new Date('2026-06-15T09:00:00Z'),
+    },
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'Role',
+      name: 'pod-reader',
+    },
+    subjects: [{ kind: 'User', name: 'dev-user', apiGroup: 'rbac.authorization.k8s.io' }],
+  };
+
+  const result = helper.getRoleBindingUI(rb);
+
+  expect(result.kind).toBe('RoleBinding');
+  expect(result.uid).toBe('rb-uid-1');
+  expect(result.name).toBe('dev-binding');
+  expect(result.namespace).toBe('development');
+  expect(result.status).toBe('RUNNING');
+  expect(result.selected).toBe(false);
+  expect(result.created).toEqual(new Date('2026-06-15T09:00:00Z'));
+});
+
+test('expect bindings joined from subjects names', async () => {
+  const rb: V1RoleBinding = {
+    metadata: { uid: 'rb-uid-2', name: 'team-binding', namespace: 'prod' },
+    roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'Role', name: 'editor' },
+    subjects: [
+      { kind: 'User', name: 'carol', apiGroup: 'rbac.authorization.k8s.io' },
+      { kind: 'Group', name: 'developers', apiGroup: 'rbac.authorization.k8s.io' },
+    ],
+  };
+
+  const result = helper.getRoleBindingUI(rb);
+
+  expect(result.bindings).toBe('carol, developers');
+});
+
+test('expect role from roleRef name', async () => {
+  const rb: V1RoleBinding = {
+    metadata: { uid: 'rb-uid-3', name: 'viewer-binding', namespace: 'default' },
+    roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'Role', name: 'view' },
+  };
+
+  const result = helper.getRoleBindingUI(rb);
+
+  expect(result.role).toBe('view');
+  expect(result.bindings).toBe('');
+});

--- a/packages/webview/src/component/role-bindings/role-binding-helper.ts
+++ b/packages/webview/src/component/role-bindings/role-binding-helper.ts
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject, V1RoleBinding } from '@kubernetes/client-node';
+
+import type { RoleBindingUI } from './RoleBindingUI';
+
+export class RoleBindingHelper {
+  getRoleBindingUI(o: KubernetesObject): RoleBindingUI {
+    const obj = o as V1RoleBinding;
+    return {
+      kind: 'RoleBinding',
+      uid: obj.metadata?.uid ?? '',
+      name: obj.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: obj.metadata?.namespace ?? '',
+      created: obj.metadata?.creationTimestamp,
+      selected: false,
+      bindings: (obj.subjects ?? []).map(s => s.name).join(', '),
+      role: obj.roleRef?.name ?? '',
+    };
+  }
+}

--- a/packages/webview/src/inject/inversify-binding.ts
+++ b/packages/webview/src/inject/inversify-binding.ts
@@ -46,6 +46,7 @@ import { pvsModule } from '/@/component/pvs/_pvs-module';
 import { storageClassesModule } from '/@/component/storage-classes/_storage-classes-module';
 import { serviceAccountsModule } from '/@/component/service-accounts/_service-accounts-module';
 import { rolesModule } from '/@/component/roles/_roles-module';
+import { roleBindingsModule } from '/@/component/role-bindings/_role-bindings-module';
 
 export class InversifyBinding {
   #container: Container | undefined;
@@ -86,6 +87,7 @@ export class InversifyBinding {
     await this.#container.load(storageClassesModule);
     await this.#container.load(serviceAccountsModule);
     await this.#container.load(rolesModule);
+    await this.#container.load(roleBindingsModule);
 
     return this.#container;
   }

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -217,6 +217,11 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+
+  test('go to roleBindings page', async () => {
+    const roleBindingsPage = await navigation.openTabPage(KubernetesResources.RoleBindings);
+    await playExpect(roleBindingsPage.heading).toBeVisible();
+    await playExpect.poll(async () => roleBindingsPage.isEmpty('No rolebindings')).toBeTruthy();
   });
 
   test('go to roles page', async () => {

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -217,6 +217,7 @@ test.describe(`Extension usage`, { tag: '@integration' }, () => {
     const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
     await playExpect(serviceAccountsPage.heading).toBeVisible();
     await playExpect.poll(async () => serviceAccountsPage.isEmpty('No serviceaccounts')).toBeTruthy();
+  });
 
   test('go to roleBindings page', async () => {
     const roleBindingsPage = await navigation.openTabPage(KubernetesResources.RoleBindings);

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -43,6 +43,7 @@ export enum KubernetesResources {
   Jobs = 'Jobs',
   ServiceAccounts = 'Service Accounts',
   Roles = 'Roles',
+  RoleBindings = 'Role Bindings',
 }
 
 export const KubernetesResourceAttributes: Record<KubernetesResources, string[]> = {
@@ -94,4 +95,5 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   [KubernetesResources.Jobs]: ['Selected', 'Status', 'Name', 'Conditions', 'Completions', 'Age', 'Actions'],
   [KubernetesResources.ServiceAccounts]: ['Selected', 'Status', 'Name', 'Secrets', 'Age', 'Actions'],
   [KubernetesResources.Roles]: ['Selected', 'Status', 'Name', 'Rules', 'Age', 'Actions'],
+  [KubernetesResources.RoleBindings]: ['Selected', 'Status', 'Name', 'Bindings', 'Role', 'Age', 'Actions'],
 };

--- a/tests/playwright/src/model/pages/navigation.ts
+++ b/tests/playwright/src/model/pages/navigation.ts
@@ -40,6 +40,7 @@ const RESOURCE_SECTION: Partial<Record<KubernetesResources, NavSection>> = {
   [KubernetesResources.StorageClasses]: NavSection.Storage,
   [KubernetesResources.ServiceAccounts]: NavSection.Config,
   [KubernetesResources.Roles]: NavSection.AccessControl,
+  [KubernetesResources.RoleBindings]: NavSection.AccessControl,
 };
 
 export class KubernetesBar {


### PR DESCRIPTION
feat(access-control): add RoleBinding resource

### What does this PR do?

Adds resource views for RoleBinding under the Access Control section.

### Screenshot / video of UI

https://github.com/user-attachments/assets/0180522a-3ac0-41f2-bad4-3bf412c22c57

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/979

### How to test this PR?

1. Connect to a cluster with example a RoleBinding resource
2. Confirm you are able to view the new section

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
