### PR TITLE
chore(pnpm): update pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,5 +79,5 @@
   "resolutions": {
     "@testing-library/dom>@babel/runtime": "^7.26.10"
   },
-  "packageManager": "pnpm@11.16.0+sha512.b767e9a98fc87aec0f42daefcd0e84941c2cdb45d73c4e1e68860fb2bdfdbe032ab592105479e5e05c237f740c8a5ffdbbb52385797ddc2296745a1bbb883e8d"
+  "packageManager": "pnpm@11.24.0+sha512.bd27e345e976dcb0be0b7a1228217b049a817e21b1f355c90dbe7dc46671895a8bc1e6d06c24554505ea93ea0b45f489a27ec1bfbc8de6a9659fca0f16fa0000"
 }


### PR DESCRIPTION
chore(pnpm): update pnpm

### What does this PR do?

When building the container, it will "freeze" on the install, which is a known
issue with the version of pnpm we are using:

```sh
[1/2] STEP 1/13: FROM ghcr.io/podman-desktop/podman-desktop-extension-kubernetes-dashboard-builder:next AS builder
Trying to pull ghcr.io/podman-desktop/podman-desktop-extension-kubernetes-dashboard-builder:next...
Getting image source signatures
Copying blob sha256:059e0d16d0a8ffb22f6faceaa2097184cf6d845fcd6a3bed513ab2e015fd5ac1
Copying blob sha256:3543db58c8493d991b1e3a79fd668bfef01952fd9aa6229d683c1b89e4c34a68
Copying blob sha256:667a92748c3651364482cd90fc8e8638708fbf95ee4b34bef653eeb58b5c32a0
Copying blob sha256:265319ce87c96409929cf2fa634d0f03c106564a3bcae07a94d52f9ac868406e
Copying config sha256:62a9267e4457dec09564360495dc65eab8adf4275cfab9efe19f321eb940b7b1
Writing manifest to image destination
[1/2] STEP 2/13: WORKDIR /opt/app-root/extension-source
--> 52883640f4cd
[1/2] STEP 3/13: COPY --chown=1001:root *.ts /opt/app-root/extension-source/
--> cf5a756fdc9c
[1/2] STEP 4/13: COPY --chown=1001:root pnpm-workspace.yaml /opt/app-root/extension-source/
--> 44a0db6a7df3
[1/2] STEP 5/13: COPY --chown=1001:root pnpm-lock.yaml /opt/app-root/extension-source/
--> 81978155a64c
[1/2] STEP 6/13: COPY --chown=1001:root .gitignore /opt/app-root/extension-source/
--> bdd59a9a9127
[1/2] STEP 7/13: COPY --chown=1001:root package.json /opt/app-root/extension-source/
--> 604d06666196
[1/2] STEP 8/13: COPY --chown=1001:root packages /opt/app-root/extension-source/packages
--> 154d31c0c9af
[1/2] STEP 9/13: RUN CI=true pnpm install &&     pnpm build
Scope: all 6 workspace projects
✓ Lockfile passes supply-chain policies (verified 23h ago)
Lockfile is up to date, resolution step is skipped
Progress: resolved 0, reused 0, downloaded 1, added 0
Packages: -122
--------------------------------------------------------------------------------
Progress: resolved 0, reused 0, downloaded 3, added 0, done

Done in 1.9s using pnpm v11.16.0
```

This is because of issue: https://github.com/pnpm/pnpm/issues/12297

This PR updates pnpm to 11.24 which no longer has the issue, you can now
build the container successfully.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Be able to build the container now and not encounter freezing

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
