### PR TITLE
fix: resolve GHSA-5jgf-p345-68v8 in fast-uri

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ overrides:
   undici@>=6.0.0 <7: ~6.27.0
   shell-quote@<=1.8.4: '>=1.9.0'
   nanoid@<3.3.18: '>=3.3.18'
-  fast-uri@>=3.0.0 <4: ^3.1.5
+  fast-uri@>=3.0.0 <4: ^3.1.6
   js-yaml@>=4.0.0 <5: ^4.3.1
   browserslist@<=4.28.6: '>=4.28.7'
 
@@ -2646,8 +2646,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -6024,7 +6024,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
     optional: true
@@ -6930,7 +6930,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.5:
+  fast-uri@3.1.7:
     optional: true
 
   fastq@1.19.1:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,7 +26,7 @@ overrides:
   undici@>=6.0.0 <7: ~6.27.0
   shell-quote@<=1.8.4: '>=1.9.0'
   nanoid@<3.3.18: '>=3.3.18'
-  fast-uri@>=3.0.0 <4: ^3.1.5
+  fast-uri@>=3.0.0 <4: ^3.1.6
   js-yaml@>=4.0.0 <5: ^4.3.1
   browserslist@<=4.28.6: '>=4.28.7'
 nodeLinker: hoisted


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-5jgf-p345-68v8 in `fast-uri`.

**Advisory**: fast-uri vulnerable to host confusion via skipped IDN canonicalization on scheme-relative references
**Vulnerable versions**: >=3.1.3 <3.1.6
**Patched versions**: >=3.1.6
**Advisory URL**: https://github.com/advisories/GHSA-5jgf-p345-68v8

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-5jgf-p345-68v8: _fast-uri vulnerable to host confusion via skipped IDN canonicalization on scheme-relative references_

### How to test this PR?

Run `pnpm audit` and verify GHSA-5jgf-p345-68v8 is no longer reported