### PR TITLE
fix(cronjobs): add type guard for V1CronJob required spec field

### DIFF
--- a/packages/webview/src/component/cronjobs/CronJobsList.svelte
+++ b/packages/webview/src/component/cronjobs/CronJobsList.svelte
@@ -11,8 +11,16 @@ import ActionsColumn from '/@/component/cronjobs/columns/Actions.svelte';
 import ScheduleColumn from '/@/component/cronjobs/columns/Schedule.svelte';
 import { CronJobHelper } from './cronjob-helper';
 import type { CronJobUI } from './CronJobUI';
+import type { KubernetesObject, V1CronJob } from '@kubernetes/client-node';
+
 import CronJobIcon from '/@/component/icons/CronJobIcon.svelte';
 import { KubernetesObjectUIHelper } from '/@/component/objects/kubernetes-object-ui-helper';
+import type { KubernetesObjectUI } from '/@/component/objects/KubernetesObjectUI';
+
+// V1CronJob requires spec (unlike most K8s types where spec is optional)
+function isV1CronJob(o: KubernetesObject): o is V1CronJob {
+  return 'spec' in o && o.spec !== undefined;
+}
 
 const dependencyAccessor = getContext<DependencyAccessor>(DependencyAccessor);
 const cronjobHelper = dependencyAccessor.get<CronJobHelper>(CronJobHelper);
@@ -80,7 +88,12 @@ const row = new TableRow<CronJobUI>({ selectable: (_cronjob): boolean => true })
   kinds={[
     {
       resource: 'cronjobs',
-      transformer: cronjobHelper.getCronJobUI.bind(cronjobHelper),
+      transformer: (o: KubernetesObject): KubernetesObjectUI => {
+        if (!isV1CronJob(o)) {
+          throw new Error(`CronJob ${o.metadata?.name} is missing spec`);
+        }
+        return cronjobHelper.getCronJobUI.bind(cronjobHelper)(o);
+      },
     },
   ]}
   singular="CronJob"

--- a/packages/webview/src/component/cronjobs/cronjob-helper.spec.ts
+++ b/packages/webview/src/component/cronjobs/cronjob-helper.spec.ts
@@ -34,6 +34,10 @@ test('expect basic UI conversion', async () => {
       name: 'my-cronjob',
       namespace: 'test-namespace',
     },
+    spec: {
+      schedule: '*/5 * * * *',
+      jobTemplate: {},
+    },
     status: {},
   } as V1CronJob;
   const cronjobUI = cronjobHelper.getCronJobUI(cronjob);

--- a/packages/webview/src/component/cronjobs/cronjob-helper.ts
+++ b/packages/webview/src/component/cronjobs/cronjob-helper.ts
@@ -29,8 +29,8 @@ export class CronJobHelper {
       namespace: cronjob.metadata?.namespace ?? '',
       created: cronjob.metadata?.creationTimestamp,
       selected: false,
-      schedule: cronjob.spec?.schedule ?? '',
-      suspended: cronjob.spec?.suspend ?? false,
+      schedule: cronjob.spec.schedule ?? '',
+      suspended: cronjob.spec.suspend ?? false,
       lastScheduleTime: cronjob.status?.lastScheduleTime,
       // Get the number of "active" jobs, we just get the length of the array
       active: cronjob.status?.active?.length ?? 0,


### PR DESCRIPTION

### What does this PR do?

In @kubernetes/client-node v2, V1CronJob.spec became required (unlike most K8s types). This adds an isV1CronJob type guard to validate spec before passing to getCronJobUI, preserving the helper's precise V1CronJob signature.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

For #1277 

### How to test this PR?

<!-- Please explain steps to reproduce -->
