### PR TITLE
fix: resolve GHSA-r292-9mhp-454m in tar

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   minimatch>brace-expansion: ^2.0.2
   '@microsoft/api-extractor>lodash': ^4.18.0
   test-exclude>glob: ^10.5.0
-  node-gyp>tar: ^7.5.7
+  node-gyp>tar: '>=7.5.21'
   minimatch@<3.1.4: ^3.1.4
   minimatch@>=9.0.0 <9.0.7: ^9.0.7
   minimatch@>=10.0.0 <10.2.3: ^10.2.3
@@ -4104,8 +4104,8 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@7.5.19:
-    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -7721,7 +7721,7 @@ snapshots:
       nopt: 10.0.1
       proc-log: 7.0.0
       semver: 7.8.5
-      tar: 7.5.19
+      tar: 7.5.22
       tinyglobby: 0.2.17
       undici: 8.6.0
       which: 7.0.0
@@ -8422,7 +8422,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.19:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ overrides:
   minimatch>brace-expansion: ^2.0.2
   '@microsoft/api-extractor>lodash': ^4.18.0
   test-exclude>glob: ^10.5.0
-  node-gyp>tar: ^7.5.7
+  node-gyp>tar: '>=7.5.21'
   minimatch@<3.1.4: ^3.1.4
   minimatch@>=9.0.0 <9.0.7: ^9.0.7
   minimatch@>=10.0.0 <10.2.3: ^10.2.3


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability GHSA-r292-9mhp-454m in `tar`.

**Advisory**: node-tar: Uncontrolled recursion in mapHas/filesFilter allows uncatchable stack-overflow DoS via crafted long-path tar with member selection
**Vulnerable versions**: <=7.5.20
**Patched versions**: >=7.5.21
**Advisory URL**: https://github.com/advisories/GHSA-r292-9mhp-454m

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-r292-9mhp-454m: _node-tar: Uncontrolled recursion in mapHas/filesFilter allows uncatchable stack-overflow DoS via crafted long-path tar with member selection_

### How to test this PR?

Run `pnpm audit` and verify GHSA-r292-9mhp-454m is no longer reported