### PR TITLE
fix(ci): drop export from command substitution assignments

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -88,7 +88,7 @@ jobs:
         shell: bash
         run: |
           # Using pnpm list to get the resolved version (E.g. getting 1.15.0 when ^1.15.0)
-          export PD_VERSION=$(pnpm list --filter kubernetes-dashboard --json --depth 0 | jq -r '.[0].devDependencies."@podman-desktop/api".version')
+          PD_VERSION=$(pnpm list --filter kubernetes-dashboard --json --depth 0 | jq -r '.[0].devDependencies."@podman-desktop/api".version')
           echo "PD_VERSION=$PD_VERSION" >> $GITHUB_OUTPUT
           echo "Using @podman-desktop/api $PD_VERSION"
 
@@ -151,7 +151,7 @@ jobs:
         id: setup-envtest
         shell: bash
         run: |
-          export KUBEBUILDER_ASSETS=$(setup-envtest use -p path)
+          KUBEBUILDER_ASSETS=$(setup-envtest use -p path)
           echo "KUBEBUILDER_ASSETS=$KUBEBUILDER_ASSETS" >> $GITHUB_OUTPUT
 
       - name: run envtest-start to start the envtest cluster with 1 user user1


### PR DESCRIPTION
### What does this PR do?

`export VAR=$(cmd)` always exits 0 even when `cmd` fails, masking the error under bash's `-e` flag. Splitting into a plain assignment lets the shell see the non-zero exit code and fail the step immediately instead of continuing with an empty variable.

The root cause of the failure (a file not being removed by setup-envtest) will be investigated / fixed as part of another PR (here or in setup-envtest)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #1271

### How to test this PR?

<!-- Please explain steps to reproduce -->
