### PR TITLE
feat(api): add getApiVersions and getApiResources endpoints

### DIFF
--- a/packages/api/src/kubernetes-dashboard-extension-api.d.ts
+++ b/packages/api/src/kubernetes-dashboard-extension-api.d.ts
@@ -179,6 +179,70 @@ export interface KubernetesDashboardExtensionApi {
   getSubscriber(): KubernetesDashboardSubscriber;
 
   readonly contexts: typeof contexts;
+
+  /**
+   * Returns the list of API groups/versions served by the Kubernetes API server.
+   *
+   * The returned value maps the value returned by the `/apis` endpoint directly.
+   */
+  getApiVersions(): Promise<ApiGroupList>;
+
+  /**
+   * Returns the list of resources for a specific API group/version.
+   *
+   * The returned value maps the value returned by the `/apis/<groupVersion>` or `/api/<version>` endpoint directly.
+   *
+   * @param groupVersion - The group/version to get resources for (e.g., 'v1', 'apps/v1').
+   */
+  getApiResources(groupVersion: string): Promise<ApiResourceList>;
+}
+
+/**
+ * A version of an API group.
+ */
+export interface ApiGroupVersion {
+  groupVersion: string;
+  version: string;
+}
+
+/**
+ * An API group served by the Kubernetes API server.
+ */
+export interface ApiGroup {
+  name: string;
+  versions: ApiGroupVersion[];
+  preferredVersion?: ApiGroupVersion;
+}
+
+/**
+ * The list of API groups served by the Kubernetes API server.
+ */
+export interface ApiGroupList {
+  groups: ApiGroup[];
+}
+
+/**
+ * A resource served by a specific API group/version.
+ */
+export interface ApiResource {
+  name: string;
+  singularName: string;
+  namespaced: boolean;
+  kind: string;
+  verbs: string[];
+  shortNames?: string[];
+  categories?: string[];
+  group?: string;
+  version?: string;
+  storageVersionHash?: string;
+}
+
+/**
+ * The list of resources served by a specific API group/version.
+ */
+export interface ApiResourceList {
+  groupVersion: string;
+  resources: ApiResource[];
 }
 
 /**

--- a/packages/extension/src/dashboard-extension.spec.ts
+++ b/packages/extension/src/dashboard-extension.spec.ts
@@ -139,6 +139,24 @@ test('activate should return a KubernetesDashboardExtensionApi', async () => {
   expect((apiSubscriber as ApiSubscriber).dispose).toHaveBeenCalledOnce();
 });
 
+test('api.getApiVersions should delegate to ContextsManager.getApiVersions', async () => {
+  ContextsManager.prototype.getApiVersions = vi.fn().mockResolvedValue({ groups: [] });
+  const api = await dashboardExtension.activate();
+
+  await api.getApiVersions();
+
+  expect(ContextsManager.prototype.getApiVersions).toHaveBeenCalled();
+});
+
+test('api.getApiResources should delegate to ContextsManager.getApiResources', async () => {
+  ContextsManager.prototype.getApiResources = vi.fn().mockResolvedValue({ groupVersion: 'apps/v1', resources: [] });
+  const api = await dashboardExtension.activate();
+
+  await api.getApiResources('apps/v1');
+
+  expect(ContextsManager.prototype.getApiResources).toHaveBeenCalledWith('apps/v1');
+});
+
 test('subscriber.onResourceUpdate should subscribe to UPDATE_RESOURCE channel', async () => {
   const api = await dashboardExtension.activate();
   const subscriber = api.getSubscriber();

--- a/packages/extension/src/dashboard-extension.ts
+++ b/packages/extension/src/dashboard-extension.ts
@@ -178,6 +178,12 @@ export class DashboardExtension {
           return this.#contextsManager.refreshContextState(contextName, options);
         },
       },
+      getApiVersions: () => {
+        return this.#contextsManager.getApiVersions();
+      },
+      getApiResources: (groupVersion: string) => {
+        return this.#contextsManager.getApiResources(groupVersion);
+      },
     } as KubernetesDashboardExtensionApi;
   }
 

--- a/packages/extension/src/manager/contexts-manager.spec.ts
+++ b/packages/extension/src/manager/contexts-manager.spec.ts
@@ -2287,3 +2287,24 @@ describe('lazy informer lifecycle', () => {
     expect(createdLazyInformerMock.start).not.toHaveBeenCalled();
   });
 });
+
+describe('validateGroupVersion', () => {
+  test.each(['v1', 'apps/v1', 'batch/v1', 'networking.k8s.io/v1', 'rbac.authorization.k8s.io/v1beta1'])(
+    'accepts valid groupVersion %s',
+    (gv: string) => {
+      expect(() => ContextsManager.validateGroupVersion(gv)).not.toThrow();
+    },
+  );
+
+  test.each([
+    '../../api/v1/secrets',
+    '../api/v1/namespaces/kube-system/secrets',
+    'apps/../v1/secrets',
+    './v1',
+    '',
+    'apps/',
+    '/v1',
+  ])('rejects invalid groupVersion %s', (gv: string) => {
+    expect(() => ContextsManager.validateGroupVersion(gv)).toThrow('invalid groupVersion');
+  });
+});

--- a/packages/extension/src/manager/contexts-manager.spec.ts
+++ b/packages/extension/src/manager/contexts-manager.spec.ts
@@ -25,6 +25,9 @@ import type {
   V1Status,
 } from '@kubernetes/client-node';
 import { ApiException, KubeConfig, PatchStrategy } from '@kubernetes/client-node';
+import { EventEmitter } from 'node:events';
+import https from 'node:https';
+
 import { type Uri, Disposable, type TelemetryLogger } from '@podman-desktop/api';
 import { afterEach, assert, beforeEach, describe, expect, test, vi } from 'vitest';
 import { kubernetes, window } from '@podman-desktop/api';
@@ -2306,5 +2309,126 @@ describe('validateGroupVersion', () => {
     '/v1',
   ])('rejects invalid groupVersion %s', (gv: string) => {
     expect(() => ContextsManager.validateGroupVersion(gv)).toThrow('invalid groupVersion');
+  });
+});
+
+describe('getApiResources', () => {
+  let manager: TestContextsManager;
+
+  function mockHttpsRequest(respond: (res: EventEmitter, req: EventEmitter) => void): void {
+    vi.spyOn(https, 'request').mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (res: unknown) => void;
+      const res = new EventEmitter();
+      const req = new EventEmitter();
+      Object.assign(req, { end: vi.fn() });
+      cb(res);
+      respond(res, req);
+      return req as unknown as ReturnType<typeof https.request>;
+    });
+  }
+
+  beforeEach(() => {
+    manager = new TestContextsManager();
+    const context = { name: 'ctx', cluster: 'c', user: 'u' };
+    const kubeConfig = new KubeConfig();
+    kubeConfig.loadFromOptions({
+      clusters: [{ name: 'c', server: 'https://localhost:6443' }],
+      users: [{ name: 'u' }],
+      contexts: [context],
+      currentContext: 'ctx',
+    });
+    const singleContext = new KubeConfigSingleContext(kubeConfig, context);
+    vi.spyOn(ContextsManager.prototype, 'currentContext', 'get').mockReturnValue(singleContext);
+  });
+
+  test('throws when there is no current cluster', async () => {
+    const context = { name: 'ctx', cluster: 'missing', user: 'u' };
+    const kubeConfig = new KubeConfig();
+    kubeConfig.loadFromOptions({
+      clusters: [],
+      users: [{ name: 'u' }],
+      contexts: [context],
+      currentContext: 'ctx',
+    });
+    const singleContext = new KubeConfigSingleContext(kubeConfig, context);
+    vi.spyOn(ContextsManager.prototype, 'currentContext', 'get').mockReturnValue(singleContext);
+
+    await expect(manager.getApiResources('v1')).rejects.toThrow('no current cluster');
+  });
+
+  test('resolves with parsed resources on successful response', async () => {
+    const payload = { apiVersion: 'v1', kind: 'APIResourceList', resources: [] };
+    mockHttpsRequest(res => {
+      Object.assign(res, { statusCode: 200 });
+      res.emit('data', JSON.stringify(payload));
+      res.emit('end');
+    });
+
+    const result = await manager.getApiResources('apps/v1');
+    expect(result).toEqual(payload);
+  });
+
+  test('uses /api/ path for core v1 groupVersion', async () => {
+    const payload = { apiVersion: 'v1', kind: 'APIResourceList', resources: [] };
+    mockHttpsRequest(res => {
+      Object.assign(res, { statusCode: 200 });
+      res.emit('data', JSON.stringify(payload));
+      res.emit('end');
+    });
+
+    await manager.getApiResources('v1');
+    const url = vi.mocked(https.request).mock.calls[0]![0] as URL;
+    expect(url.pathname).toBe('/api/v1');
+  });
+
+  test('uses /apis/ path for named group groupVersion', async () => {
+    const payload = { apiVersion: 'v1', kind: 'APIResourceList', resources: [] };
+    mockHttpsRequest(res => {
+      Object.assign(res, { statusCode: 200 });
+      res.emit('data', JSON.stringify(payload));
+      res.emit('end');
+    });
+
+    await manager.getApiResources('apps/v1');
+    const url = vi.mocked(https.request).mock.calls[0]![0] as URL;
+    expect(url.pathname).toBe('/apis/apps/v1');
+  });
+
+  test('rejects with status error on non-2xx response', async () => {
+    mockHttpsRequest(res => {
+      Object.assign(res, { statusCode: 403, statusMessage: 'Forbidden' });
+      res.emit('end');
+    });
+
+    await expect(manager.getApiResources('apps/v1')).rejects.toThrow(
+      'Failed to get API resources for apps/v1: 403 Forbidden',
+    );
+  });
+
+  test('rejects when the request emits an error', async () => {
+    mockHttpsRequest((_res, req) => {
+      req.emit('error', new Error('ECONNREFUSED'));
+    });
+
+    await expect(manager.getApiResources('apps/v1')).rejects.toThrow('ECONNREFUSED');
+  });
+
+  test('rejects with parse error when response body is invalid JSON', async () => {
+    mockHttpsRequest(res => {
+      Object.assign(res, { statusCode: 200 });
+      res.emit('data', 'not-json');
+      res.emit('end');
+    });
+
+    await expect(manager.getApiResources('apps/v1')).rejects.toThrow('Failed to parse API resources response');
+  });
+
+  test('rejects when the response stream emits an error', async () => {
+    mockHttpsRequest(res => {
+      Object.assign(res, { statusCode: 200 });
+      res.emit('error', new Error('connection reset'));
+    });
+
+    await expect(manager.getApiResources('apps/v1')).rejects.toThrow('connection reset');
   });
 });

--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -1211,7 +1211,16 @@ export class ContextsManager implements ContextsApi {
     };
   }
 
+  static validateGroupVersion(groupVersion: string): void {
+    for (const part of groupVersion.split('/')) {
+      if (part === '' || part === '.' || part === '..') {
+        throw new Error(`invalid groupVersion: ${JSON.stringify(groupVersion)}`);
+      }
+    }
+  }
+
   async getApiResources(groupVersion: string): Promise<ApiResourceList> {
+    ContextsManager.validateGroupVersion(groupVersion);
     const kubeConfig = this.getCurrentKubeConfig();
     const cluster = kubeConfig.getCurrentCluster();
     if (!cluster) {

--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import {
+  ApisApi,
   ApiException,
   CoreV1Event,
   KubeConfig,
@@ -100,7 +101,14 @@ import { ValidatingWebhooksResourceFactory } from '/@/resources/validating-webho
 import { HpasResourceFactory } from '/@/resources/hpas-resource-factory.js';
 import { parseAllDocuments, stringify, type Tags } from 'yaml';
 import { writeFile } from 'node:fs/promises';
-import { ConnectOptions, ContextPermission, ResourceCount } from '@podman-desktop/kubernetes-dashboard-extension-api';
+import https from 'node:https';
+import {
+  ConnectOptions,
+  ContextPermission,
+  ResourceCount,
+  type ApiGroupList,
+  type ApiResourceList,
+} from '@podman-desktop/kubernetes-dashboard-extension-api';
 import { TelemetryLoggerSymbol } from '/@/inject/symbol.js';
 
 const HEALTH_CHECK_TIMEOUT_MS = 5_000;
@@ -1193,5 +1201,58 @@ export class ContextsManager implements ContextsApi {
     const yamlString = jsYaml.dump(JSON.parse(jsonString));
     const kubeconfigUri = kubernetes.getKubeconfig();
     await writeFile(kubeconfigUri.path, yamlString);
+  }
+
+  async getApiVersions(): Promise<ApiGroupList> {
+    const kubeConfig = this.getCurrentKubeConfig();
+    const result = await kubeConfig.makeApiClient(ApisApi).getAPIVersions();
+    return {
+      groups: result.groups,
+    };
+  }
+
+  async getApiResources(groupVersion: string): Promise<ApiResourceList> {
+    const kubeConfig = this.getCurrentKubeConfig();
+    const cluster = kubeConfig.getCurrentCluster();
+    if (!cluster) {
+      throw new Error('no current cluster');
+    }
+    const apiPath = groupVersion === 'v1' ? '/api/v1' : `/apis/${groupVersion}`;
+    const url = new URL(cluster.server + apiPath);
+    const opts: https.RequestOptions = {
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname,
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    };
+    await kubeConfig.applyToHTTPSOptions(opts);
+
+    return new Promise<ApiResourceList>((resolve, reject) => {
+      const req = https.request(url, opts, res => {
+        let data = '';
+        res.on('data', chunk => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+            resolve(JSON.parse(data) as ApiResourceList);
+          } else {
+            reject(
+              new Error(`Failed to get API resources for ${groupVersion}: ${res.statusCode} ${res.statusMessage}`),
+            );
+          }
+        });
+      });
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  private getCurrentKubeConfig(): KubeConfig {
+    if (!this.currentContext) {
+      throw new Error('no current Kubernetes context');
+    }
+    return this.currentContext.getKubeConfig();
   }
 }

--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -1243,9 +1243,14 @@ export class ContextsManager implements ContextsApi {
         res.on('data', chunk => {
           data += chunk;
         });
+        res.on('error', reject);
         res.on('end', () => {
           if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
-            resolve(JSON.parse(data) as ApiResourceList);
+            try {
+              resolve(JSON.parse(data) as ApiResourceList);
+            } catch (err: unknown) {
+              reject(new Error(`Failed to parse API resources response for ${groupVersion}: ${String(err)}`));
+            }
           } else {
             reject(
               new Error(`Failed to get API resources for ${groupVersion}: ${res.statusCode} ${res.statusMessage}`),


### PR DESCRIPTION
### What does this PR do?

Expose two new methods on the Dashboard API so external extensions can discover API groups/versions and resources served by the Kubernetes API server, without any data transformation.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes #1346

### How to test this PR?

<!-- Please explain steps to reproduce -->
