### PR TITLE
fix: e2e failure on error 429 too many requests

### DIFF
--- a/packages/extension/src/types/resource-informer.spec.ts
+++ b/packages/extension/src/types/resource-informer.spec.ts
@@ -495,7 +495,9 @@ test('ResourceInformer should increase the delay between retries and go offline 
   expect(onOfflineCB).not.toHaveBeenCalled();
 
   // the retries are exhausted, the informer goes offline
+  const consoleErrorSpy = vi.spyOn(console, 'error').mockReturnValue(undefined);
   fireError(error);
+  expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('after 5 retries, going offline'));
   expect(onOfflineCB).toHaveBeenCalledWith({
     kubeconfig,
     resourceName: 'myresources',
@@ -505,6 +507,7 @@ test('ResourceInformer should increase the delay between retries and go offline 
   expect(informer.isOffline()).toBeTruthy();
   vi.advanceTimersByTime(60_000);
   expect(startMock).not.toHaveBeenCalled();
+  consoleErrorSpy.mockRestore();
 });
 
 test('ResourceInformer should not restart the informer after a 429 if it has been disposed', () => {

--- a/packages/extension/src/types/resource-informer.spec.ts
+++ b/packages/extension/src/types/resource-informer.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024, 2025 Red Hat, Inc.
+ * Copyright (C) 2024 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,21 @@
 
 import type { Cluster, Context, ListWatch, User, V1ObjectMeta } from '@kubernetes/client-node';
 import { ApiException, DELETE, ERROR, KubeConfig, UPDATE } from '@kubernetes/client-node';
-import { expect, test, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { afterEach, expect, test, vi } from 'vitest';
 
 import { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 import { ResourceInformer } from './resource-informer.js';
+
+// the jitter added to the retry delays would make the tests non-deterministic
+vi.mock(import('node:crypto'), async importOriginal => ({
+  ...(await importOriginal()),
+  randomInt: vi.fn().mockReturnValue(0),
+}));
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 interface MyResource {
   apiVersion?: string;
@@ -356,4 +367,175 @@ test('ResourceInformer should fire onObjectDeleted event when a resource is dele
       namespace: 'ns1',
     });
   });
+});
+
+interface InformerMock {
+  informer: ResourceInformer<MyResource>;
+  kubeconfig: KubeConfigSingleContext;
+  startMock: Mock;
+  stopMock: Mock;
+  fireError: (error: unknown) => void;
+}
+
+// creates a ResourceInformer with a mocked internal informer,
+// giving access to the ERROR callback registered by the ResourceInformer
+function createInformerWithMock(): InformerMock {
+  const kc = new KubeConfig();
+  kc.loadFromOptions(kcWith2contexts);
+  const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
+  const informer = new ResourceInformer<MyResource>({
+    kubeconfig,
+    path: '/a/path',
+    listFn: vi.fn(),
+    kind: 'MyResource',
+    plural: 'myresources',
+  });
+  const callbacks = new Map<string, (arg: unknown) => void>();
+  const startMock = vi.fn().mockResolvedValue(undefined);
+  const stopMock = vi.fn().mockResolvedValue(undefined);
+  vi.spyOn(informer, 'makeInformer').mockReturnValue({
+    on: vi.fn().mockImplementation((event: string, cb: (arg: unknown) => void) => {
+      callbacks.set(event, cb);
+    }),
+    start: startMock,
+    stop: stopMock,
+  } as unknown as ListWatch<MyResource>);
+  return {
+    informer,
+    kubeconfig,
+    startMock,
+    stopMock,
+    fireError: (error: unknown): void => callbacks.get(ERROR)?.(error),
+  };
+}
+
+test('ResourceInformer should not go offline but restart the informer when the list request returns 429', () => {
+  vi.useFakeTimers();
+  const { informer, startMock, fireError } = createInformerWithMock();
+  const onOfflineCB = vi.fn();
+  informer.onOffline(onOfflineCB);
+  informer.start();
+  expect(startMock).toHaveBeenCalledOnce();
+  startMock.mockClear();
+
+  fireError(new ApiException(429, 'Too Many Requests', {}, {}));
+  expect(onOfflineCB).not.toHaveBeenCalled();
+  expect(informer.isOffline()).toBeFalsy();
+
+  // first retry happens after the base delay
+  vi.advanceTimersByTime(999);
+  expect(startMock).not.toHaveBeenCalled();
+  vi.advanceTimersByTime(1);
+  expect(startMock).toHaveBeenCalledOnce();
+});
+
+test('ResourceInformer should restart the informer when the watch request returns 429', () => {
+  vi.useFakeTimers();
+  const { informer, startMock, fireError } = createInformerWithMock();
+  const onOfflineCB = vi.fn();
+  informer.onOffline(onOfflineCB);
+  informer.start();
+  startMock.mockClear();
+
+  // the watch request does not report the error as an ApiException,
+  // but as an Error carrying a statusCode
+  fireError(Object.assign(new Error('Too Many Requests'), { statusCode: 429 }));
+  expect(onOfflineCB).not.toHaveBeenCalled();
+
+  vi.advanceTimersByTime(1000);
+  expect(startMock).toHaveBeenCalledOnce();
+});
+
+test('ResourceInformer should honour the Retry-After header', () => {
+  vi.useFakeTimers();
+  const { informer, startMock, fireError } = createInformerWithMock();
+  informer.start();
+  startMock.mockClear();
+
+  fireError(new ApiException(429, 'Too Many Requests', {}, { 'Retry-After': '7' }));
+
+  vi.advanceTimersByTime(6_999);
+  expect(startMock).not.toHaveBeenCalled();
+  vi.advanceTimersByTime(1);
+  expect(startMock).toHaveBeenCalledOnce();
+});
+
+test('ResourceInformer should honour retryAfterSeconds in the body when there is no Retry-After header', () => {
+  vi.useFakeTimers();
+  const { informer, startMock, fireError } = createInformerWithMock();
+  informer.start();
+  startMock.mockClear();
+
+  fireError(new ApiException(429, 'Too Many Requests', JSON.stringify({ details: { retryAfterSeconds: 4 } }), {}));
+
+  vi.advanceTimersByTime(3_999);
+  expect(startMock).not.toHaveBeenCalled();
+  vi.advanceTimersByTime(1);
+  expect(startMock).toHaveBeenCalledOnce();
+});
+
+test('ResourceInformer should increase the delay between retries and go offline after too many 429', () => {
+  vi.useFakeTimers();
+  const { informer, kubeconfig, startMock, fireError } = createInformerWithMock();
+  const onOfflineCB = vi.fn();
+  informer.onOffline(onOfflineCB);
+  informer.start();
+  startMock.mockClear();
+
+  const error = new ApiException(429, 'Too Many Requests', {}, {});
+  // the delay doubles at each retry
+  for (const expectedDelay of [1_000, 2_000, 4_000, 8_000, 16_000]) {
+    fireError(error);
+    vi.advanceTimersByTime(expectedDelay - 1);
+    expect(startMock).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(startMock).toHaveBeenCalledOnce();
+    startMock.mockClear();
+  }
+  expect(onOfflineCB).not.toHaveBeenCalled();
+
+  // the retries are exhausted, the informer goes offline
+  fireError(error);
+  expect(onOfflineCB).toHaveBeenCalledWith({
+    kubeconfig,
+    resourceName: 'myresources',
+    offline: true,
+    reason: String(error),
+  });
+  expect(informer.isOffline()).toBeTruthy();
+  vi.advanceTimersByTime(60_000);
+  expect(startMock).not.toHaveBeenCalled();
+});
+
+test('ResourceInformer should not restart the informer after a 429 if it has been disposed', () => {
+  vi.useFakeTimers();
+  const { informer, startMock, stopMock, fireError } = createInformerWithMock();
+  informer.start();
+  startMock.mockClear();
+
+  fireError(new ApiException(429, 'Too Many Requests', {}, {}));
+  informer.dispose();
+  expect(stopMock).toHaveBeenCalled();
+
+  vi.advanceTimersByTime(60_000);
+  expect(startMock).not.toHaveBeenCalled();
+});
+
+test('ResourceInformer should cancel a pending retry when reconnecting', () => {
+  vi.useFakeTimers();
+  const { informer, startMock, fireError } = createInformerWithMock();
+  informer.start();
+  startMock.mockClear();
+
+  // the informer is offline, and a retry is pending after a 429
+  fireError(new ApiException(500, 'an error', {}, {}));
+  fireError(new ApiException(429, 'Too Many Requests', {}, {}));
+
+  informer.reconnect();
+  expect(startMock).toHaveBeenCalledOnce();
+  startMock.mockClear();
+
+  // the pending retry has been cancelled, the informer is not started twice
+  vi.advanceTimersByTime(60_000);
+  expect(startMock).not.toHaveBeenCalled();
 });

--- a/packages/extension/src/types/resource-informer.spec.ts
+++ b/packages/extension/src/types/resource-informer.spec.ts
@@ -521,6 +521,23 @@ test('ResourceInformer should not restart the informer after a 429 if it has bee
   expect(startMock).not.toHaveBeenCalled();
 });
 
+test('ResourceInformer should not schedule a retry for a 429 received after being disposed', () => {
+  vi.useFakeTimers();
+  const { informer, startMock, fireError } = createInformerWithMock();
+  const onOfflineCB = vi.fn();
+  informer.onOffline(onOfflineCB);
+  informer.start();
+  startMock.mockClear();
+
+  informer.dispose();
+  // the request in flight when the informer was disposed returns after the disposal
+  fireError(new ApiException(429, 'Too Many Requests', {}, {}));
+
+  vi.advanceTimersByTime(60_000);
+  expect(startMock).not.toHaveBeenCalled();
+  expect(onOfflineCB).not.toHaveBeenCalled();
+});
+
 test('ResourceInformer should cancel a pending retry when reconnecting', () => {
   vi.useFakeTimers();
   const { informer, startMock, fireError } = createInformerWithMock();

--- a/packages/extension/src/types/resource-informer.ts
+++ b/packages/extension/src/types/resource-informer.ts
@@ -168,9 +168,14 @@ export class ResourceInformer<T extends KubernetesObject> implements Disposable 
       }
       // the server asks us to slow down: retry instead of declaring the informer offline,
       // as going offline drops the caches of every resource of the context
-      if (statusCode === 429 && this.#getRetryCount() < MAX_RETRIES_ON_THROTTLING) {
-        this.#scheduleRetry(error);
-        return;
+      if (statusCode === 429) {
+        if (this.#getRetryCount() < MAX_RETRIES_ON_THROTTLING) {
+          this.#scheduleRetry(error);
+          return;
+        }
+        console.error(
+          `[informer] ${this.#pluralName} on context ${this.#kubeConfig.getKubeConfig().currentContext} is still receiving 429 (Too Many Requests) after ${MAX_RETRIES_ON_THROTTLING} retries, going offline`,
+        );
       }
       this.#offline = true;
       this.#onOffline.fire({

--- a/packages/extension/src/types/resource-informer.ts
+++ b/packages/extension/src/types/resource-informer.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024, 2025 Red Hat, Inc.
+ * Copyright (C) 2024 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+
+import { randomInt } from 'node:crypto';
 
 import type {
   Informer,
@@ -62,6 +64,16 @@ export interface ResourceInformerOptions<T extends KubernetesObject> {
   plural: string;
 }
 
+// how many consecutive 429 responses we retry before declaring the informer offline
+const MAX_RETRIES_ON_THROTTLING = 5;
+// delay of the first retry after a 429, when the server does not tell us how long to wait
+const BASE_RETRY_DELAY_MS = 1_000;
+// upper bound of the retry delay, including the delay asked by the server
+const MAX_RETRY_DELAY_MS = 60_000;
+// after this delay without any 429, the next one is considered a new incident
+// and the backoff starts again from the beginning
+const RETRY_COUNT_RESET_MS = 5 * 60_000;
+
 export class ResourceInformer<T extends KubernetesObject> implements Disposable {
   #kubeConfig: KubeConfigSingleContext;
   #path: string;
@@ -70,6 +82,12 @@ export class ResourceInformer<T extends KubernetesObject> implements Disposable 
   #kindName: string;
   #informer: Informer<T> | undefined;
   #offline: boolean = false;
+  // timer of a pending retry after the server asked us to slow down (HTTP 429)
+  #retryTimer: NodeJS.Timeout | undefined;
+  // number of retries after a 429 during the current incident
+  #retryCount: number = 0;
+  // date of the last retry after a 429, used to detect the end of an incident
+  #lastRetryTime: number = 0;
 
   #onCacheUpdated = new Emitter<CacheUpdatedEvent>();
   onCacheUpdated: Event<CacheUpdatedEvent> = this.#onCacheUpdated.event;
@@ -136,9 +154,16 @@ export class ResourceInformer<T extends KubernetesObject> implements Disposable 
     });
     // This is issued when there is an error
     this.#informer.on(ERROR, (error: unknown) => {
-      if (error instanceof ApiException && error.code === 404) {
+      const statusCode = getStatusCode(error);
+      if (statusCode === 404) {
         // starting from kubernetes-client v1.1, informer is correctly started even if resource does not exist in API
         // and the 404 error is received here
+        return;
+      }
+      // the server asks us to slow down: retry instead of declaring the informer offline,
+      // as going offline drops the caches of every resource of the context
+      if (statusCode === 429 && this.#getRetryCount() < MAX_RETRIES_ON_THROTTLING) {
+        this.#scheduleRetry(error);
         return;
       }
       this.#offline = true;
@@ -149,11 +174,9 @@ export class ResourceInformer<T extends KubernetesObject> implements Disposable 
         reason: String(error),
       });
     });
-    this.#informer.start().catch((err: unknown) => {
-      console.error(
-        `error starting the informer for resource ${this.#pluralName} on context ${this.#kubeConfig.getKubeConfig().currentContext}: ${String(err)}`,
-      );
-    });
+    this.#cancelRetry();
+    this.#retryCount = 0;
+    this.#startInformer();
     return internalInformer;
   }
 
@@ -167,15 +190,14 @@ export class ResourceInformer<T extends KubernetesObject> implements Disposable 
         resourceName: this.#pluralName,
         offline: false,
       });
-      this.#informer.start().catch((err: unknown) => {
-        console.error(
-          `error starting the informer for resource ${this.#pluralName} on context ${this.#kubeConfig.getKubeConfig().currentContext}: ${String(err)}`,
-        );
-      });
+      this.#cancelRetry();
+      this.#retryCount = 0;
+      this.#startInformer();
     }
   }
 
   dispose(): void {
+    this.#cancelRetry();
     this.#onCacheUpdated.dispose();
     this.#onOffline.dispose();
     this.#informer?.stop().catch((err: unknown) => {
@@ -189,7 +211,93 @@ export class ResourceInformer<T extends KubernetesObject> implements Disposable 
     return this.#offline;
   }
 
+  #startInformer(): void {
+    this.#informer?.start().catch((err: unknown) => {
+      console.error(
+        `error starting the informer for resource ${this.#pluralName} on context ${this.#kubeConfig.getKubeConfig().currentContext}: ${String(err)}`,
+      );
+    });
+  }
+
+  // the informer has no event telling us the watch is established (CONNECT is fired before
+  // the list request), so instead of resetting the counter when connected, we consider that
+  // a 429 received long enough after the previous one starts a new incident
+  #getRetryCount(): number {
+    return Date.now() - this.#lastRetryTime > RETRY_COUNT_RESET_MS ? 0 : this.#retryCount;
+  }
+
+  // schedules a restart of the informer after the server answered 429 (Too Many Requests)
+  #scheduleRetry(error: unknown): void {
+    this.#cancelRetry();
+    this.#retryCount = this.#getRetryCount() + 1;
+    this.#lastRetryTime = Date.now();
+    const delay = getRetryDelayMs(error, this.#retryCount);
+    console.warn(
+      `[informer] ${this.#pluralName} on context ${this.#kubeConfig.getKubeConfig().currentContext} received 429 (Too Many Requests), retrying in ${Math.round(delay / 100) / 10}s (attempt ${this.#retryCount}/${MAX_RETRIES_ON_THROTTLING})`,
+    );
+    this.#retryTimer = setTimeout(() => {
+      this.#retryTimer = undefined;
+      this.#startInformer();
+    }, delay);
+    // a pending retry must not keep the process alive
+    this.#retryTimer.unref?.();
+  }
+
+  #cancelRetry(): void {
+    if (this.#retryTimer) {
+      clearTimeout(this.#retryTimer);
+      this.#retryTimer = undefined;
+    }
+  }
+
   makeInformer(kubeConfig: KubeConfig, path: string, listFn: ListPromise<T>): Informer<T> & ObjectCache<T> {
     return makeInformer(kubeConfig, path, listFn);
   }
+}
+
+// the error received on the ERROR event is an ApiException when it comes from the list request,
+// and a plain Error carrying a statusCode when it comes from the watch request
+function getStatusCode(error: unknown): number | undefined {
+  if (error instanceof ApiException) {
+    return error.code;
+  }
+  const statusCode: unknown = (error as { statusCode?: unknown })?.statusCode;
+  return typeof statusCode === 'number' ? statusCode : undefined;
+}
+
+// returns how long to wait before retrying, honouring the delay asked by the server
+// (Retry-After header or Status.details.retryAfterSeconds), falling back to an exponential
+// backoff, and adding a jitter so that all the informers of a context do not retry at the same time
+function getRetryDelayMs(error: unknown, retryCount: number): number {
+  const serverDelayMs = getServerRetryAfterMs(error);
+  const backoffMs = BASE_RETRY_DELAY_MS * 2 ** (retryCount - 1);
+  const delayMs = Math.min(Math.max(serverDelayMs ?? 0, backoffMs), MAX_RETRY_DELAY_MS);
+  // up to 20% of jitter
+  return delayMs + randomInt(Math.floor(delayMs / 5) + 1);
+}
+
+function getServerRetryAfterMs(error: unknown): number | undefined {
+  if (!(error instanceof ApiException)) {
+    return undefined;
+  }
+  const header = Object.entries(error.headers ?? {}).find(([name]) => name.toLowerCase() === 'retry-after')?.[1];
+  const headerSeconds = header ? Number(header) : Number.NaN;
+  if (Number.isFinite(headerSeconds) && headerSeconds > 0) {
+    return headerSeconds * 1_000;
+  }
+  const bodySeconds = getRetryAfterSecondsFromBody(error.body);
+  return bodySeconds === undefined ? undefined : bodySeconds * 1_000;
+}
+
+function getRetryAfterSecondsFromBody(body: unknown): number | undefined {
+  let status: unknown = body;
+  if (typeof status === 'string') {
+    try {
+      status = JSON.parse(status);
+    } catch {
+      return undefined;
+    }
+  }
+  const seconds: unknown = (status as { details?: { retryAfterSeconds?: unknown } })?.details?.retryAfterSeconds;
+  return typeof seconds === 'number' && seconds > 0 ? seconds : undefined;
 }

--- a/packages/extension/src/types/resource-informer.ts
+++ b/packages/extension/src/types/resource-informer.ts
@@ -88,6 +88,7 @@ export class ResourceInformer<T extends KubernetesObject> implements Disposable 
   #retryCount: number = 0;
   // date of the last retry after a 429, used to detect the end of an incident
   #lastRetryTime: number = 0;
+  #disposed: boolean = false;
 
   #onCacheUpdated = new Emitter<CacheUpdatedEvent>();
   onCacheUpdated: Event<CacheUpdatedEvent> = this.#onCacheUpdated.event;
@@ -154,6 +155,11 @@ export class ResourceInformer<T extends KubernetesObject> implements Disposable 
     });
     // This is issued when there is an error
     this.#informer.on(ERROR, (error: unknown) => {
+      // an error can still be received after the informer has been stopped,
+      // for instance the error caused by the abortion of the watch request
+      if (this.#disposed) {
+        return;
+      }
       const statusCode = getStatusCode(error);
       if (statusCode === 404) {
         // starting from kubernetes-client v1.1, informer is correctly started even if resource does not exist in API
@@ -197,6 +203,7 @@ export class ResourceInformer<T extends KubernetesObject> implements Disposable 
   }
 
   dispose(): void {
+    this.#disposed = true;
     this.#cancelRetry();
     this.#onCacheUpdated.dispose();
     this.#onOffline.dispose();


### PR DESCRIPTION
### What does this PR do?

It happens regularly that e2e test fail when starting the gateway classes informer, with a 429 error (Too many requests).

This PR adds the handle of this error, which will restart the informer with the given delay (with jitter)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from the
repository (or from another issue tracker). -->

### How to test this PR?

In https://github.com/podman-desktop/extension-kubernetes-dashboard/actions/runs/33843929991/job/100934684646?pr=1322, the dashboard receives a 429 error and handles it:

```
main ↪️ [kubernetes-dashboard] [informer] starting lazy informer on demand: gatewayclasses on envtest (1 subscribers)
STDERR: [kubernetes-dashboard] [informer] gatewayclasses on context envtest received 429 (Too Many Requests), retrying in 1.1s (attempt 1/5)
main ↪️ [kubernetes-dashboard] [informer] gatewayclasses on context envtest received 429 (Too Many Requests), retrying in 1.1s (attempt 1/5)
  ✓  18 [chromium] › src/extension.spec.ts:229:3 › Extension usage › go to gateway classes page @integration (1.1s)
main ↪️ [kubernetes-dashboard] [informer] no subscribers left for gatewayclasses on envtest, scheduling grace period (30000ms)
```

Previously (ie https://github.com/podman-desktop/extension-kubernetes-dashboard/actions/runs/33763382864/job/100700784478?pr=1210), the dashboard was not able to recover after the error:

```
main ↪️ [kubernetes-dashboard] [informer] starting lazy informer on demand: gatewayclasses on envtest (1 subscribers)
Starting Podman Desktop close sequence
Closing Podman Desktop with a timeout of 30000 ms, PID: 6079
STDERR: Debugger ending on ws://127.0.0.1:49425/3e593100-e13c-45cd-a064-0da234a98061
For help, see: https://nodejs.org/learn/getting-started/debugging

Saving a video file took: 11.502709000000323 ms
Video file saved as: tests/playwright/output/videos/kubernetes-dashboard-e2e_w0.webm
Removing raw traces folder: tests/playwright/output/traces/raw
Test finished with status:failed
  ✘  18 [chromium] › src/extension.spec.ts:229:3 › Extension usage › go to gateway classes page @integration (14.4s)
```

