### PR TITLE
test(e2e): add missing resources to anonymous user tests 

### DIFF
--- a/tests/playwright/src/anonymous-user.ts
+++ b/tests/playwright/src/anonymous-user.ts
@@ -86,6 +86,18 @@ export function anonymousUserTests(): void {
     await playExpect.poll(async () => podsPage.isEmpty('Not accessible')).toBeTruthy();
   });
 
+  test('go to replicaSets page', async () => {
+    const replicaSetsPage = await navigation.openTabPage(KubernetesResources.ReplicaSets);
+    await playExpect(replicaSetsPage.heading).toBeVisible();
+    await playExpect.poll(async () => replicaSetsPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to daemonSets page', async () => {
+    const daemonSetsPage = await navigation.openTabPage(KubernetesResources.DaemonSets);
+    await playExpect(daemonSetsPage.heading).toBeVisible();
+    await playExpect.poll(async () => daemonSetsPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
   test('go to services page', async () => {
     const servicesPage = await navigation.openTabPage(KubernetesResources.Services);
     await playExpect(servicesPage.heading).toBeVisible();
@@ -96,6 +108,48 @@ export function anonymousUserTests(): void {
     const ingresssRoutesPage = await navigation.openTabPage(KubernetesResources.IngressesRoutes);
     await playExpect(ingresssRoutesPage.heading).toBeVisible();
     await playExpect.poll(async () => ingresssRoutesPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to endpoints page', async () => {
+    const endpointsPage = await navigation.openTabPage(KubernetesResources.Endpoints);
+    await playExpect(endpointsPage.heading).toBeVisible();
+    await playExpect.poll(async () => endpointsPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to endpoint slices page', async () => {
+    const endpointSlicesPage = await navigation.openTabPage(KubernetesResources.EndpointSlices);
+    await playExpect(endpointSlicesPage.heading).toBeVisible();
+    await playExpect.poll(async () => endpointSlicesPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to network policies page', async () => {
+    const networkPoliciesPage = await navigation.openTabPage(KubernetesResources.NetworkPolicies);
+    await playExpect(networkPoliciesPage.heading).toBeVisible();
+    await playExpect.poll(async () => networkPoliciesPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to ingress classes page', async () => {
+    const ingressClassesPage = await navigation.openTabPage(KubernetesResources.IngressClasses);
+    await playExpect(ingressClassesPage.heading).toBeVisible();
+    await playExpect.poll(async () => ingressClassesPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to httproutes page', async () => {
+    const httpRoutesPage = await navigation.openTabPage(KubernetesResources.HTTPRoutes);
+    await playExpect(httpRoutesPage.heading).toBeVisible();
+    await playExpect.poll(async () => httpRoutesPage.isEmpty('Not accessible'), { timeout: 15_000 }).toBeTruthy();
+  });
+
+  test('go to gateway classes page', async () => {
+    const gatewayClassesPage = await navigation.openTabPage(KubernetesResources.GatewayClasses);
+    await playExpect(gatewayClassesPage.heading).toBeVisible();
+    await playExpect.poll(async () => gatewayClassesPage.isEmpty('Not accessible'), { timeout: 15_000 }).toBeTruthy();
+  });
+
+  test('go to gateways page', async () => {
+    const gatewaysPage = await navigation.openTabPage(KubernetesResources.Gateways);
+    await playExpect(gatewaysPage.heading).toBeVisible();
+    await playExpect.poll(async () => gatewaysPage.isEmpty('Not accessible'), { timeout: 15_000 }).toBeTruthy();
   });
 
   test('go to pvc page', async () => {
@@ -114,6 +168,90 @@ export function anonymousUserTests(): void {
     const storageClassesPage = await navigation.openTabPage(KubernetesResources.StorageClasses);
     await playExpect(storageClassesPage.heading).toBeVisible();
     await playExpect.poll(async () => storageClassesPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to serviceAccounts page', async () => {
+    const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
+    await playExpect(serviceAccountsPage.heading).toBeVisible();
+    await playExpect.poll(async () => serviceAccountsPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to validatingWebhooks page', async () => {
+    const validatingWebhooksPage = await navigation.openTabPage(KubernetesResources.ValidatingWebhookConfigs);
+    await playExpect(validatingWebhooksPage.heading).toBeVisible();
+    await playExpect.poll(async () => validatingWebhooksPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to hpas page', async () => {
+    const hpasPage = await navigation.openTabPage(KubernetesResources.HorizontalPodAutoscalers);
+    await playExpect(hpasPage.heading).toBeVisible();
+    await playExpect.poll(async () => hpasPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to mutatingWebhooks page', async () => {
+    const mutatingWebhooksPage = await navigation.openTabPage(KubernetesResources.MutatingWebhookConfigs);
+    await playExpect(mutatingWebhooksPage.heading).toBeVisible();
+    await playExpect.poll(async () => mutatingWebhooksPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to leases page', async () => {
+    const leasesPage = await navigation.openTabPage(KubernetesResources.Leases);
+    await playExpect(leasesPage.heading).toBeVisible();
+    await playExpect.poll(async () => leasesPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to runtimeClasses page', async () => {
+    const runtimeClassesPage = await navigation.openTabPage(KubernetesResources.RuntimeClasses);
+    await playExpect(runtimeClassesPage.heading).toBeVisible();
+    await playExpect.poll(async () => runtimeClassesPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to priorityClasses page', async () => {
+    const priorityClassesPage = await navigation.openTabPage(KubernetesResources.PriorityClasses);
+    await playExpect(priorityClassesPage.heading).toBeVisible();
+    await playExpect.poll(async () => priorityClassesPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to pdbs page', async () => {
+    const pdbsPage = await navigation.openTabPage(KubernetesResources.PodDisruptionBudgets);
+    await playExpect(pdbsPage.heading).toBeVisible();
+    await playExpect.poll(async () => pdbsPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to limitRanges page', async () => {
+    const limitRangesPage = await navigation.openTabPage(KubernetesResources.LimitRanges);
+    await playExpect(limitRangesPage.heading).toBeVisible();
+    await playExpect.poll(async () => limitRangesPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to resourceQuotas page', async () => {
+    const resourceQuotasPage = await navigation.openTabPage(KubernetesResources.ResourceQuotas);
+    await playExpect(resourceQuotasPage.heading).toBeVisible();
+    await playExpect.poll(async () => resourceQuotasPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to clusterRoleBindings page', async () => {
+    const clusterRoleBindingsPage = await navigation.openTabPage(KubernetesResources.ClusterRoleBindings);
+    await playExpect(clusterRoleBindingsPage.heading).toBeVisible();
+    await playExpect.poll(async () => clusterRoleBindingsPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to clusterRoles page', async () => {
+    const clusterRolesPage = await navigation.openTabPage(KubernetesResources.ClusterRoles);
+    await playExpect(clusterRolesPage.heading).toBeVisible();
+    await playExpect.poll(async () => clusterRolesPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to roleBindings page', async () => {
+    const roleBindingsPage = await navigation.openTabPage(KubernetesResources.RoleBindings);
+    await playExpect(roleBindingsPage.heading).toBeVisible();
+    await playExpect.poll(async () => roleBindingsPage.isEmpty('Not accessible')).toBeTruthy();
+  });
+
+  test('go to roles page', async () => {
+    const rolesPage = await navigation.openTabPage(KubernetesResources.Roles);
+    await playExpect(rolesPage.heading).toBeVisible();
+    await playExpect.poll(async () => rolesPage.isEmpty('Not accessible')).toBeTruthy();
   });
 
   test('go to configmaps & secrets page', async () => {


### PR DESCRIPTION
### What does this PR do?

Cover all resource pages in the anonymous-user E2E test suite, matching the navigation tests already present in the integration tests. Adds 23 new tests verifying "Not accessible" for ReplicaSets, DaemonSets, Endpoints, EndpointSlices, NetworkPolicies, IngressClasses, HTTPRoutes, GatewayClasses, Gateways, ServiceAccounts, ValidatingWebhookConfigs, MutatingWebhookConfigs, HorizontalPodAutoscalers, Leases, RuntimeClasses, PriorityClasses, PodDisruptionBudgets, LimitRanges, ResourceQuotas, ClusterRoleBindings, ClusterRoles, RoleBindings, and Roles.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes #1342

### How to test this PR?

<!-- Please explain steps to reproduce -->
