### PR TITLE
fix(ci): restrict permissions, update runners, and scope tokens

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -19,9 +19,6 @@ name: build and publish next image
 
 permissions:
   contents: read
-  packages: write
-  attestations: write
-  id-token: write
 
 on:
   workflow_dispatch:
@@ -32,7 +29,7 @@ on:
 jobs:
   extension-build:
     name: build oci image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       artifact-id: ${{ steps.build.outputs.artifact-id }}
     steps:
@@ -46,7 +43,7 @@ jobs:
     name: publish oci image
     if: ${{ !failure() && !cancelled() }}
     needs: extension-build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -29,9 +29,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: "windows-2022"
-          - os: "macos-14"
-          - os: "ubuntu-24.04"
+          - os: "windows-2025"
+          - os: "macos-26"
+          - os: "ubuntu-26.04"
     timeout-minutes: 20
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Execute pnpm
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Run build:rpc
         run: pnpm build:rpc
@@ -65,7 +65,7 @@ jobs:
 
         # skip formatter on windows
       - name: Run formatter
-        if: ${{ matrix.os=='ubuntu-24.04' || matrix.os=='macos-14' }}
+        if: ${{ matrix.os=='ubuntu-26.04' || matrix.os=='macos-26' }}
         run: pnpm format:check
 
       - name: Run linter
@@ -80,7 +80,7 @@ jobs:
 
   build-oci:
     name: build oci image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Build OCI
         id: build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,12 +18,7 @@
 name: release
 
 permissions:
-  contents: write
-  packages: write
-  attestations: write
-  id-token: write
-  pull-requests: write
-  repository-projects: write
+  contents: read
 
 on:
   workflow_dispatch:
@@ -35,13 +30,14 @@ on:
         description: 'Branch to use for the release'
         required: true
         default: main
-env:
-  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
 jobs:
   tag:
     name: Tagging
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       githubTag: ${{ steps.TAG_UTIL.outputs.githubTag}}
       extVersion: ${{ steps.TAG_UTIL.outputs.extVersion}}
@@ -51,7 +47,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.inputs.branch }}
-          token: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
+          persist-credentials: false
 
       - name: Generate tag utilities
         id: TAG_UTIL
@@ -61,9 +57,12 @@ jobs:
           echo "extVersion=$TAG_PATTERN" >> ${GITHUB_OUTPUT}
 
       - name: tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --local user.name ${{ github.actor }}
           git config --local user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
 
           # Add the new version in package.json file
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ steps.TAG_UTIL.outputs.extVersion }}\",#g" package.json
@@ -95,6 +94,7 @@ jobs:
         if: ${{ github.event.inputs.branch == 'main' }}
         run: |
           git config --local user.name ${{ github.actor }}
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
           CURRENT_VERSION=$(echo "${{ steps.TAG_UTIL.outputs.extVersion }}")
           tmp=${CURRENT_VERSION%.*}
           minor=${tmp#*.}
@@ -125,7 +125,7 @@ jobs:
 
   extension-build:
     name: build oci image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: tag
     outputs:
       artifact-id: ${{ steps.build.outputs.artifact-id }}
@@ -140,7 +140,7 @@ jobs:
   extension-publish:
     name: publish oci image
     needs: [extension-build, tag]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       id-token: write
@@ -163,7 +163,9 @@ jobs:
   release:
     needs: [tag, extension-publish]
     name: Release
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: write
     steps:
       - name: id
         run: echo the release id is ${{ needs.tag.outputs.releaseId}}

--- a/Containerfile
+++ b/Containerfile
@@ -27,7 +27,7 @@ WORKDIR /opt/app-root/extension-source
 COPY --chown=1001:root . .
 
 RUN corepack enable && corepack install && \
-    CI=true pnpm --frozen-lockfile install
+    CI=true pnpm install
 
 RUN pnpm build
 


### PR DESCRIPTION
### What does this PR do?

Apply workflow fixes from extension-kreate PR #951: reduce top-level permissions to least privilege with per-job scoping, update runners to ubuntu-26.04/windows-2025/macos-26, disable persist-credentials on release checkout with explicit token-scoped git pushes, and remove unnecessary --frozen-lockfile from pnpm install.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes: #1352

### How to test this PR?

<!-- Please explain steps to reproduce -->
