### PR TITLE
test(e2e): add detail page tests for all resource types 

### DIFF
--- a/tests/playwright/src/extension.spec.ts
+++ b/tests/playwright/src/extension.spec.ts
@@ -702,6 +702,225 @@ test.describe('With resources', { tag: '@integration' }, () => {
     await playExpect(kubernetesResourceDetails.heading).toBeVisible();
     await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
   });
+
+  test('go to daemonset1 page', async () => {
+    const daemonSetsPage = await navigation.openTabPage(KubernetesResources.DaemonSets);
+    await playExpect(daemonSetsPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await daemonSetsPage.openResourceDetails(
+      'daemonset1',
+      KubernetesResources.DaemonSets,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Stopped);
+  });
+
+  test('go to statefulset1 page', async () => {
+    const statefulSetsPage = await navigation.openTabPage(KubernetesResources.StatefulSets);
+    await playExpect(statefulSetsPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await statefulSetsPage.openResourceDetails(
+      'statefulset1',
+      KubernetesResources.StatefulSets,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe('DEGRADED');
+  });
+
+  test('go to replicaset1 page', async () => {
+    const replicaSetsPage = await navigation.openTabPage(KubernetesResources.ReplicaSets);
+    await playExpect(replicaSetsPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await replicaSetsPage.openResourceDetails(
+      'replicaset1',
+      KubernetesResources.ReplicaSets,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe('DEGRADED');
+  });
+
+  test('go to pvc1 page', async () => {
+    const pvcsPage = await navigation.openTabPage(KubernetesResources.PVCs);
+    await playExpect(pvcsPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await pvcsPage.openResourceDetails('pvc1', KubernetesResources.PVCs);
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Stopped);
+  });
+
+  test('go to endpointslice1 page', async () => {
+    const endpointSlicesPage = await navigation.openTabPage(KubernetesResources.EndpointSlices);
+    await playExpect(endpointSlicesPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await endpointSlicesPage.openResourceDetails(
+      'endpointslice1',
+      KubernetesResources.EndpointSlices,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to serviceaccount1 page', async () => {
+    const serviceAccountsPage = await navigation.openTabPage(KubernetesResources.ServiceAccounts);
+    await playExpect(serviceAccountsPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await serviceAccountsPage.openResourceDetails(
+      'serviceaccount1',
+      KubernetesResources.ServiceAccounts,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to role1 page', async () => {
+    const rolesPage = await navigation.openTabPage(KubernetesResources.Roles);
+    await playExpect(rolesPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await rolesPage.openResourceDetails('role1', KubernetesResources.Roles);
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to rolebinding1 page', async () => {
+    const roleBindingsPage = await navigation.openTabPage(KubernetesResources.RoleBindings);
+    await playExpect(roleBindingsPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await roleBindingsPage.openResourceDetails(
+      'rolebinding1',
+      KubernetesResources.RoleBindings,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to clusterrole1 page', async () => {
+    const clusterRolesPage = await navigation.openTabPage(KubernetesResources.ClusterRoles);
+    await playExpect(clusterRolesPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await clusterRolesPage.openResourceDetails(
+      'clusterrole1',
+      KubernetesResources.ClusterRoles,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to clusterrolebinding1 page', async () => {
+    const clusterRoleBindingsPage = await navigation.openTabPage(KubernetesResources.ClusterRoleBindings);
+    await playExpect(clusterRoleBindingsPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await clusterRoleBindingsPage.openResourceDetails(
+      'clusterrolebinding1',
+      KubernetesResources.ClusterRoleBindings,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to resourcequota1 page', async () => {
+    const resourceQuotasPage = await navigation.openTabPage(KubernetesResources.ResourceQuotas);
+    await playExpect(resourceQuotasPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await resourceQuotasPage.openResourceDetails(
+      'resourcequota1',
+      KubernetesResources.ResourceQuotas,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to limitrange1 page', async () => {
+    const limitRangesPage = await navigation.openTabPage(KubernetesResources.LimitRanges);
+    await playExpect(limitRangesPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await limitRangesPage.openResourceDetails(
+      'limitrange1',
+      KubernetesResources.LimitRanges,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to pdb1 page', async () => {
+    const pdbsPage = await navigation.openTabPage(KubernetesResources.PodDisruptionBudgets);
+    await playExpect(pdbsPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await pdbsPage.openResourceDetails(
+      'pdb1',
+      KubernetesResources.PodDisruptionBudgets,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to priorityclass1 page', async () => {
+    const priorityClassesPage = await navigation.openTabPage(KubernetesResources.PriorityClasses);
+    await playExpect(priorityClassesPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await priorityClassesPage.openResourceDetails(
+      'priorityclass1',
+      KubernetesResources.PriorityClasses,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to runtimeclass1 page', async () => {
+    const runtimeClassesPage = await navigation.openTabPage(KubernetesResources.RuntimeClasses);
+    await playExpect(runtimeClassesPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await runtimeClassesPage.openResourceDetails(
+      'runtimeclass1',
+      KubernetesResources.RuntimeClasses,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to lease1 page', async () => {
+    const leasesPage = await navigation.openTabPage(KubernetesResources.Leases);
+    await playExpect(leasesPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await leasesPage.openResourceDetails('lease1', KubernetesResources.Leases);
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to mutatingwebhook1 page', async () => {
+    const mutatingWebhooksPage = await navigation.openTabPage(KubernetesResources.MutatingWebhookConfigs);
+    await playExpect(mutatingWebhooksPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await mutatingWebhooksPage.openResourceDetails(
+      'mutatingwebhook1',
+      KubernetesResources.MutatingWebhookConfigs,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to validatingwebhook1 page', async () => {
+    const validatingWebhooksPage = await navigation.openTabPage(KubernetesResources.ValidatingWebhookConfigs);
+    await playExpect(validatingWebhooksPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await validatingWebhooksPage.openResourceDetails(
+      'validatingwebhook1',
+      KubernetesResources.ValidatingWebhookConfigs,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
+
+  test('go to hpa1 page', async () => {
+    const hpasPage = await navigation.openTabPage(KubernetesResources.HorizontalPodAutoscalers);
+    await playExpect(hpasPage.heading).toBeVisible();
+
+    const kubernetesResourceDetails = await hpasPage.openResourceDetails(
+      'hpa1',
+      KubernetesResources.HorizontalPodAutoscalers,
+    );
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect.poll(async () => kubernetesResourceDetails.getState()).toBe(KubernetesResourceState.Running);
+  });
 });
 
 test.describe('Namespace change', { tag: '@integration' }, () => {

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -65,12 +65,12 @@ export enum KubernetesResources {
 }
 
 export const KubernetesResourceAttributes: Record<KubernetesResources, string[]> = {
-  [KubernetesResources.Namespaces]: ['Status', 'Name', 'Age', 'Actions'],
+  [KubernetesResources.Namespaces]: ['Selected', 'Status', 'Name', 'Age', 'Actions'],
   [KubernetesResources.Nodes]: ['Status', 'Name', 'Roles', 'Version', 'OS', 'Kernel', 'Age'],
   [KubernetesResources.Deployments]: ['Selected', 'Status', 'Name', 'Conditions', 'Pods', 'Age', 'Actions'],
-  [KubernetesResources.DaemonSets]: ['Status', 'Name', 'Ready', 'Up-to-date', 'Node Selector', 'Age'],
-  [KubernetesResources.StatefulSets]: ['Selected', 'Status', 'Name', 'Replicas', 'Age', 'Actions'],
-  [KubernetesResources.ReplicaSets]: ['Status', 'Name', 'Desired', 'Current', 'Ready', 'Owner', 'Age'],
+  [KubernetesResources.DaemonSets]: ['Selected', 'Status', 'Name', 'Ready', 'Up-to-date', 'Node Selector', 'Age'],
+  [KubernetesResources.StatefulSets]: ['Selected', 'Status', 'Name', 'Ready', 'Up-to-date', 'Age'],
+  [KubernetesResources.ReplicaSets]: ['Selected', 'Status', 'Name', 'Desired', 'Current', 'Ready', 'Owner', 'Age'],
   [KubernetesResources.Services]: ['Selected', 'Status', 'Name', 'Type', 'Cluster IP', 'Ports', 'Age', 'Actions'],
   [KubernetesResources.IngressesRoutes]: ['Selected', 'Status', 'Name', 'Host/Path', 'Backend', 'Age', 'Actions'],
   [KubernetesResources.Endpoints]: ['Selected', 'Status', 'Name', 'Endpoints', 'Ports', 'Age', 'Actions'],
@@ -85,8 +85,8 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
     'Age',
     'Actions',
   ],
-  [KubernetesResources.IngressClasses]: ['Status', 'Name', 'Controller', 'Default', 'Age'],
-  [KubernetesResources.GatewayClasses]: ['Status', 'Name', 'Controller', 'Age'],
+  [KubernetesResources.IngressClasses]: ['Selected', 'Status', 'Name', 'Controller', 'Default', 'Age', 'Actions'],
+  [KubernetesResources.GatewayClasses]: ['Selected', 'Status', 'Name', 'Controller', 'Age', 'Actions'],
   [KubernetesResources.Gateways]: [
     'Selected',
     'Status',
@@ -107,7 +107,7 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
     'Age',
     'Actions',
   ],
-  [KubernetesResources.PVCs]: ['Selected', 'Status', 'Name', 'Environment', 'Age', 'Size', 'Actions'],
+  [KubernetesResources.PVCs]: ['Selected', 'Status', 'Name', 'Mode', 'Storage', 'Size', 'Age', 'Actions'],
   [KubernetesResources.PersistentVolumes]: [
     'Selected',
     'Status',
@@ -132,7 +132,18 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   ],
   [KubernetesResources.ConfigMapsSecrets]: ['Selected', 'Status', 'Name', 'Type', 'Keys', 'Age', 'Actions'],
   [KubernetesResources.PortForwarding]: ['Status', 'Name', 'Type', 'Local Port', 'Remote Port', 'Actions'],
-  [KubernetesResources.Pods]: ['Selected', 'Status', 'Name', 'Containers', 'Age', 'Actions'],
+  [KubernetesResources.Pods]: [
+    'Selected',
+    'Status',
+    'Name',
+    'Containers',
+    'Restarts',
+    'Controlled By',
+    'Node',
+    'QoS',
+    'Age',
+    'Actions',
+  ],
   [KubernetesResources.Cronjobs]: [
     'Selected',
     'Status',

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -74,16 +74,7 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   [KubernetesResources.Services]: ['Selected', 'Status', 'Name', 'Type', 'Cluster IP', 'Ports', 'Age', 'Actions'],
   [KubernetesResources.IngressesRoutes]: ['Selected', 'Status', 'Name', 'Host/Path', 'Backend', 'Age', 'Actions'],
   [KubernetesResources.Endpoints]: ['Selected', 'Status', 'Name', 'Endpoints', 'Ports', 'Age', 'Actions'],
-  [KubernetesResources.EndpointSlices]: [
-    'Selected',
-    'Status',
-    'Name',
-    'Address Type',
-    'Ports',
-    'Endpoints',
-    'Age',
-    'Actions',
-  ],
+  [KubernetesResources.EndpointSlices]: ['Status', 'Name', 'Address Type', 'Ports', 'Endpoints', 'Age'],
 
   [KubernetesResources.NetworkPolicies]: [
     'Selected',
@@ -174,8 +165,17 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
     'Age',
     'Actions',
   ],
-  [KubernetesResources.PriorityClasses]: ['Status', 'Name', 'Value', 'Global Default', 'Preemption Policy', 'Age'],
-  [KubernetesResources.RuntimeClasses]: ['Status', 'Name', 'Handler', 'Age'],
+  [KubernetesResources.PriorityClasses]: [
+    'Selected',
+    'Status',
+    'Name',
+    'Value',
+    'Global Default',
+    'Preemption Policy',
+    'Age',
+    'Actions',
+  ],
+  [KubernetesResources.RuntimeClasses]: ['Selected', 'Status', 'Name', 'Handler', 'Age', 'Actions'],
   [KubernetesResources.Leases]: [
     'Selected',
     'Status',

--- a/tests/playwright/src/model/pages/kubernetes-resource-page.ts
+++ b/tests/playwright/src/model/pages/kubernetes-resource-page.ts
@@ -75,8 +75,7 @@ export class KubernetesResourcePage extends MainPage {
       if (
         resourceType === KubernetesResources.Nodes ||
         resourceType === KubernetesResources.StorageClasses ||
-        resourceType === KubernetesResources.PriorityClasses ||
-        resourceType === KubernetesResources.RuntimeClasses
+        resourceType === KubernetesResources.EndpointSlices
       ) {
         resourceRowName = resourceRow.getByRole('cell').nth(2);
       } else {

--- a/tests/playwright/src/model/pages/kubernetes-resource-page.ts
+++ b/tests/playwright/src/model/pages/kubernetes-resource-page.ts
@@ -18,7 +18,7 @@
 
 import test, { expect as playExpect, type Locator, type Page } from '@playwright/test';
 
-import { KubernetesResourceAttributes, KubernetesResources } from '/@/model/core/types';
+import { KubernetesResourceAttributes, type KubernetesResources } from '/@/model/core/types';
 import { MainPage } from '@podman-desktop/tests-playwright';
 import { KubernetesResourceDetailsPage } from '/@/model/pages/kubernetes-resource-details-page';
 
@@ -70,17 +70,7 @@ export class KubernetesResourcePage extends MainPage {
   ): Promise<KubernetesResourceDetailsPage> {
     return test.step(`Open ${resourceType}: ${resourceName} details`, async () => {
       const resourceRow = await this.fetchKubernetesResource(resourceName, timeout);
-
-      let resourceRowName: Locator;
-      if (
-        resourceType === KubernetesResources.Nodes ||
-        resourceType === KubernetesResources.StorageClasses ||
-        resourceType === KubernetesResources.EndpointSlices
-      ) {
-        resourceRowName = resourceRow.getByRole('cell').nth(2);
-      } else {
-        resourceRowName = resourceRow.getByRole('cell').nth(3);
-      }
+      const resourceRowName = await this.getAttributeByRow(resourceRow, 'Name', resourceType);
 
       await playExpect(resourceRowName).toBeEnabled();
       await resourceRowName.click();

--- a/tests/resources/cluster-resources.yaml
+++ b/tests/resources/cluster-resources.yaml
@@ -996,3 +996,290 @@ spec:
         - name: svc1-clusterip
           port: 8080
 ---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: '2026-02-09T10:21:00Z'
+  generation: 1
+  labels:
+    app: statefulset1
+  name: statefulset1
+  namespace: default
+  uid: a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: statefulset1
+  serviceName: statefulset1
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: statefulset1
+    spec:
+      containers:
+        - image: httpd
+          imagePullPolicy: Always
+          name: httpd
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+status: {}
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  creationTimestamp: '2026-02-09T10:22:00Z'
+  labels:
+    kubernetes.io/service-name: svc1-clusterip
+  name: endpointslice1
+  namespace: default
+  uid: b2b3b4b5-c2c3-d2d3-e2e3-f2f3f4f5f6f7
+addressType: IPv4
+endpoints:
+  - addresses:
+      - 10.0.0.1
+    conditions:
+      ready: true
+ports:
+  - name: 8080-8080
+    port: 8080
+    protocol: TCP
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: '2026-02-09T10:23:00Z'
+  name: serviceaccount1
+  namespace: default
+  uid: c3c4c5c6-d3d4-e3e4-f3f4-a3a4a5a6a7a8
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: '2026-02-09T10:24:00Z'
+  name: role1
+  namespace: default
+  uid: d4d5d6d7-e4e5-f4f5-a4a5-b4b5b6b7b8b9
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: '2026-02-09T10:25:00Z'
+  name: rolebinding1
+  namespace: default
+  uid: e5e6e7e8-f5f6-a5a6-b5b6-c5c6c7c8c9ca
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: role1
+subjects:
+  - kind: ServiceAccount
+    name: serviceaccount1
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: '2026-02-09T10:26:00Z'
+  name: clusterrole1
+  uid: f6f7f8f9-a6a7-b6b7-c6c7-d6d7d8d9dadb
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: '2026-02-09T10:27:00Z'
+  name: clusterrolebinding1
+  uid: a7a8a9aa-b7b8-c7c8-d7d8-e7e8e9eaebec
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterrole1
+subjects:
+  - kind: ServiceAccount
+    name: serviceaccount1
+    namespace: default
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  creationTimestamp: '2026-02-09T10:28:00Z'
+  name: resourcequota1
+  namespace: default
+  uid: b8b9babb-c8c9-d8d9-e8e9-f8f9fafbfcfd
+spec:
+  hard:
+    pods: '10'
+    requests.cpu: '4'
+    requests.memory: 4Gi
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  creationTimestamp: '2026-02-09T10:29:00Z'
+  name: limitrange1
+  namespace: default
+  uid: c9cacbcc-d9da-e9ea-f9fa-a9aaabacadae
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: 500m
+        memory: 512Mi
+      defaultRequest:
+        cpu: 100m
+        memory: 128Mi
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  creationTimestamp: '2026-02-09T10:30:00Z'
+  generation: 1
+  name: pdb1
+  namespace: default
+  uid: dadbdcdd-eaeb-fafc-abac-babbbcbdbebf
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: deploy1
+status:
+  conditions: []
+  currentHealthy: 0
+  desiredHealthy: 1
+  disruptionsAllowed: 0
+  expectedPods: 0
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  creationTimestamp: '2026-02-09T10:31:00Z'
+  name: priorityclass1
+  uid: ebecedee-fbfc-abac-bcbd-cbcccdcecfd0
+value: 1000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: Test priority class for E2E
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  creationTimestamp: '2026-02-09T10:32:00Z'
+  name: runtimeclass1
+  uid: fcfdfeff-abac-bcbd-cdce-dbdcdddedfe0
+handler: runc
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  creationTimestamp: '2026-02-09T10:33:00Z'
+  name: lease1
+  namespace: default
+  uid: adaeafb0-bcbd-cdce-dedf-ebecedeef0f1
+spec:
+  holderIdentity: lease-holder-1
+  leaseDurationSeconds: 60
+  renewTime: '2026-02-09T10:33:00.000000Z'
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: '2026-02-09T10:34:00Z'
+  name: mutatingwebhook1
+  uid: beafb0b1-cdce-dedf-eff0-fcfdfeff0102
+webhooks:
+  - name: mutating.example.com
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      url: https://example.com/mutate
+    rules:
+      - apiGroups:
+          - ''
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: '2026-02-09T10:35:00Z'
+  name: validatingwebhook1
+  uid: cfb0b1b2-dedf-eff0-f0f1-adbebfd0d1d2
+webhooks:
+  - name: validating.example.com
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      url: https://example.com/validate
+    rules:
+      - apiGroups:
+          - ''
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: '2026-02-09T10:36:00Z'
+  generation: 1
+  name: hpa1
+  namespace: default
+  uid: d0b1b2b3-eff0-f0f1-a1a2-becfd0d1d2d3
+spec:
+  maxReplicas: 10
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 50
+          type: Utilization
+      type: Resource
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: deploy1
+status:
+  conditions: []
+  currentMetrics: []
+  currentReplicas: 0
+  desiredReplicas: 0
+---


### PR DESCRIPTION

### What does this PR do?

Add 19 missing resource detail page tests to the "With resources" E2E block and 16 new YAML resource definitions with cluster metadata for envtest.

Fix KubernetesResourceAttributes to match actual table columns: add missing Selected/Actions for 5 resources, fix wrong column names for Pods, PVCs, and StatefulSets. Replace hardcoded cell index in openResourceDetails with getAttributeByRow lookup.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #1340

### How to test this PR?

<!-- Please explain steps to reproduce -->
