### PR TITLE
fix(ci): ensure extension image is published regardless of builder changes

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -115,6 +115,7 @@ jobs:
 
   extension-publish:
     name: publish oci image
+    if: ${{ !failure() && !cancelled() }}
     needs: extension-build
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION

### What does this PR do?

The extension-publish job was skipped when the builder-image job was skipped (no package.json/pnpm-lock.yaml changes), because the default success() condition propagated the skipped status through the needs chain.

### Screenshot / video of UI


### What issues does this PR fix or reference?

Fixes #1316 

### How to test this PR?

Needs to be merged on main to validate that it build and publish the image