### PR TITLE
chore(test): bump setup-envtest to release-0.24

### DIFF
--- a/.agents/skills/e2e-container/scripts/install-prerequisites.sh
+++ b/.agents/skills/e2e-container/scripts/install-prerequisites.sh
@@ -19,7 +19,7 @@ fi
 
 # envtest tools
 go install github.com/feloy/envtest-start@v0.1.0
-go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.24
 
 # Xvfb and Electron shared libraries (Fedora / RHEL-based)
 sudo dnf install -y \

--- a/.agents/skills/playwright-testing/SKILL.md
+++ b/.agents/skills/playwright-testing/SKILL.md
@@ -35,7 +35,7 @@ E2E tests require a local Kubernetes API server via envtest (Kubebuilder):
 
 1. Install `setup-envtest`:
    ```sh
-   go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
+   go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.24
    ```
 2. Install `envtest-start`:
    ```sh

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -139,13 +139,13 @@ jobs:
       # Run envtest cluster
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: install envtest-start and setup-envtest binaries
         shell: bash
         run: |
           go install github.com/feloy/envtest-start@v0.3.0
-          go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
+          go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.24
 
       - name: install envtest with latest kubernetes version with setup-envtest
         id: setup-envtest

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ export PATH="$PATH:$(go env GOPATH)/bin"
 
 ```sh
 go install github.com/feloy/envtest-start@v0.3.0
-go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.24
 ```
 
 #### Run the tests


### PR DESCRIPTION
### What does this PR do?

Use latest version of setup-envtest

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

may fix #1271

Error is now:

```
2026-09-02T08:12:10.066Z	ERROR	fetch	env/env.go:318	unable to remove downloaded archive	{"path": "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\495031607-envtest-v1.37.0-windows-amd64.tar.gz", "error": "remove C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\495031607-envtest-v1.37.0-windows-amd64.tar.gz: The process cannot access the file because it is being used by another process."}
sigs.k8s.io/controller-runtime/tools/setup-envtest/env.(*Env).Fetch
	C:/Users/runneradmin/go/pkg/mod/sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.24.2-0.20260713111223-0f529e22d5c0/env/env.go:318
sigs.k8s.io/controller-runtime/tools/setup-envtest/workflows.Use.Do
	C:/Users/runneradmin/go/pkg/mod/sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.24.2-0.20260713111223-0f529e22d5c0/workflows/workflows.go:44
main.main
	C:/Users/runneradmin/go/pkg/mod/sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.24.2-0.20260713111223-0f529e22d5c0/main.go:269
runtime.main
	C:/hostedtoolcache/windows/go/1.26.7/x64/src/runtime/proc.go:290
```

which is not blocking the tests anymore, as the envtest is correctly installed, and the error happens during the cleanup of the archive used to install it

### How to test this PR?

<!-- Please explain steps to reproduce -->
