### PR TITLE
chore(agent): add skill to run e2e tests from a container

### DIFF
--- a/.agents/skills/e2e-container/SKILL.md
+++ b/.agents/skills/e2e-container/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: e2e-container
+description: >-
+  Guides running Playwright E2E tests for the Kubernetes Dashboard extension
+  inside a Linux container (e.g. on macOS via Docker/Podman). Covers
+  prerequisites, installing a Podman Desktop testing binary, building the
+  extension plugin without podman, starting an envtest cluster, running the
+  tests via CDP mode (no test runner patching needed), and cleanup.
+  Triggers when running E2E tests inside a container, setting up a containerised
+  test environment, or troubleshooting headless Electron issues.
+---
+
+# Running E2E Tests in a Linux Container
+
+> **Platform:** Tested and supported on **macOS/arm64** only. The container
+> images, binary downloads, and scripts assume an ARM64 host.
+
+This skill covers running the Playwright E2E test suite from inside a Linux
+arm64 container where `podman`, `brew`, and macOS-specific tools (`hdiutil`,
+`codesign`) are unavailable.
+
+All executable scripts are in the `scripts/` directory alongside this file.
+
+## Prerequisites
+
+These tools must be available in the container. Use the check commands to verify,
+and install anything missing.
+
+| Tool                 | Check command                                             |
+| -------------------- | --------------------------------------------------------- |
+| Go                   | `go version`                                              |
+| kubectl              | `kubectl version --client`                                |
+| Go PATH              | `echo $PATH \| grep -q "$(go env GOPATH)/bin" && echo ok` |
+| envtest tools        | `command -v envtest-start && command -v setup-envtest`    |
+| Xvfb + Electron libs | `command -v Xvfb`                                         |
+| dbus-launch          | `command -v dbus-launch`                                  |
+
+Run the prerequisites install script to install everything:
+
+```sh
+bash .agents/skills/e2e-container/scripts/install-prerequisites.sh
+```
+
+This installs Go PATH setup, envtest tools, Xvfb with Electron shared
+libraries, and `dbus-x11` (for `dbus-launch`). For Debian/Ubuntu containers,
+follow the commented instructions in the script.
+
+## Step-by-Step Workflow
+
+### Step 1: Install a Podman Desktop testing binary
+
+Downloads the latest nightly Linux arm64 build and creates a wrapper script
+that passes `--disable-dev-shm-usage` to work around the 64 MB `/dev/shm`
+limit in containers:
+
+```sh
+bash .agents/skills/e2e-container/scripts/install-pd-binary.sh
+```
+
+### Step 2: Build the extension plugin
+
+Without `podman`, this replicates the container export by copying build output
+directly into the plugins directory:
+
+```sh
+bash .agents/skills/e2e-container/scripts/build-extension-plugin.sh
+```
+
+### Step 3: Start the envtest Kubernetes cluster
+
+Starts a local Kubernetes API server via envtest and waits for the kubeconfig
+to be written:
+
+```sh
+bash .agents/skills/e2e-container/scripts/start-envtest.sh
+```
+
+The script exports `KUBEBUILDER_ASSETS` and backgrounds the `envtest-start`
+process. The PID is saved to `/tmp/envtest-start.pid` for later cleanup.
+
+### Step 4: Run the tests
+
+Copies kubeconfigs and runs the E2E suite using CDP mode:
+
+```sh
+bash .agents/skills/e2e-container/scripts/run-tests.sh
+```
+
+**How it works:** Setting `DEBUGGING_PORT` switches the test runner to
+`ChromeDevToolsProtocolRunner`, which launches Electron with
+`--remote-debugging-port` and connects via CDP — the same mechanism used by
+the interactive Podman Desktop skill. This avoids `recordVideo` in
+`electron.launch()`, which triggers Chromium's `Page.startScreencast` and
+blocks the compositor in GPU-less containers.
+
+### Step 5: Stop the cluster
+
+```sh
+bash .agents/skills/e2e-container/scripts/stop-envtest.sh
+```
+
+## Restarting the Tests
+
+**Quick restart** — only the cluster needs to be restarted: redo steps 3 and 4,
+keeping `EXTENSION_PREINSTALLED=true`.
+
+**Full clean restart** (e.g. after modifying extension sources) — after stopping
+the cluster, reset the Podman Desktop profile:
+
+```sh
+rm -rf tests/playwright/tests/playwright/
+```
+
+Then redo steps 2, 3, and 4.
+
+## Cleanup
+
+After stopping the cluster (step 5), remove all generated files:
+
+```sh
+bash .agents/skills/e2e-container/scripts/cleanup.sh
+```

--- a/.agents/skills/e2e-container/SKILL.md
+++ b/.agents/skills/e2e-container/SKILL.md
@@ -38,7 +38,7 @@ and install anything missing.
 Run the prerequisites install script to install everything:
 
 ```sh
-bash .agents/skills/e2e-container/scripts/install-prerequisites.sh
+bash skills/e2e-container/scripts/install-prerequisites.sh
 ```
 
 This installs Go PATH setup, envtest tools, Xvfb with Electron shared
@@ -53,7 +53,7 @@ that passes `--disable-dev-shm-usage` to work around the 64 MB `/dev/shm`
 limit in containers:
 
 ```sh
-bash .agents/skills/e2e-container/scripts/install-pd-binary.sh
+bash skills/e2e-container/scripts/install-pd-binary.sh
 ```
 
 ### Step 2: Build the extension plugin
@@ -62,7 +62,7 @@ Without `podman`, this replicates the container export by copying build output
 directly into the plugins directory:
 
 ```sh
-bash .agents/skills/e2e-container/scripts/build-extension-plugin.sh
+bash skills/e2e-container/scripts/build-extension-plugin.sh
 ```
 
 ### Step 3: Start the envtest Kubernetes cluster
@@ -71,7 +71,7 @@ Starts a local Kubernetes API server via envtest and waits for the kubeconfig
 to be written:
 
 ```sh
-bash .agents/skills/e2e-container/scripts/start-envtest.sh
+bash skills/e2e-container/scripts/start-envtest.sh
 ```
 
 The script exports `KUBEBUILDER_ASSETS` and backgrounds the `envtest-start`
@@ -82,7 +82,7 @@ process. The PID is saved to `/tmp/envtest-start.pid` for later cleanup.
 Copies kubeconfigs and runs the E2E suite using CDP mode:
 
 ```sh
-bash .agents/skills/e2e-container/scripts/run-tests.sh
+bash skills/e2e-container/scripts/run-tests.sh
 ```
 
 **How it works:** Setting `DEBUGGING_PORT` switches the test runner to
@@ -95,7 +95,7 @@ blocks the compositor in GPU-less containers.
 ### Step 5: Stop the cluster
 
 ```sh
-bash .agents/skills/e2e-container/scripts/stop-envtest.sh
+bash skills/e2e-container/scripts/stop-envtest.sh
 ```
 
 ## Restarting the Tests
@@ -117,5 +117,5 @@ Then redo steps 2, 3, and 4.
 After stopping the cluster (step 5), remove all generated files:
 
 ```sh
-bash .agents/skills/e2e-container/scripts/cleanup.sh
+bash skills/e2e-container/scripts/cleanup.sh
 ```

--- a/.agents/skills/e2e-container/SKILL.md
+++ b/.agents/skills/e2e-container/SKILL.md
@@ -42,8 +42,7 @@ bash .agents/skills/e2e-container/scripts/install-prerequisites.sh
 ```
 
 This installs Go PATH setup, envtest tools, Xvfb with Electron shared
-libraries, and `dbus-x11` (for `dbus-launch`). For Debian/Ubuntu containers,
-follow the commented instructions in the script.
+libraries, and `dbus-x11` (for `dbus-launch`).
 
 ## Step-by-Step Workflow
 

--- a/.agents/skills/e2e-container/scripts/build-extension-plugin.sh
+++ b/.agents/skills/e2e-container/scripts/build-extension-plugin.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Build the extension and copy it into the plugins directory.
+# This replicates the container export without requiring podman.
+
+set -euo pipefail
+
+export CI=true
+
+pnpm install
+pnpm build
+
+PLUGINS_DIR=tests/playwright/tests/playwright/output/kubernetes-dashboard-tests/plugins/extension
+
+mkdir -p "$PLUGINS_DIR"
+
+cp -r packages/extension/dist "$PLUGINS_DIR/"
+cp packages/extension/package.json "$PLUGINS_DIR/"
+cp packages/extension/*.png "$PLUGINS_DIR/"
+cp -r packages/extension/media "$PLUGINS_DIR/media" 2>/dev/null || true
+cp pnpm-workspace.yaml "$PLUGINS_DIR/"
+mkdir -p "$PLUGINS_DIR/packages/rpc" "$PLUGINS_DIR/packages/channels" "$PLUGINS_DIR/packages/api"
+cp packages/rpc/package.json "$PLUGINS_DIR/packages/rpc/"
+cp packages/channels/package.json "$PLUGINS_DIR/packages/channels/"
+cp packages/api/package.json "$PLUGINS_DIR/packages/api/"
+cp LICENSE "$PLUGINS_DIR/"
+cp README.md "$PLUGINS_DIR/"
+
+ISOMORPHIC_WS_VERSION=$(node -e "console.log(require('./node_modules/isomorphic-ws/package.json').version)")
+python3 -c "
+import json, sys
+with open('$PLUGINS_DIR/package.json') as f:
+    d = json.load(f)
+d.setdefault('dependencies', {})['isomorphic-ws'] = sys.argv[1]
+d.pop('devDependencies', None)
+d.pop('scripts', None)
+with open('$PLUGINS_DIR/package.json', 'w') as f:
+    json.dump(d, f, indent=2)
+" "$ISOMORPHIC_WS_VERSION"
+
+pnpm --dir "$PLUGINS_DIR" install --prod
+
+echo "Extension plugin built at $PLUGINS_DIR"

--- a/.agents/skills/e2e-container/scripts/cleanup.sh
+++ b/.agents/skills/e2e-container/scripts/cleanup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Remove all generated files after stopping the cluster.
+
+set -euo pipefail
+
+rm -rf tests/playwright/tests/
+rm -f tests/resources/envtest-kubeconfig tests/resources/envtest-kubeconfig-user1
+rm -f /tmp/envtest-kubeconfig /tmp/user1-kubeconfig
+
+echo "Cleanup complete"

--- a/.agents/skills/e2e-container/scripts/install-pd-binary.sh
+++ b/.agents/skills/e2e-container/scripts/install-pd-binary.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Download the latest Podman Desktop nightly Linux arm64 build and create
+# a wrapper that passes --disable-dev-shm-usage to work around the 64 MB
+# /dev/shm limit in containers.
+
+set -euo pipefail
+
+LATEST_TAG=$(gh api repos/podman-desktop/testing-prereleases/releases \
+  --jq 'sort_by(.created_at) | reverse | first(.[] | select(.assets | length > 0)) | .tag_name')
+
+echo "Downloading Podman Desktop tag: $LATEST_TAG"
+
+gh release download "$LATEST_TAG" \
+  --repo podman-desktop/testing-prereleases \
+  --pattern '*-arm64.tar.gz'
+
+mkdir -p tests/playwright/tests/PodmanDesktop
+tar xz --strip-components=1 \
+  -C tests/playwright/tests/PodmanDesktop \
+  -f podman-desktop-*-arm64.tar.gz
+rm podman-desktop-*-arm64.tar.gz
+
+PDDIR=tests/playwright/tests/PodmanDesktop
+mv "$PDDIR/podman-desktop" "$PDDIR/podman-desktop.real"
+
+cat > "$PDDIR/podman-desktop" << 'WRAPPER'
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$DIR/podman-desktop.real" --disable-dev-shm-usage "$@"
+WRAPPER
+chmod +x "$PDDIR/podman-desktop"
+
+echo "Podman Desktop installed at $PDDIR/podman-desktop"

--- a/.agents/skills/e2e-container/scripts/install-prerequisites.sh
+++ b/.agents/skills/e2e-container/scripts/install-prerequisites.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Install prerequisites for running E2E tests in a Linux container.
+
+set -euo pipefail
+
+# Go PATH
+if ! echo "$PATH" | grep -q "$(go env GOPATH)/bin"; then
+  export PATH="$PATH:$(go env GOPATH)/bin"
+  echo 'export PATH="$PATH:$(go env GOPATH)/bin"' >> ~/.bashrc
+  echo "Added Go bin to PATH"
+fi
+
+# kubectl
+if ! command -v kubectl &>/dev/null; then
+  cat <<'REPO' | sudo tee /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.36/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.36/rpm/repodata/repomd.xml.key
+REPO
+  sudo dnf install -y kubectl
+  echo "Installed kubectl $(kubectl version --client --short 2>/dev/null || kubectl version --client)"
+fi
+
+# envtest tools
+go install github.com/feloy/envtest-start@v0.1.0
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
+
+# Xvfb and Electron shared libraries (Fedora / RHEL-based)
+sudo dnf install -y \
+  xorg-x11-server-Xvfb \
+  nspr nss \
+  atk at-spi2-atk at-spi2-core \
+  cups-libs dbus-libs dbus-daemon \
+  cairo gtk3 pango \
+  libXcomposite libXdamage libXfixes libXrandr \
+  mesa-libgbm alsa-lib \
+  dbus-x11
+
+# For Debian / Ubuntu-based containers, comment the dnf block above and
+# uncomment the following:
+# sudo apt-get install -y xvfb libnss3 libatk1.0-0 libatk-bridge2.0-0 \
+#   libcups2 libdbus-1-3 dbus dbus-x11 libcairo2 libgtk-3-0 libpango-1.0-0 \
+#   libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libasound2 libatspi2.0-0

--- a/.agents/skills/e2e-container/scripts/install-prerequisites.sh
+++ b/.agents/skills/e2e-container/scripts/install-prerequisites.sh
@@ -3,13 +3,6 @@
 
 set -euo pipefail
 
-# Go PATH
-if ! echo "$PATH" | grep -q "$(go env GOPATH)/bin"; then
-  export PATH="$PATH:$(go env GOPATH)/bin"
-  echo 'export PATH="$PATH:$(go env GOPATH)/bin"' >> ~/.bashrc
-  echo "Added Go bin to PATH"
-fi
-
 # kubectl
 if ! command -v kubectl &>/dev/null; then
   cat <<'REPO' | sudo tee /etc/yum.repos.d/kubernetes.repo
@@ -37,4 +30,5 @@ sudo dnf install -y \
   cairo gtk3 pango \
   libXcomposite libXdamage libXfixes libXrandr \
   mesa-libgbm alsa-lib \
-  dbus-x11
+  dbus-x11 \
+  xdpyinfo xdotool

--- a/.agents/skills/e2e-container/scripts/install-prerequisites.sh
+++ b/.agents/skills/e2e-container/scripts/install-prerequisites.sh
@@ -38,9 +38,3 @@ sudo dnf install -y \
   libXcomposite libXdamage libXfixes libXrandr \
   mesa-libgbm alsa-lib \
   dbus-x11
-
-# For Debian / Ubuntu-based containers, comment the dnf block above and
-# uncomment the following:
-# sudo apt-get install -y xvfb libnss3 libatk1.0-0 libatk-bridge2.0-0 \
-#   libcups2 libdbus-1-3 dbus dbus-x11 libcairo2 libgtk-3-0 libpango-1.0-0 \
-#   libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libasound2 libatspi2.0-0

--- a/.agents/skills/e2e-container/scripts/run-tests.sh
+++ b/.agents/skills/e2e-container/scripts/run-tests.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copy kubeconfigs and run the E2E test suite.
+#
+# Uses DEBUGGING_PORT to switch the test runner to CDP mode
+# (ChromeDevToolsProtocolRunner), which avoids recordVideo and the
+# compositor-blocking screencast that hangs in GPU-less containers.
+
+set -euo pipefail
+
+export PATH="$PATH:$(go env GOPATH)/bin"
+export KUBEBUILDER_ASSETS=${KUBEBUILDER_ASSETS:-$(setup-envtest use -p path)}
+
+# Ensure DISPLAY and DBUS_SESSION_BUS_ADDRESS are set
+# (needed by the CDP runner which spawns Electron directly)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+eval "$("$SCRIPT_DIR/start-dbus.sh")"
+
+cp /tmp/envtest-kubeconfig tests/resources/envtest-kubeconfig
+cp /tmp/user1-kubeconfig tests/resources/envtest-kubeconfig-user1
+
+CI=true \
+DEBUGGING_PORT=9333 \
+EXTENSION_PREINSTALLED=true \
+PODMAN_DESKTOP_BINARY="$(pwd)/tests/playwright/tests/PodmanDesktop/podman-desktop" \
+KUBEBUILDER_ASSETS="$KUBEBUILDER_ASSETS" \
+NODE_OPTIONS=--no-experimental-strip-types \
+pnpm test:e2e:integration

--- a/.agents/skills/e2e-container/scripts/start-dbus.sh
+++ b/.agents/skills/e2e-container/scripts/start-dbus.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Start Xvfb, D-Bus system bus, and D-Bus session bus.
+# Required each time the container starts.
+# Exports DISPLAY and DBUS_SESSION_BUS_ADDRESS.
+
+set -euo pipefail
+
+# Xvfb
+if ! [ -e /tmp/.X11-unix/X99 ]; then
+  Xvfb :99 -screen 0 1280x960x24 >/dev/null 2>&1 &
+  sleep 0.5
+  echo "Xvfb started on display :99" >&2
+fi
+export DISPLAY=:99
+
+# D-Bus system bus
+if ! pgrep -f "dbus-daemon --system" >/dev/null 2>&1; then
+  sudo mkdir -p /run/dbus
+  sudo dbus-daemon --system --fork
+  echo "D-Bus system bus started" >&2
+fi
+
+# D-Bus session bus (needed by Electron's renderer process)
+if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+  eval $(dbus-launch --sh-syntax)
+  echo "D-Bus session bus started: $DBUS_SESSION_BUS_ADDRESS" >&2
+fi
+
+echo "export DISPLAY=$DISPLAY"
+echo "export DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"

--- a/.agents/skills/e2e-container/scripts/start-envtest.sh
+++ b/.agents/skills/e2e-container/scripts/start-envtest.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Start the envtest Kubernetes cluster and wait for the kubeconfig.
+
+set -euo pipefail
+
+export KUBEBUILDER_ASSETS=$(setup-envtest use -p path)
+
+envtest-start --users 1 /tmp/envtest-kubeconfig &
+ENVTEST_START_PID=$!
+echo "$ENVTEST_START_PID" > /tmp/envtest-start.pid
+
+echo "Waiting for envtest kubeconfig..."
+while [ ! -f /tmp/envtest-kubeconfig ]; do sleep 1; done
+
+"$KUBEBUILDER_ASSETS/kubectl" --kubeconfig /tmp/envtest-kubeconfig get all | grep "service/kubernetes"
+echo "envtest cluster running (PID: $ENVTEST_START_PID)"
+echo "KUBEBUILDER_ASSETS=$KUBEBUILDER_ASSETS"

--- a/.agents/skills/e2e-container/scripts/start-envtest.sh
+++ b/.agents/skills/e2e-container/scripts/start-envtest.sh
@@ -3,19 +3,45 @@
 
 set -euo pipefail
 
-export KUBEBUILDER_ASSETS=$(setup-envtest use -p path)
+KUBEBUILDER_ASSETS="$(setup-envtest use -p path)"
+export KUBEBUILDER_ASSETS
 
 envtest-start --users 1 /tmp/envtest-kubeconfig &
 ENVTEST_START_PID=$!
 echo "$ENVTEST_START_PID" > /tmp/envtest-start.pid
 
-echo "Waiting for envtest kubeconfig..."
-if ! timeout 60 bash -c 'while [ ! -f /tmp/envtest-kubeconfig ]; do sleep 1; done'; then
-  echo "ERROR: timed out waiting for envtest kubeconfig after 60s"
+cleanup() {
   kill "$ENVTEST_START_PID" 2>/dev/null || true
+  wait "$ENVTEST_START_PID" 2>/dev/null || true
+}
+
+echo "Waiting for envtest kubeconfig..."
+for i in $(seq 1 60); do
+  if ! kill -0 "$ENVTEST_START_PID" 2>/dev/null; then
+    echo "ERROR: envtest-start exited unexpectedly"
+    wait "$ENVTEST_START_PID" 2>/dev/null || true
+    exit 1
+  fi
+  [ -f /tmp/envtest-kubeconfig ] && break
+  sleep 1
+done
+if [ ! -f /tmp/envtest-kubeconfig ]; then
+  echo "ERROR: timed out waiting for envtest kubeconfig after 60s"
+  cleanup
   exit 1
 fi
 
-"$KUBEBUILDER_ASSETS/kubectl" --kubeconfig /tmp/envtest-kubeconfig get all | grep "service/kubernetes"
+echo "Waiting for API server readiness..."
+for i in $(seq 1 15); do
+  if "$KUBEBUILDER_ASSETS/kubectl" --kubeconfig /tmp/envtest-kubeconfig get all 2>/dev/null | grep -q "service/kubernetes"; then
+    break
+  fi
+  sleep 1
+done
+if ! "$KUBEBUILDER_ASSETS/kubectl" --kubeconfig /tmp/envtest-kubeconfig get all 2>/dev/null | grep -q "service/kubernetes"; then
+  echo "ERROR: API server not ready after 15s"
+  cleanup
+  exit 1
+fi
 echo "envtest cluster running (PID: $ENVTEST_START_PID)"
 echo "KUBEBUILDER_ASSETS=$KUBEBUILDER_ASSETS"

--- a/.agents/skills/e2e-container/scripts/start-envtest.sh
+++ b/.agents/skills/e2e-container/scripts/start-envtest.sh
@@ -10,7 +10,11 @@ ENVTEST_START_PID=$!
 echo "$ENVTEST_START_PID" > /tmp/envtest-start.pid
 
 echo "Waiting for envtest kubeconfig..."
-while [ ! -f /tmp/envtest-kubeconfig ]; do sleep 1; done
+if ! timeout 60 bash -c 'while [ ! -f /tmp/envtest-kubeconfig ]; do sleep 1; done'; then
+  echo "ERROR: timed out waiting for envtest kubeconfig after 60s"
+  kill "$ENVTEST_START_PID" 2>/dev/null || true
+  exit 1
+fi
 
 "$KUBEBUILDER_ASSETS/kubectl" --kubeconfig /tmp/envtest-kubeconfig get all | grep "service/kubernetes"
 echo "envtest cluster running (PID: $ENVTEST_START_PID)"

--- a/.agents/skills/e2e-container/scripts/stop-envtest.sh
+++ b/.agents/skills/e2e-container/scripts/stop-envtest.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Stop the envtest cluster.
+
+set -euo pipefail
+
+if [ -f /tmp/envtest-start.pid ]; then
+  kill "$(cat /tmp/envtest-start.pid)" 2>/dev/null || true
+  rm -f /tmp/envtest-start.pid
+  echo "envtest cluster stopped"
+else
+  echo "No envtest PID file found at /tmp/envtest-start.pid"
+fi

--- a/.claude/skills/e2e-container
+++ b/.claude/skills/e2e-container
@@ -1,0 +1,1 @@
+../../.agents/skills/e2e-container


### PR DESCRIPTION
### What does this PR do?

Add a skill for agents to run e2e tests from a container (macOS/arm64 only supported)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to #1162 

### How to test this PR?

<!-- Please explain steps to reproduce -->
