### PR TITLE
chore(ci): use podman-desktop/gh-extensions-actions for image creation/deployment  

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -133,5 +133,5 @@ jobs:
           github-token: ${{ github.token }}
           registry-username: ${{ github.repository_owner }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
-          image-name: podman-desktop-extension-kubernetes-dashboard
+          image-name: ${{ github.repository_owner }}/podman-desktop-extension-kubernetes-dashboard
           tags: next ${{ github.sha }}

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -121,7 +121,9 @@ jobs:
       contents: read
       id-token: write
       attestations: write
+      actions: read
       packages: write
+      checks: write
     steps:
       - name: Publish OCI
         uses: podman-desktop/gh-extensions-actions/.github/actions/oci-publish@2e7a02e8c8e9256a2fa466fb166e215175130dd7 # v0.1.2
@@ -131,5 +133,5 @@ jobs:
           github-token: ${{ github.token }}
           registry-username: ${{ github.repository_owner }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
-          image-name: ${{ github.repository }}
+          image-name: podman-desktop-extension-kubernetes-dashboard
           tags: next ${{ github.sha }}

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2025 Red Hat, Inc.
+# Copyright (C) 2025 - 2026 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -99,52 +99,35 @@ jobs:
           subject-digest: ${{ steps.push-to-ghcr.outputs.digest }}
           push-to-registry: true
 
-  extension-image:
-    name: Build and publish extension OCI image
+  extension-build:
+    name: build oci image
     if: always()
     runs-on: ubuntu-24.04
     needs: builder-image
-
+    outputs:
+      artifact-id: ${{ steps.build.outputs.artifact-id }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
+      - name: Build OCI
+        id: build
+        uses: podman-desktop/gh-extensions-actions/.github/actions/oci-build@2e7a02e8c8e9256a2fa466fb166e215175130dd7 # v0.1.2
 
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-
-      - name: build extension image
-        id: extension-image
-        uses: redhat-actions/buildah-build@719e3c40d8af9790c23eca13f7daa339f2867034 #v3.1.0
+  extension-publish:
+    name: publish oci image
+    needs: extension-build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      packages: write
+    steps:
+      - name: Publish OCI
+        uses: podman-desktop/gh-extensions-actions/.github/actions/oci-publish@2e7a02e8c8e9256a2fa466fb166e215175130dd7 # v0.1.2
         with:
-          image: podman-desktop-extension-kubernetes-dashboard
+          run-id: ${{ github.run_id }}
+          artifact-id: ${{ needs.extension-build.outputs.artifact-id }}
+          github-token: ${{ github.token }}
+          registry-username: ${{ github.repository_owner }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+          image-name: ghcr.io/${{ github.repository }}
           tags: next ${{ github.sha }}
-          archs: amd64, arm64
-          containerfiles: |
-            build/Containerfile
-          context: .
-          oci: true
-
-      - name: Log in to ghcr.io
-        uses: redhat-actions/podman-login@50c2d9a331bb67c8fdab99b86455fad05e2e3252 # v2.0
-        with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-
-      - name: publish extension to ghcr.io
-        id: push-to-ghcr
-        uses: redhat-actions/push-to-registry@94ade333c38ecc0e60e94785125d9a52ca423b37 #v3.0.0
-        with:
-          image: ${{ steps.extension-image.outputs.image }}
-          tags: ${{ steps.extension-image.outputs.tags }}
-          registry: ghcr.io/${{ github.repository_owner }}
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
-        with:
-          subject-name: ghcr.io/${{ github.repository_owner }}/podman-desktop-extension-kubernetes-dashboard
-          subject-digest: ${{ steps.push-to-ghcr.outputs.digest }}
-          push-to-registry: true

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -101,7 +101,7 @@ jobs:
 
   extension-build:
     name: build oci image
-    if: always()
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-24.04
     needs: builder-image
     outputs:

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -110,6 +110,8 @@ jobs:
       - name: Build OCI
         id: build
         uses: podman-desktop/gh-extensions-actions/.github/actions/oci-build@2e7a02e8c8e9256a2fa466fb166e215175130dd7 # v0.1.2
+        with:
+          containerfile: build/Containerfile
 
   extension-publish:
     name: publish oci image

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -131,5 +131,5 @@ jobs:
           github-token: ${{ github.token }}
           registry-username: ${{ github.repository_owner }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
-          image-name: ghcr.io/${{ github.repository }}
+          image-name: ${{ github.repository }}
           tags: next ${{ github.sha }}

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2025 Red Hat, Inc.
+# Copyright (C) 2025 - 2026 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -78,31 +78,12 @@ jobs:
         run: pnpm build
         timeout-minutes: 40
 
-  ## the builder image is not built as part of this workflow
-  ## but is built in the release workflow
-  ## Changes to the builder image must be merged before to use these changes in the extension image
-  extension-image:
-    name: Build extension OCI image
+  build-oci:
+    name: build oci image
     runs-on: ubuntu-24.04
-
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Build OCI
+        id: build
+        uses: podman-desktop/gh-extensions-actions/.github/actions/oci-build@2e7a02e8c8e9256a2fa466fb166e215175130dd7 # v0.1.2
         with:
-          fetch-depth: 0
-
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-
-      - name: build extension image
-        id: extension-image
-        uses: redhat-actions/buildah-build@719e3c40d8af9790c23eca13f7daa339f2867034 #v3.1.0
-        with:
-          image: podman-desktop-extension-kubernetes-dashboard
-          tags: next ${{ github.sha }}
-          archs: amd64, arm64
-          containerfiles: |
-            build/Containerfile
-          context: .
-          oci: true
+          ref: ${{ github.ref }}

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -87,3 +87,4 @@ jobs:
         uses: podman-desktop/gh-extensions-actions/.github/actions/oci-build@2e7a02e8c8e9256a2fa466fb166e215175130dd7 # v0.1.2
         with:
           ref: ${{ github.ref }}
+          containerfile: build/Containerfile

--- a/.github/workflows/publish-oci-pr.yaml
+++ b/.github/workflows/publish-oci-pr.yaml
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: publish-oci-pr
+
+on:
+  workflow_run:
+    workflows:
+      - 'pr-check'
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: podman-desktop/gh-extensions-actions/.github/workflows/publish-oci-pr.yml@0dfd06899ce71f9a469ac745e97f8449d42529bb
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      actions: read
+      packages: write
+      checks: write
+    with:
+      run-id: ${{ github.event.workflow_run.id }}
+      head-sha: ${{ github.event.workflow_run.head_sha }}
+      image-name: ${{ github.repository }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-oci-pr.yaml
+++ b/.github/workflows/publish-oci-pr.yaml
@@ -41,6 +41,6 @@ jobs:
     with:
       run-id: ${{ github.event.workflow_run.id }}
       head-sha: ${{ github.event.workflow_run.head_sha }}
-      image-name: ${{ github.repository }}
+      image-name: podman-desktop-extension-kubernetes-dashboard
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-oci-pr.yaml
+++ b/.github/workflows/publish-oci-pr.yaml
@@ -41,6 +41,6 @@ jobs:
     with:
       run-id: ${{ github.event.workflow_run.id }}
       head-sha: ${{ github.event.workflow_run.head_sha }}
-      image-name: podman-desktop-extension-kubernetes-dashboard
+      image-name: ${{ github.repository_owner }}/podman-desktop-extension-kubernetes-dashboard
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -210,7 +210,7 @@ jobs:
           github-token: ${{ github.token }}
           registry-username: ${{ github.repository_owner }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
-          image-name: ghcr.io/${{ github.repository }}
+          image-name: ${{ github.repository }}
           tags: ${{ steps.version.outputs.version }} latest
 
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2025 Red Hat, Inc.
+# Copyright (C) 2025 - 2026 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -174,58 +174,46 @@ jobs:
           subject-digest: ${{ steps.push-to-ghcr.outputs.digest }}
           push-to-registry: true
 
-  extension-image:
-    name: Build and publish extension OCI image
-
+  extension-build:
+    name: build oci image
     runs-on: ubuntu-24.04
     needs: [builder-image, tag]
-
+    outputs:
+      artifact-id: ${{ steps.build.outputs.artifact-id }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Build OCI
+        id: build
+        uses: podman-desktop/gh-extensions-actions/.github/actions/oci-build@2e7a02e8c8e9256a2fa466fb166e215175130dd7 # v0.1.2
         with:
           ref: ${{ needs.tag.outputs.githubTag }}
 
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
+  extension-publish:
+    name: publish oci image
+    needs: [extension-build, tag]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      packages: write
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${{ needs.tag.outputs.extVersion }}" >> "$GITHUB_OUTPUT"
 
-      - name: build extension image
-        id: extension-image
-        uses: redhat-actions/buildah-build@719e3c40d8af9790c23eca13f7daa339f2867034 #v3.1.0
+      - name: Publish OCI
+        uses: podman-desktop/gh-extensions-actions/.github/actions/oci-publish@2e7a02e8c8e9256a2fa466fb166e215175130dd7 # v0.1.2
         with:
-          image: podman-desktop-extension-kubernetes-dashboard
-          tags: latest ${{ needs.tag.outputs.extVersion }}
-          archs: amd64, arm64
-          containerfiles: |
-            build/Containerfile
-          context: .
-          oci: true
-
-      - name: Log in to ghcr.io
-        uses: redhat-actions/podman-login@50c2d9a331bb67c8fdab99b86455fad05e2e3252 # v2.0
-        with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-
-      - name: publish extension to ghcr.io
-        id: push-to-ghcr
-        uses: redhat-actions/push-to-registry@94ade333c38ecc0e60e94785125d9a52ca423b37 #v3.0.0
-        with:
-          image: ${{ steps.extension-image.outputs.image }}
-          tags: ${{ steps.extension-image.outputs.tags }}
-          registry: ghcr.io/${{ github.repository_owner }}
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
-        with:
-          subject-name: ghcr.io/${{ github.repository_owner }}/podman-desktop-extension-kubernetes-dashboard
-          subject-digest: ${{ steps.push-to-ghcr.outputs.digest }}
-          push-to-registry: true
+          run-id: ${{ github.run_id }}
+          artifact-id: ${{ needs.extension-build.outputs.artifact-id }}
+          github-token: ${{ github.token }}
+          registry-username: ${{ github.repository_owner }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+          image-name: ghcr.io/${{ github.repository }}
+          tags: ${{ steps.version.outputs.version }} latest
 
   release:
-    needs: [tag, builder-image, extension-image]
+    needs: [tag, builder-image, extension-publish]
     name: Release
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -186,6 +186,7 @@ jobs:
         uses: podman-desktop/gh-extensions-actions/.github/actions/oci-build@2e7a02e8c8e9256a2fa466fb166e215175130dd7 # v0.1.2
         with:
           ref: ${{ needs.tag.outputs.githubTag }}
+          containerfile: build/Containerfile
 
   extension-publish:
     name: publish oci image

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -208,7 +208,7 @@ jobs:
           github-token: ${{ github.token }}
           registry-username: ${{ github.repository_owner }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
-          image-name: podman-desktop-extension-kubernetes-dashboard
+          image-name: ${{ github.repository_owner }}/podman-desktop-extension-kubernetes-dashboard
           tags: ${{ needs.tag.outputs.extVersion }} latest
 
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -196,12 +196,10 @@ jobs:
       contents: read
       id-token: write
       attestations: write
+      actions: read
       packages: write
+      checks: write
     steps:
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${{ needs.tag.outputs.extVersion }}" >> "$GITHUB_OUTPUT"
-
       - name: Publish OCI
         uses: podman-desktop/gh-extensions-actions/.github/actions/oci-publish@2e7a02e8c8e9256a2fa466fb166e215175130dd7 # v0.1.2
         with:
@@ -210,8 +208,8 @@ jobs:
           github-token: ${{ github.token }}
           registry-username: ${{ github.repository_owner }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
-          image-name: ${{ github.repository }}
-          tags: ${{ steps.version.outputs.version }} latest
+          image-name: podman-desktop-extension-kubernetes-dashboard
+          tags: ${{ needs.tag.outputs.extVersion }} latest
 
   release:
     needs: [tag, builder-image, extension-publish]


### PR DESCRIPTION
### What does this PR do?

Replace manual buildah-build/push/attestation steps with the shared oci-build and oci-publish actions. Add publish-oci-pr workflow to automatically publish PR-specific OCI images.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #1316 

### How to test this PR?

<!-- Please explain steps to reproduce -->

Build on PR check passes
To test other workflows, this PR will need to be merged first