### PR TITLE
feat(api): expose resource data to external extensions via the public API.

### DIFF
--- a/packages/api/src/kubernetes-dashboard-extension-api.d.ts
+++ b/packages/api/src/kubernetes-dashboard-extension-api.d.ts
@@ -69,6 +69,48 @@ export interface ResourcesCountInfo {
 }
 
 /**
+ * Options for subscribing to resource updates.
+ */
+export interface ResourceUpdateOptions {
+  /**
+   * The resource name to subscribe to (e.g., 'pods', 'deployments', 'services').
+   */
+  resourceName: string;
+  /**
+   * The context name to subscribe to. If not set, defaults to the current context.
+   */
+  contextName?: string;
+}
+
+/**
+ * A Kubernetes resource object.
+ * Consumer extensions should cast items to specific types from `@kubernetes/client-node`
+ * (e.g., `items as V1Pod[]` for `'pods'` resources).
+ */
+export interface KubernetesObject {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
+ * Resource items for a specific context and resource type.
+ */
+export interface ContextResourceItems {
+  contextName?: string;
+  resourceName: string;
+  items: readonly KubernetesObject[];
+}
+
+/**
+ * The payload for resource update events.
+ */
+export interface ResourceUpdateInfo {
+  resources: ContextResourceItems[];
+}
+
+/**
  * The subscriber for the events emitted by the Kubernetes Dashboard extension.
  */
 export interface KubernetesDashboardSubscriber {
@@ -86,6 +128,17 @@ export interface KubernetesDashboardSubscriber {
    * Subscribes to the events emitted every time the resources count changes.
    */
   onResourcesCount(listener: (event: ResourcesCountInfo) => void): Disposable;
+
+  /**
+   * Subscribes to the events emitted every time the resources of the specified type are updated.
+   *
+   * The listener receives the full list of resources for the specified resource type and context.
+   * An initial event is emitted immediately with the current cached data.
+   *
+   * Consumer extensions should cast the received items to specific types from `@kubernetes/client-node`
+   * (e.g., `items as V1Pod[]` for `'pods'` resources).
+   */
+  onResourceUpdate(options: ResourceUpdateOptions, listener: (event: ResourceUpdateInfo) => void): Disposable;
 
   /**
    * Disposes the subscriber and unsubscribes from all the events emitted by the Kubernetes Dashboard extension.

--- a/packages/extension/src/dashboard-extension.spec.ts
+++ b/packages/extension/src/dashboard-extension.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,4 +137,20 @@ test('activate should return a KubernetesDashboardExtensionApi', async () => {
   expect(ContextsStatesDispatcher.prototype.removeSubscriber).toHaveBeenCalled();
   expect(apiSubscriber).toBeDefined();
   expect((apiSubscriber as ApiSubscriber).dispose).toHaveBeenCalledOnce();
+});
+
+test('subscriber.onResourceUpdate should subscribe to UPDATE_RESOURCE channel', async () => {
+  const api = await dashboardExtension.activate();
+  const subscriber = api.getSubscriber();
+  const apiSubscriber = vi.mocked(ContextsStatesDispatcher.prototype.addSubscriber).mock.lastCall?.[0] as ApiSubscriber;
+
+  const listener = vi.fn();
+  const options = { resourceName: 'pods', contextName: 'my-context' };
+  subscriber.onResourceUpdate(options, listener);
+
+  expect(apiSubscriber.subscribe).toHaveBeenCalledWith(
+    expect.objectContaining({ name: 'UpdateResource' }),
+    options,
+    listener,
+  );
 });

--- a/packages/extension/src/dashboard-extension.ts
+++ b/packages/extension/src/dashboard-extension.ts
@@ -42,7 +42,9 @@ import {
   CONTEXTS_PERMISSIONS,
   IDisposable,
   RESOURCES_COUNT,
+  UPDATE_RESOURCE,
 } from '@kubernetes-dashboard/channels';
+import type { UpdateResourceInfo } from '@kubernetes-dashboard/channels';
 import { SystemApiImpl } from './manager/system-api';
 import { OpenDialogApiImpl } from './manager/open-dialog-api';
 import { PortForwardApiImpl } from './manager/port-forward-api-impl';
@@ -59,6 +61,8 @@ import type {
   KubernetesDashboardExtensionApi,
   KubernetesDashboardSubscriber,
   ResourcesCountInfo,
+  ResourceUpdateInfo,
+  ResourceUpdateOptions,
 } from '@podman-desktop/kubernetes-dashboard-extension-api';
 import { ApiSubscriber } from '/@/subscriber/api-subscriber';
 import { TelemetryApiImpl } from './manager/telemetry-api';
@@ -156,6 +160,12 @@ export class DashboardExtension {
           },
           onResourcesCount: (listener: (event: ResourcesCountInfo) => void): IDisposable => {
             return subscriber.subscribe(RESOURCES_COUNT, undefined, listener);
+          },
+          onResourceUpdate: (
+            options: ResourceUpdateOptions,
+            listener: (event: ResourceUpdateInfo) => void,
+          ): IDisposable => {
+            return subscriber.subscribe(UPDATE_RESOURCE, options, listener as (event: UpdateResourceInfo) => void);
           },
           dispose: () => {
             this.#contextsStatesDispatcher.removeSubscriber(subscriber);

--- a/packages/extension/src/manager/contexts-states-dispatcher.spec.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ import {
 } from '@kubernetes-dashboard/channels';
 import { KubernetesProvidersManager } from '/@/manager/kubernetes-providers.js';
 import { ChannelSubscriber } from '/@/subscriber/channel-subscriber.js';
+import { ApiSubscriber } from '/@/subscriber/api-subscriber.js';
 
 let container: Container;
 const contextsManagerMock: ContextsManager = {
@@ -63,6 +64,8 @@ const contextsManagerMock: ContextsManager = {
   isContextOffline: vi.fn(),
   onCurrentContextChange: vi.fn(),
   onEndpointsChange: vi.fn(),
+  subscribeToResource: vi.fn(),
+  unsubscribeFromResource: vi.fn(),
 } as unknown as ContextsManager;
 const rpcExtension: RpcExtension = {
   fire: vi.fn(),
@@ -242,4 +245,22 @@ test('ContextsStatesDispatcher should dispatch KUBERNETES_PROVIDERS when onKuber
     expect(dispatcherSpy).toHaveBeenCalledTimes(1);
   });
   expect(dispatcherSpy).toHaveBeenCalledWith(KUBERNETES_PROVIDERS);
+});
+
+test('removeSubscriber should clean up resource subscriptions', () => {
+  vi.spyOn(dispatcher, 'dispatchByChannelName').mockResolvedValue();
+  dispatcher.init();
+
+  const apiSubscriber = new ApiSubscriber();
+  Object.defineProperty(contextsManagerMock, 'currentContext', {
+    get: () => ({ getKubeConfig: (): { currentContext: string } => ({ currentContext: 'ctx1' }) }),
+    configurable: true,
+  });
+  dispatcher.addSubscriber(apiSubscriber);
+
+  apiSubscriber.subscribe(UPDATE_RESOURCE, { resourceName: 'pods', contextName: 'ctx1' }, () => {});
+  expect(contextsManagerMock.subscribeToResource).toHaveBeenCalledWith('ctx1', 'pods', expect.any(String));
+
+  dispatcher.removeSubscriber(apiSubscriber);
+  expect(contextsManagerMock.unsubscribeFromResource).toHaveBeenCalledWith('ctx1', 'pods', expect.any(String));
 });

--- a/packages/extension/src/manager/contexts-states-dispatcher.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.ts
@@ -139,6 +139,18 @@ export class ContextsStatesDispatcher {
    * Should be called when a subscriber is disposed.
    */
   removeSubscriber(subscriber: StateSubscriber): void {
+    // Clean up resource subscriptions for this subscriber
+    const tracked = this.#subscriberResourceTracker.get(subscriber);
+    if (tracked) {
+      for (const [key, subscriptionIds] of tracked.entries()) {
+        const [contextName, resourceName] = key.split('/');
+        for (const subscriptionId of subscriptionIds) {
+          this.manager.unsubscribeFromResource(contextName, resourceName, subscriptionId);
+        }
+      }
+      this.#subscriberResourceTracker.delete(subscriber);
+    }
+
     // Clean up timers for this subscriber in all dispatchers
     for (const dispatcher of this.#dispatchers.values()) {
       if (dispatcher instanceof AbsDispatcherObjectImpl) {

--- a/packages/extension/src/subscriber/api-subscriber.spec.ts
+++ b/packages/extension/src/subscriber/api-subscriber.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,17 @@ test('subscribe makes onSubscribe emit an event', async () => {
   subscriber.onSubscribe(listener);
   await subscriber.resetApiSubscribers(channel.name);
   subscriber.subscribe(channel, {}, () => {});
+  expect(listener).toHaveBeenCalledWith(channel.name);
+});
+
+test('disposing a subscription fires onUnsubscribe', () => {
+  const channel = new RpcChannel('channel1');
+  const subscriber = new ApiSubscriber();
+  const listener = vi.fn();
+  subscriber.onUnsubscribe(listener);
+  const disposable = subscriber.subscribe(channel, {}, () => {});
+  expect(listener).not.toHaveBeenCalled();
+  disposable.dispose();
   expect(listener).toHaveBeenCalledWith(channel.name);
 });
 

--- a/packages/extension/src/subscriber/api-subscriber.ts
+++ b/packages/extension/src/subscriber/api-subscriber.ts
@@ -52,6 +52,7 @@ export class ApiSubscriber implements StateSubscriber, IDisposable {
       this.#subscribers[channelName] = (this.#subscribers[channelName] ?? []).filter(
         subscriber => subscriber.listener !== listener,
       );
+      this.#onUnsubscribe.fire(channelName);
     });
   }
 


### PR DESCRIPTION
## Summary

Expose resource data to external extensions via the public API. This enables extensions like [kubernetes-iam](https://github.com/feloy/podman-desktop-extension-kubernetes-iam) to subscribe to resource updates (pods, deployments, roles, etc.) from the dashboard without accessing `@kubernetes/client-node` directly.

- Add `onResourceUpdate(options, listener)` to `KubernetesDashboardSubscriber`, letting external extensions subscribe to any resource type for any context
- Define `KubernetesObject`, `ResourceUpdateInfo`, `ContextResourceItems`, and `ResourceUpdateOptions` types in the public API package (no new dependencies)
- Fix `ApiSubscriber` to fire `onUnsubscribe` on disposal so lazy informers clean up properly
- Fix `ContextsStatesDispatcher.removeSubscriber()` to unsubscribe tracked resources, preventing informer leaks

### Usage

```typescript
const api = extensions.getExtension<KubernetesDashboardExtensionApi>(
  'podman-desktop.kubernetes-dashboard',
)?.exports;

// Connect to a context with specific resources
await api.contexts.connect('my-context', { resources: ['roles', 'pods'] });

// Subscribe to resource updates
const subscriber = api.getSubscriber();
const disposable = subscriber.onResourceUpdate(
  { resourceName: 'roles', contextName: 'my-context' },
  (event) => {
    for (const resource of event.resources) {
      // Cast items to specific types from @kubernetes/client-node
      const roles = resource.items as V1Role[];
    }
  },
);

// Initial data is pushed immediately on subscribe.
// Subsequent updates are pushed whenever the resources change.

// Clean up
disposable.dispose();
subscriber.dispose();
```

## Test plan

- [x] New test: `subscriber.onResourceUpdate` subscribes to `UPDATE_RESOURCE` channel with correct options
- [x] New test: disposing an API subscription fires `onUnsubscribe` event
- [x] New test: `removeSubscriber` calls `unsubscribeFromResource` for tracked resources
- [x] All 291 existing tests pass
- [x] `pnpm typecheck` passes
