### PR TITLE
fix: patch custom resources with server-side apply

### DIFF
--- a/.agents/skills/add-resource/SKILL.md
+++ b/.agents/skills/add-resource/SKILL.md
@@ -151,6 +151,36 @@ crashing.
 
 ---
 
+##### `setIsCustomResource()`
+
+**Purpose**: declares that the kind is provided by a CustomResourceDefinition.
+The Kubernetes API server does not serve strategic merge patch for those kinds —
+it accepts only `application/json-patch+json`, `application/merge-patch+json` and
+`application/apply-patch+yaml` — so `ContextsManager.applyResources()` patches
+them with a server-side apply (`PatchStrategy.ServerSideApply`, with `force` set
+so the `kubernetes-dashboard` field manager takes ownership) instead of the
+strategic merge patch used for the other kinds. Without this declaration, the
+"Patch resource" button of the YAML tab fails with `the body of the request was
+in an unknown format`.
+
+**When to define it**: whenever the kind comes from a CRD installed in the
+cluster, such as the Gateway API resources (`gateway.networking.k8s.io`).
+
+**When to omit it**: for every kind served natively by the API server. Using
+`CustomObjectsApi` in the informer is *not* the criterion: OpenShift Routes
+(`route.openshift.io`) are read with `CustomObjectsApi` but are served by the
+OpenShift aggregated API server from typed Go objects, so they do support
+strategic merge patch and must not be declared as custom resources.
+
+**Existing examples**: `HttpRoutesResourceFactory`, `GatewayClassesResourceFactory`.
+
+**Signature**:
+```typescript
+setIsCustomResource()
+```
+
+---
+
 ##### `setIsActive(fn: (obj) => boolean)`
 
 **Purpose**: enables the "Active" metric column on the dashboard home page cards.
@@ -966,6 +996,7 @@ When reviewing a PR that adds a new resource, verify each item:
 - [ ] Factory import added to `contexts-manager.ts`
 - [ ] Factory unit test exists and covers `isActive` logic (if applicable)
 - [ ] `setDeleteObject` is defined only if the UI will expose a delete action; omit for admin resources (Nodes, StorageClasses) and system resources (Events, EndpointSlices)
+- [ ] `setIsCustomResource()` is called if the kind is provided by a CRD (Gateway API and other cluster-installed CRDs), so that patching uses server-side apply; not called for kinds served natively, including OpenShift Routes
 
 ### Webview
 

--- a/packages/extension/src/manager/contexts-manager.spec.ts
+++ b/packages/extension/src/manager/contexts-manager.spec.ts
@@ -24,7 +24,7 @@ import type {
   ObjectCache,
   V1Status,
 } from '@kubernetes/client-node';
-import { ApiException, KubeConfig } from '@kubernetes/client-node';
+import { ApiException, KubeConfig, PatchStrategy } from '@kubernetes/client-node';
 import { type Uri, Disposable, type TelemetryLogger } from '@podman-desktop/api';
 import { afterEach, assert, beforeEach, describe, expect, test, vi } from 'vitest';
 import { kubernetes, window } from '@podman-desktop/api';
@@ -218,6 +218,21 @@ class TestContextsManager extends ContextsManager {
           ],
         })
         .setReadObject(resource5ReadObjectMock),
+      new ResourceFactoryBase({
+        kind: 'CustomResource1',
+        resource: 'customresource1',
+      })
+        .setIsCustomResource()
+        .setPermissions({
+          isNamespaced: true,
+          permissionsRequests: [
+            {
+              group: '*',
+              resource: '*',
+              verb: 'watch',
+            },
+          ],
+        }),
       new ResourceFactoryBase({
         kind: 'Event',
         resource: 'events',
@@ -1931,6 +1946,84 @@ test('applyResources sends telemetry', async () => {
   expect(telemetryLoggerMock.logUsage).toHaveBeenCalledWith('apply.resources', {
     manifestsSize: 1,
     kinds: 'Namespace',
+  });
+});
+
+describe('applyResources patch strategy', () => {
+  const patchMock = vi.fn();
+
+  async function createManager(): Promise<TestContextsManager> {
+    const kc = new KubeConfig();
+    kc.loadFromOptions(kcWithContext1asDefault);
+    const manager = new TestContextsManager();
+    vi.spyOn(manager, 'startMonitoring').mockImplementation(async (): Promise<void> => {});
+    vi.spyOn(manager, 'stopMonitoring').mockImplementation((): void => {});
+    vi.spyOn(ContextsManager.prototype, 'currentContext', 'get').mockReturnValue({
+      getKubeConfig: vi.fn().mockReturnValue({
+        makeApiClient: vi.fn().mockReturnValue({
+          patch: patchMock,
+        } as unknown as KubernetesObjectApi),
+      }),
+      getNamespace: vi.fn().mockReturnValue('ns1'),
+    } as unknown as KubeConfigSingleContext);
+    await manager.update(kc);
+    return manager;
+  }
+
+  test('a resource not provided by a CRD is patched with a strategic merge patch', async () => {
+    const manager = await createManager();
+
+    await manager.applyResources('apiVersion: v1\nkind: Resource2\nmetadata:\n  name: resource-name\n');
+
+    expect(patchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'Resource2',
+        metadata: expect.objectContaining({
+          namespace: 'ns1',
+          annotations: expect.objectContaining({
+            'kubectl.kubernetes.io/last-applied-configuration': expect.any(String),
+          }),
+        }),
+      }),
+      undefined, // pretty
+      undefined, // dryRun
+      'kubernetes-dashboard',
+      undefined, // force
+      PatchStrategy.StrategicMergePatch,
+    );
+  });
+
+  test('a resource provided by a CRD is patched with a server-side apply', async () => {
+    const manager = await createManager();
+
+    await manager.applyResources(
+      'apiVersion: example.com/v1\nkind: CustomResource1\nmetadata:\n  name: resource-name\n',
+    );
+
+    expect(patchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'CustomResource1',
+        metadata: expect.objectContaining({
+          namespace: 'ns1',
+        }),
+      }),
+      undefined, // pretty
+      undefined, // dryRun
+      'kubernetes-dashboard',
+      true, // force
+      PatchStrategy.ServerSideApply,
+    );
+  });
+
+  test('the last-applied-configuration annotation is not added for a resource provided by a CRD', async () => {
+    const manager = await createManager();
+
+    await manager.applyResources(
+      'apiVersion: example.com/v1\nkind: CustomResource1\nmetadata:\n  name: resource-name\n',
+    );
+
+    const patchedManifest = patchMock.mock.calls[0]?.[0] as KubernetesObject;
+    expect(patchedManifest.metadata?.annotations).toBeUndefined();
   });
 });
 

--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -1030,18 +1030,29 @@ export class ContextsManager implements ContextsApi {
     }
     const manifests = loadAllYaml(this.convertYamlFrom11to12(yamlDocuments)).filter(manifest => !!manifest);
     for (const manifest of manifests) {
+      // the API server does not serve strategic merge patch for kinds provided by a
+      // CustomResourceDefinition (it accepts only json-patch, merge-patch and apply-patch),
+      // these resources are patched using server-side apply instead
+      const factory = this.#resourceFactoryHandler.getResourceFactoryByKind(manifest.kind ?? '');
+      const serverSideApply = factory?.isCustomResource ?? false;
+      const strategy = serverSideApply ? PatchStrategy.ServerSideApply : PatchStrategy.StrategicMergePatch;
+
       manifest.metadata ??= {};
-      manifest.metadata.annotations ??= {};
-      manifest.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration'] = JSON.stringify(manifest);
       manifest.metadata.namespace ??= this.currentContext?.getNamespace() ?? DEFAULT_NAMESPACE;
+      if (!serverSideApply) {
+        // last-applied-configuration is a client-side apply artifact,
+        // server-side apply tracks ownership in metadata.managedFields instead
+        manifest.metadata.annotations ??= {};
+        manifest.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration'] = JSON.stringify(manifest);
+      }
       try {
         const result = await client.patch(
           manifest,
           undefined, // pretty
           undefined, // dryRun
           FIELD_MANAGER,
-          undefined, // force
-          PatchStrategy.StrategicMergePatch,
+          serverSideApply ? true : undefined, // force: take ownership from the other field managers
+          strategy,
         );
         this.handleResult(result, `patch of ${manifest.kind} ${manifest.metadata?.name}`);
       } catch (error: unknown) {

--- a/packages/extension/src/resources/gatewayclasses-resource-factory.spec.ts
+++ b/packages/extension/src/resources/gatewayclasses-resource-factory.spec.ts
@@ -25,3 +25,8 @@ test('factory has correct resource and kind', () => {
   expect(factory.resource).toBe('gatewayclasses');
   expect(factory.kind).toBe('GatewayClass');
 });
+
+test('factory is declared as a custom resource', () => {
+  const factory = new GatewayClassesResourceFactory();
+  expect(factory.isCustomResource).toBeTruthy();
+});

--- a/packages/extension/src/resources/gatewayclasses-resource-factory.ts
+++ b/packages/extension/src/resources/gatewayclasses-resource-factory.ts
@@ -35,6 +35,8 @@ export class GatewayClassesResourceFactory extends ResourceFactoryBase implement
       kind: 'GatewayClass',
     });
 
+    this.setIsCustomResource();
+
     this.setPermissions({
       isNamespaced: false,
       permissionsRequests: [

--- a/packages/extension/src/resources/httproutes-resource-factory.spec.ts
+++ b/packages/extension/src/resources/httproutes-resource-factory.spec.ts
@@ -26,6 +26,11 @@ test('factory has correct resource name and kind', () => {
   expect(factory.kind).toBe('HTTPRoute');
 });
 
+test('factory is declared as a custom resource', () => {
+  const factory = new HttpRoutesResourceFactory();
+  expect(factory.isCustomResource).toBeTruthy();
+});
+
 test('deleteObject is defined', () => {
   const factory = new HttpRoutesResourceFactory();
   expect(factory.deleteObject).toBeDefined();

--- a/packages/extension/src/resources/httproutes-resource-factory.ts
+++ b/packages/extension/src/resources/httproutes-resource-factory.ts
@@ -35,6 +35,8 @@ export class HttpRoutesResourceFactory extends ResourceFactoryBase implements Re
       kind: 'HTTPRoute',
     });
 
+    this.setIsCustomResource();
+
     this.setPermissions({
       isNamespaced: true,
       permissionsRequests: [

--- a/packages/extension/src/resources/resource-factory.spec.ts
+++ b/packages/extension/src/resources/resource-factory.spec.ts
@@ -47,6 +47,18 @@ test('ResourceFactoryBase set permissions', () => {
   expect(isResourceFactoryWithPermissions(factory)).toBeTruthy();
 });
 
+test('ResourceFactoryBase is not a custom resource by default', () => {
+  const factory = new ResourceFactoryBase({ resource: 'resource1', kind: 'kind1' });
+
+  expect(factory.isCustomResource).toBeFalsy();
+});
+
+test('ResourceFactoryBase set is custom resource', () => {
+  const factory = new ResourceFactoryBase({ resource: 'resource1', kind: 'kind1' }).setIsCustomResource();
+
+  expect(factory.isCustomResource).toBeTruthy();
+});
+
 test('copyWithSlicedPermissions', () => {
   const factory = new ResourceFactoryBase({ resource: 'resource1', kind: 'kind1' });
 

--- a/packages/extension/src/resources/resource-factory.ts
+++ b/packages/extension/src/resources/resource-factory.ts
@@ -84,6 +84,7 @@ export class ResourceFactoryBase {
   #resource: string;
   #kind: string;
   #eagerStart: boolean;
+  #isCustomResource: boolean;
   #permissions: ResourcePermissionsFactory | undefined;
   #informer: ResourceInformerFactory | undefined;
   #isActive: undefined | ((resource: KubernetesObject) => boolean);
@@ -98,10 +99,19 @@ export class ResourceFactoryBase {
     this.#resource = options.resource;
     this.#kind = options.kind;
     this.#eagerStart = false;
+    this.#isCustomResource = false;
   }
 
   setEagerStart(): ResourceFactoryBase {
     this.#eagerStart = true;
+    return this;
+  }
+
+  // declares that the kind is provided by a CustomResourceDefinition.
+  // the API server does not serve strategic merge patch for these kinds,
+  // they are patched using server-side apply instead
+  setIsCustomResource(): ResourceFactoryBase {
+    this.#isCustomResource = true;
     return this;
   }
 
@@ -171,6 +181,10 @@ export class ResourceFactoryBase {
     return this.#eagerStart;
   }
 
+  get isCustomResource(): boolean {
+    return this.#isCustomResource;
+  }
+
   get permissions(): ResourcePermissionsFactory | undefined {
     return this.#permissions;
   }
@@ -229,6 +243,8 @@ export interface ResourceFactory {
   get resource(): string;
   get kind(): string;
   get eagerStart(): boolean;
+  // isCustomResource is true if the kind is provided by a CustomResourceDefinition
+  get isCustomResource(): boolean;
   permissions?: ResourcePermissionsFactory;
   informer?: ResourceInformerFactory;
   // isActive returns true if `resource` is considered active

--- a/packages/webview/src/component/editor/EditYAML.svelte
+++ b/packages/webview/src/component/editor/EditYAML.svelte
@@ -74,7 +74,7 @@ async function applyToCluster(): Promise<void> {
   class="flex flex-row-reverse p-6 bg-transparent fixed bottom-0 right-0 mb-0 pr-10 max-h-20 bg-opacity-90 z-50"
   role="group"
   aria-label="Edit Buttons">
-  <Tooltip topLeft tip="Patch resource using Strategic Merge">
+  <Tooltip topLeft tip="Patch resource using Strategic Merge (Server-Side Apply for custom resources)">
     <Button
       type="primary"
       aria-label="Patch resource"


### PR DESCRIPTION
### What does this PR do?

The Kubernetes API server does not serve strategic merge patch for kinds provided by a CustomResourceDefinition: it accepts only json-patch, merge-patch and apply-patch for them. Patching such a resource from the YAML tab failed with "the body of the request was in an unknown format".

Resource factories now declare whether their kind comes from a CRD, with setIsCustomResource(), and applyResources() patches those resources using a server-side apply (with force, so the kubernetes-dashboard field manager takes ownership) instead of a strategic merge patch. The other kinds keep being patched with a strategic merge patch.

More work will be done separately to add an option for patch, so the user can choose the strategy (see WIP #1307)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #1315

### How to test this PR?

<!-- Please explain steps to reproduce -->
