### PR TITLE
fix(agent): guard PostToolUse hooks against empty CLAUDE_FILE_PATH

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm exec prettier --cache --write \"$CLAUDE_FILE_PATH\" 2>/dev/null || true"
+            "command": "[ -n \"$CLAUDE_FILE_PATH\" ] && pnpm exec prettier --cache --write \"$CLAUDE_FILE_PATH\" 2>/dev/null || true"
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm exec eslint --cache --fix \"$CLAUDE_FILE_PATH\" 2>/dev/null || true"
+            "command": "[ -n \"$CLAUDE_FILE_PATH\" ] && pnpm exec eslint --cache --fix \"$CLAUDE_FILE_PATH\" 2>/dev/null || true"
           }
         ]
       }


### PR DESCRIPTION
### What does this PR do?

When $CLAUDE_FILE_PATH is unset, pnpm exec prettier/eslint run on the entire project, reformatting unrelated files and getting a very long time. Add a non-empty guard to skip the hook when the variable is not populated.

Refs https://github.com/anthropics/claude-code/issues/9567

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from the
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
