### PR TITLE
test(e2e): e2e tests for logs

### DIFF
--- a/.agents/skills/playwright-testing/SKILL.md
+++ b/.agents/skills/playwright-testing/SKILL.md
@@ -44,7 +44,7 @@ E2E tests require a local Kubernetes API server via envtest (Kubebuilder):
 3. Set up assets and start:
    ```sh
    export KUBEBUILDER_ASSETS=$(setup-envtest use -p path)
-   envtest-start &
+   envtest-start --fake-kubelet &
    ```
 4. Copy kubeconfig:
    ```sh

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -144,7 +144,7 @@ jobs:
       - name: install envtest-start and setup-envtest binaries
         shell: bash
         run: |
-          go install github.com/feloy/envtest-start@v0.1.0
+          go install github.com/feloy/envtest-start@v0.3.0
           go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
 
       - name: install envtest with latest kubernetes version with setup-envtest
@@ -162,7 +162,7 @@ jobs:
         run: |
           KUBECONFIG='${{ runner.temp }}/envtest-kubeconfig'
           KUBECONFIG_USER1='${{ runner.temp }}/user1-kubeconfig'
-          envtest-start --users 1 "$KUBECONFIG" &
+          envtest-start --fake-kubelet --users 1 "$KUBECONFIG" &
           ENVTEST_START_PID=$!
           echo "ENVTEST_START_PID=$ENVTEST_START_PID" >> $GITHUB_OUTPUT
           echo "KUBECONFIG=$KUBECONFIG" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ export PATH="$PATH:$(go env GOPATH)/bin"
 - Install envtest tools:
 
 ```sh
-go install github.com/feloy/envtest-start@v0.1.0
+go install github.com/feloy/envtest-start@v0.3.0
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
 ```
 
@@ -161,7 +161,7 @@ podman rmi -f localhost/local_image:latest
 ```sh
 export KUBEBUILDER_ASSETS=$(setup-envtest use -p path)
 
-envtest-start --users 1 /tmp/envtest-kubeconfig &
+envtest-start --fake-kubelet --users 1 /tmp/envtest-kubeconfig &
 ENVTEST_START_PID=$!
 
 while [ ! -f /tmp/envtest-kubeconfig ]; do sleep 1; done

--- a/packages/extension/src/pod-logs/pod-logs-service.ts
+++ b/packages/extension/src/pod-logs/pod-logs-service.ts
@@ -18,6 +18,7 @@
 
 import { Log } from '@kubernetes/client-node';
 import { injectable } from 'inversify';
+import type { Readable } from 'node:stream';
 import { PassThrough } from 'node:stream';
 import { RpcExtension } from '@kubernetes-dashboard/rpc';
 import { POD_LOGS, PodLogsOptions } from '@kubernetes-dashboard/channels';
@@ -57,6 +58,20 @@ export class PodLogsService {
         })
         .catch(console.error);
     });
+
+    // Log.log pipes the response body into this stream without ever attaching an error
+    // handler to the source (`Readable.fromWeb(response.body).pipe(stream)`), and pipe()
+    // does not forward source errors to the destination. Aborting the request in
+    // stopStream therefore makes that source emit an 'error' with no listener, which
+    // Node rethrows as an uncaught exception. In Electron's main process that pops the
+    // default modal error dialog and freezes the whole application.
+    // Listening for 'pipe' is the only way to get a reference to the source stream.
+    this.#logStream.on('pipe', (source: Readable) => {
+      source.on('error', (error: unknown) => {
+        console.debug(`log stream of ${namespace}/${podName}/${containerName} ended`, error);
+      });
+    });
+
     this.#abortController = await log.log(namespace, podName, containerName, this.#logStream, {
       follow: options?.follow ?? true,
       previous: options?.previous,

--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -34,6 +34,7 @@ import { KubernetesBar } from './model/pages/navigation';
 import { KubernetesResources } from './model/core/types';
 import { createKubernetesResource } from '/@/utility/kubernetes';
 import { anonymousUserTests } from './anonymous-user';
+import { podLogsTests } from './pod-logs';
 
 const EXTENSION_OCI_IMAGE =
   process.env.EXTENSION_OCI_IMAGE ?? 'ghcr.io/podman-desktop/podman-desktop-extension-kubernetes-dashboard:latest';
@@ -599,6 +600,10 @@ test.describe('Namespace change', { tag: '@integration' }, () => {
     await podsPage.changeNamespace('default');
     await podsPage.fetchKubernetesResource('pod1');
   });
+});
+
+test.describe.serial('Pod logs', { tag: ['@integration'] }, () => {
+  podLogsTests();
 });
 
 test.describe(`Anonymous user`, { tag: ['@integration', '@anonymous'] }, () => {

--- a/tests/playwright/src/pod-logs.ts
+++ b/tests/playwright/src/pod-logs.ts
@@ -1,0 +1,85 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect as playExpect, test } from '@podman-desktop/tests-playwright';
+import { handleWebview } from './utils/webviewHandler';
+import { KubernetesBar } from './model/pages/navigation';
+import { KubernetesResources } from './model/core/types';
+import { patchPodStatus, injectFakeLogs } from '/@/utility/fake-kubelet';
+
+export function podLogsTests(): void {
+  let navigation: KubernetesBar;
+
+  const INITIAL_LOGS = ['Log line 1: Hello from pod1', 'Log line 2: Processing request...'];
+  const STREAMED_LOG = '[INFO] New connection established';
+
+  test('Patch pod1 status and inject initial logs', async () => {
+    await patchPodStatus('pod1');
+    await injectFakeLogs('default', 'pod1', 'pod1', INITIAL_LOGS);
+  });
+
+  test('Open webview and verify dashboard is connected', async ({ runner, page, navigationBar }) => {
+    const [, webview] = await handleWebview(runner, page, navigationBar);
+
+    navigation = new KubernetesBar(webview);
+    await playExpect(navigation.title).toBeVisible();
+
+    const dashboardPage = await navigation.openKubernetesDashboardPage();
+    const status = await dashboardPage.getStatus();
+    playExpect(status).toContain('Connected');
+  });
+
+  test('Navigate to pod1 logs and verify initial log lines', async () => {
+    const podsPage = await navigation.openTabPage(KubernetesResources.Pods);
+    await playExpect(podsPage.heading).toBeVisible();
+
+    const detailsPage = await podsPage.openResourceDetails('pod1', KubernetesResources.Pods);
+    await playExpect(detailsPage.heading).toBeVisible();
+
+    const logsTab = navigation.page.getByRole('link', { name: 'Logs' });
+    await logsTab.click();
+
+    const terminal = navigation.page.getByRole('term');
+    await playExpect(terminal).toBeVisible();
+
+    for (const line of INITIAL_LOGS) {
+      await playExpect(terminal).toContainText(line, { timeout: 10_000 });
+    }
+  });
+
+  test('Verify streamed logs appear in realtime', async () => {
+    const terminal = navigation.page.getByRole('term');
+
+    await injectFakeLogs('default', 'pod1', 'pod1', [STREAMED_LOG]);
+
+    await playExpect(terminal).toContainText(STREAMED_LOG, { timeout: 10_000 });
+  });
+
+  test('Navigate away from logs page', async () => {
+    const summaryTab = navigation.page
+      .getByRole('region', { name: 'Tabs' })
+      .getByRole('link', { name: 'Summary', exact: true });
+    await summaryTab.dispatchEvent('click');
+
+    const backLink = navigation.page
+      .getByRole('region', { name: 'Header' })
+      .getByRole('navigation', { name: 'Breadcrumb' })
+      .getByRole('link', { name: 'Back' });
+    await backLink.dispatchEvent('click');
+  });
+}

--- a/tests/playwright/src/pod-logs.ts
+++ b/tests/playwright/src/pod-logs.ts
@@ -69,17 +69,4 @@ export function podLogsTests(): void {
 
     await playExpect(terminal).toContainText(STREAMED_LOG, { timeout: 10_000 });
   });
-
-  test('Navigate away from logs page', async () => {
-    const summaryTab = navigation.page
-      .getByRole('region', { name: 'Tabs' })
-      .getByRole('link', { name: 'Summary', exact: true });
-    await summaryTab.dispatchEvent('click');
-
-    const backLink = navigation.page
-      .getByRole('region', { name: 'Header' })
-      .getByRole('navigation', { name: 'Breadcrumb' })
-      .getByRole('link', { name: 'Back' });
-    await backLink.dispatchEvent('click');
-  });
 }

--- a/tests/playwright/src/utility/fake-kubelet.ts
+++ b/tests/playwright/src/utility/fake-kubelet.ts
@@ -1,0 +1,83 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { execSync } from 'node:child_process';
+import * as http from 'node:http';
+
+import test from '@playwright/test';
+
+const FAKE_KUBELET_MANAGEMENT_URL = 'http://127.0.0.1:10260';
+
+export async function patchPodStatus(podName: string, namespace: string = 'default'): Promise<void> {
+  return test.step(`Patch pod ${podName} status with running containerStatuses`, async () => {
+    const patch = JSON.stringify({
+      status: {
+        phase: 'Running',
+        containerStatuses: [
+          {
+            name: podName,
+            image: 'httpd',
+            imageID: 'docker.io/library/httpd@sha256:fake',
+            containerID: `cri-o://fake-${podName}`,
+            ready: true,
+            started: true,
+            state: { running: { startedAt: new Date().toISOString() } },
+            restartCount: 0,
+          },
+        ],
+      },
+    });
+
+    try {
+      // eslint-disable-next-line sonarjs/os-command
+      execSync(`kubectl patch pod ${podName} -n ${namespace} --subresource=status --type=merge -p '${patch}'`);
+      console.log(`Pod ${podName} status patched successfully`);
+    } catch (error) {
+      throw new Error(`Failed to patch pod ${podName} status: ${error}`, { cause: error });
+    }
+  });
+}
+
+function postLog(namespace: string, pod: string, container: string, line: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(`${FAKE_KUBELET_MANAGEMENT_URL}/inject/${namespace}/${pod}/${container}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+    });
+    req.on('response', (res: http.IncomingMessage) => {
+      res.resume();
+      res.on('end', resolve);
+    });
+    req.on('error', reject);
+    req.end(line);
+  });
+}
+
+export async function injectFakeLogs(
+  namespace: string,
+  pod: string,
+  container: string,
+  lines: string[],
+): Promise<void> {
+  return test.step(`Inject ${lines.length} fake log lines into ${pod}/${container}`, async () => {
+    for (const line of lines) {
+      await postLog(namespace, pod, container, line);
+    }
+    console.log(`Injected ${lines.length} log lines into ${namespace}/${pod}/${container}`);
+  });
+}

--- a/tests/playwright/src/utility/fake-kubelet.ts
+++ b/tests/playwright/src/utility/fake-kubelet.ts
@@ -16,8 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
 import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import test from '@playwright/test';
 
@@ -43,12 +46,29 @@ export async function patchPodStatus(podName: string, namespace: string = 'defau
       },
     });
 
+    // The patch is passed through a file instead of the command line: cmd.exe does not
+    // treat single quotes as quoting characters, so an inline `-p '{...}'` reaches the
+    // API server with the quotes included and fails to decode on Windows.
+    const patchFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'kd-patch-')), 'patch.json');
+    fs.writeFileSync(patchFile, patch);
     try {
-      // eslint-disable-next-line sonarjs/os-command
-      execSync(`kubectl patch pod ${podName} -n ${namespace} --subresource=status --type=merge -p '${patch}'`);
+      // eslint-disable-next-line sonarjs/os-command, sonarjs/no-os-command-from-path
+      execFileSync('kubectl', [
+        'patch',
+        'pod',
+        podName,
+        '-n',
+        namespace,
+        '--subresource=status',
+        '--type=merge',
+        '--patch-file',
+        patchFile,
+      ]);
       console.log(`Pod ${podName} status patched successfully`);
     } catch (error) {
       throw new Error(`Failed to patch pod ${podName} status: ${error}`, { cause: error });
+    } finally {
+      fs.rmSync(path.dirname(patchFile), { recursive: true, force: true });
     }
   });
 }

--- a/tests/resources/cluster-resources.yaml
+++ b/tests/resources/cluster-resources.yaml
@@ -22,10 +22,8 @@ spec:
     - 10.244.0.0/24
 status:
   addresses:
-    - address: 192.168.1.52
+    - address: 127.0.0.1
       type: InternalIP
-    - address: node1
-      type: Hostname
   allocatable:
     cpu: '4'
     ephemeral-storage: '229909918545'
@@ -418,6 +416,7 @@ metadata:
   namespace: default
   uid: b7a5a6d9-8f6f-4982-ba15-9e295dc043f1
 spec:
+  nodeName: node1
   containers:
     - image: httpd
       imagePullPolicy: Always


### PR DESCRIPTION
### What does this PR do?

- upgrade envtest-start to v0.3.0 with fake kubelet
- enables pod log testing in E2E by using the --fake-kubelet flag, which provides a fake kubelet log server at 127.0.0.1:10250. Updates node1 address to 127.0.0.1 and adds nodeName to pod1 so the API server routes log requests to the fake kubelet.
- add Playwright tests that verify pod log viewing and real-time streaming via the fake kubelet's log injection endpoint.
- add an handler on pipe error, to catch error not handled by kubernetes/client-node library (an issue will be opened there)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

related to #635

### How to test this PR?

<!-- Please explain steps to reproduce -->
