### PR TITLE
fix: do not report an error on successful resource deletion

### DIFF
--- a/packages/extension/src/manager/contexts-manager.spec.ts
+++ b/packages/extension/src/manager/contexts-manager.spec.ts
@@ -1372,7 +1372,50 @@ test('deleteObject handler returns KubernetesObject', async () => {
   expect(manager.handleStatus).not.toHaveBeenCalled();
 });
 
-test('deleteObject handler returns Status', async () => {
+test('deleteObject handler returns a failure Status', async () => {
+  const kc = new KubeConfig();
+  kc.loadFromOptions(kcWithContext1asDefault);
+  const manager = new TestContextsManager();
+  vi.spyOn(manager, 'startMonitoring').mockImplementation(async (): Promise<void> => {});
+  vi.spyOn(manager, 'stopMonitoring').mockImplementation((): void => {});
+  vi.spyOn(manager, 'handleStatus');
+  await manager.update(kc);
+  vi.mocked(window.showInformationMessage).mockImplementation(async (): Promise<string> => 'Yes');
+  const status = {
+    kind: 'Status',
+    status: 'Failure',
+    message: 'an error message',
+  };
+  resource4DeleteObjectMock.mockReturnValue(status);
+  await manager.deleteObject('Resource4', 'resource-name', 'other-ns');
+  expect(window.showInformationMessage).toHaveBeenCalled();
+  expect(resource4DeleteObjectMock).toHaveBeenCalledWith(expect.anything(), 'resource-name', 'other-ns');
+  expect(manager.handleStatus).toHaveBeenCalledWith(status, 'deletion of Resource4 resource-name');
+});
+
+// Some kinds (Ingress, ConfigMap, etc.) return a successful Status instead of the deleted object
+test('deleteObject handler returns a successful Status', async () => {
+  const kc = new KubeConfig();
+  kc.loadFromOptions(kcWithContext1asDefault);
+  const manager = new TestContextsManager();
+  vi.spyOn(manager, 'startMonitoring').mockImplementation(async (): Promise<void> => {});
+  vi.spyOn(manager, 'stopMonitoring').mockImplementation((): void => {});
+  vi.spyOn(manager, 'handleStatus');
+  await manager.update(kc);
+  vi.mocked(window.showInformationMessage).mockImplementation(async (): Promise<string> => 'Yes');
+  resource4DeleteObjectMock.mockReturnValue({
+    kind: 'Status',
+    status: 'Success',
+    details: { name: 'resource-name' },
+  });
+  await manager.deleteObject('Resource4', 'resource-name', 'other-ns');
+  expect(window.showInformationMessage).toHaveBeenCalled();
+  expect(resource4DeleteObjectMock).toHaveBeenCalledWith(expect.anything(), 'resource-name', 'other-ns');
+  expect(manager.handleStatus).not.toHaveBeenCalled();
+  expect(window.showNotification).not.toHaveBeenCalled();
+});
+
+test('deleteObject handler returns a Status without status field', async () => {
   const kc = new KubeConfig();
   kc.loadFromOptions(kcWithContext1asDefault);
   const manager = new TestContextsManager();
@@ -1386,8 +1429,6 @@ test('deleteObject handler returns Status', async () => {
   };
   resource4DeleteObjectMock.mockReturnValue(status);
   await manager.deleteObject('Resource4', 'resource-name', 'other-ns');
-  expect(window.showInformationMessage).toHaveBeenCalled();
-  expect(resource4DeleteObjectMock).toHaveBeenCalledWith(expect.anything(), 'resource-name', 'other-ns');
   expect(manager.handleStatus).toHaveBeenCalledWith(status, 'deletion of Resource4 resource-name');
 });
 

--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -758,10 +758,10 @@ export class ContextsManager implements ContextsApi {
   }
 
   private handleResult(result: KubernetesObject | V1Status, actionMsg: string): void {
-    if (this.isV1Status(result)) {
+    if (this.isV1Status(result) && this.isFailureStatus(result)) {
       this.handleStatus(result, actionMsg);
     }
-    // Ignore if result is a KubernetesObject
+    // Ignore if result is a KubernetesObject or a successful Status
   }
 
   private handleApiException(error: unknown, actionMsg: string): void {
@@ -791,6 +791,13 @@ export class ContextsManager implements ContextsApi {
 
   private isConflict(error: unknown): boolean {
     return error instanceof ApiException && error.code === 409;
+  }
+
+  // The API returns a Status object as the result of a successful operation for some kinds
+  // (Ingress, ConfigMap, Deployment, etc.), while others return the object itself.
+  // Only a Status not explicitly marked as successful is an error.
+  private isFailureStatus(status: V1Status): boolean {
+    return status.status !== 'Success';
   }
 
   private isV1Status(status: unknown): status is V1Status {


### PR DESCRIPTION
### What does this PR do?

The Kubernetes API returns different bodies for a DELETE request depending on the kind: the deleted object for some kinds (Pod, Service), and a Status object for others (Ingress, ConfigMap, Secret, Deployment). In the latter case a successful deletion returns `{kind: Status, status: Success}`, which handleResult was reporting as an error notification.

Only report a Status that is not explicitly marked as successful.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #1294

### How to test this PR?

Delete an ingress, configmap, secret, etc and verify that no error is notified