### PR TITLE
test(connection): update tooltip queries for ui-svelte 1.29.1

### DIFF
--- a/packages/webview/src/component/connection/CurrentContextConnectionBadge.spec.ts
+++ b/packages/webview/src/component/connection/CurrentContextConnectionBadge.spec.ts
@@ -106,7 +106,7 @@ describe('current context is reachable', () => {
     const tooltipTrigger = screen.getByTestId('tooltip-trigger');
     fireEvent.mouseEnter(tooltipTrigger);
 
-    expect(screen.queryByLabelText('tooltip')).toBeNull();
+    expect(screen.queryByRole('tooltip')).toBeNull();
   });
 });
 
@@ -153,7 +153,7 @@ describe('current context is not reachable', () => {
     const tooltipTrigger = screen.getByTestId('tooltip-trigger');
     fireEvent.mouseEnter(tooltipTrigger);
 
-    expect(screen.getByLabelText('tooltip')).toBeDefined();
+    expect(screen.getByRole('tooltip')).toBeDefined();
   });
 });
 
@@ -200,7 +200,7 @@ describe('current context is offline', () => {
     const tooltipTrigger = screen.getByTestId('tooltip-trigger');
     fireEvent.mouseEnter(tooltipTrigger);
 
-    const tooltip = screen.getByLabelText('tooltip');
+    const tooltip = screen.getByRole('tooltip');
     expect(tooltip).toHaveTextContent('connection lost, you can try to reconnect');
   });
 });


### PR DESCRIPTION
### What does this PR do?

The Tooltip component now renders with role="tooltip" instead of aria-label="tooltip". Update the failing tests to use getByRole/queryByRole('tooltip') accordingly.

### Screenshot / video of UI


### What issues does this PR fix or reference?

changes for #1249

### How to test this PR?

<!-- Please explain steps to reproduce -->
