### PR TITLE
fix: resolve GHSA-5p4m-2wfm-xmqj in js-yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,7 @@ overrides:
   shell-quote@<=1.8.4: '>=1.9.0'
   nanoid@<3.3.18: '>=3.3.18'
   fast-uri@>=3.0.0 <4: ^3.1.5
+  js-yaml@>=4.0.0 <5: ^4.3.1
 
 importers:
 
@@ -3018,8 +3019,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   js-yaml@5.3.0:
@@ -4824,7 +4825,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -7245,7 +7246,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,7 @@ overrides:
   shell-quote@<=1.8.4: '>=1.9.0'
   nanoid@<3.3.18: '>=3.3.18'
   fast-uri@>=3.0.0 <4: ^3.1.5
+  js-yaml@>=4.0.0 <5: ^4.3.1
 nodeLinker: hoisted
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-5p4m-2wfm-xmqj in `js-yaml`.

**Advisory**: JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported
**Vulnerable versions**: >=4.0.0 <4.3.1
**Patched versions**: >=4.3.1
**Advisory URL**: https://github.com/advisories/GHSA-5p4m-2wfm-xmqj

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-5p4m-2wfm-xmqj: _JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported_

### How to test this PR?

Run `pnpm audit` and verify GHSA-5p4m-2wfm-xmqj is no longer reported